### PR TITLE
Bugfix for updating a event with the same banner

### DIFF
--- a/api/src/main/kotlin/net/blueshell/api/domain/event/application/command/EventCommandHandlers.kt
+++ b/api/src/main/kotlin/net/blueshell/api/domain/event/application/command/EventCommandHandlers.kt
@@ -62,7 +62,7 @@ class UpdateEventHandler(
         val event = service.findById(command.id)
         val isBoard = currentUserProvider.currentUser()?.let { hasAuthority(it, Role.BOARD) } == true
         event.applyEditableFields(command, committeeService.findById(command.committeeId))
-        event.replaceBanner(command.banner?.toEntity(event, fileService))
+        event.replaceBanner(command.banner?.toEntity(event, fileService, existingBanner = event.banner))
         applySignUpFormUpdate(event, command.signUpForm, surveyFactory)
         event.approved = isBoard && command.approved
         event.version = command.version
@@ -121,7 +121,14 @@ private fun hasAuthority(user: CurrentUser, role: Role): Boolean {
     return inherited.any { it.matchesRole(role) }
 }
 
-private fun EventBannerData.toEntity(event: Event, fileService: FileService): EventBanner {
+private fun EventBannerData.toEntity(
+    event: Event,
+    fileService: FileService,
+    existingBanner: EventBanner? = null
+): EventBanner {
+    if (existingBanner != null && existingBanner.fileId == fileId) {
+        return existingBanner  // Same file — reuse managed entity, no INSERT needed
+    }
     return EventBanner(
         event = event,
         file = fileService.findById(fileId),

--- a/api/src/test/kotlin/net/blueshell/api/domain/event/web/EventControllerSecurityTest.kt
+++ b/api/src/test/kotlin/net/blueshell/api/domain/event/web/EventControllerSecurityTest.kt
@@ -37,9 +37,12 @@ class EventControllerSecurityTest : UserTestSupport() {
         title: String = "Updated Event",
         approved: Boolean = true,
         membersOnly: Boolean = false,
-        signUp: Boolean = true
-    ): String =
-        """{"committeeId":$committeeId,"title":"$title","description":"Updated event description","location":"Campus","startTime":"2026-02-14T19:00:00Z","endTime":"2026-02-14T21:00:00Z","approved":$approved,"membersOnly":$membersOnly,"signUp":$signUp,"version":$version}"""
+        signUp: Boolean = true,
+        bannerFileId: Long? = null
+    ): String {
+        val bannerPart = if (bannerFileId == null) "" else ""","banner":{"fileId":$bannerFileId}"""
+        return """{"committeeId":$committeeId,"title":"$title","description":"Updated event description","location":"Campus","startTime":"2026-02-14T19:00:00Z","endTime":"2026-02-14T21:00:00Z","approved":$approved,"membersOnly":$membersOnly,"signUp":$signUp,"version":$version$bannerPart}"""
+    }
 
     @Nested
     inner class CreateEvent {
@@ -193,6 +196,22 @@ class EventControllerSecurityTest : UserTestSupport() {
                     .content(updateEventPayload(event.committee.id!!, event.version, "Unauthorized Update"))
             )
                 .andExpect(status().isUnauthorized)
+        }
+
+        @Test
+        fun `allows updating an event that already has a banner without constraint violation`() {
+            val board = createUserWithRole(Role.BOARD)
+            val file = createFileFixture(uploader = board)
+            val event = attachEventBanner(createEventFixture(), file)
+            val eventId = event.id!!
+
+            mvc.perform(
+                put("/events/{id}", eventId)
+                    .with(bearer(board))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(updateEventPayload(event.committee.id!!, event.version, bannerFileId = file.id!!))
+            )
+                .andExpect(status().isOk)
         }
     }
 


### PR DESCRIPTION
- Fixes: #100 

### Description

Reproduces issues with a event with a banner getting updated violating uniqueness constraints. This is achieved by reusing the current banner, whenever it does not need to be deleted.