### PR TITLE
Implement contact ID for Brevo syncing and communications

### DIFF
--- a/api/src/main/kotlin/net/blueshell/api/domain/user/application/contact/ContactSyncAdapter.kt
+++ b/api/src/main/kotlin/net/blueshell/api/domain/user/application/contact/ContactSyncAdapter.kt
@@ -18,11 +18,12 @@ interface ContactSyncAdapter {
      * If the contact exists, it will be updated.
      *
      * @param userId The domain user ID (for tracking)
+     * @param contactId The Brevo contact ID
      * @param contactData The contact data to sync
      * @return External contact ID
      * @throws ContactServiceException if the operation fails
      */
-    fun syncContact(userId: Long, contactData: ContactData): String
+    fun syncContact(userId: Long, contactId: String?, contactData: ContactData): String
 
     /**
      * Get and update the external contact ID for a user.

--- a/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/BrevoContactAdapter.kt
+++ b/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/BrevoContactAdapter.kt
@@ -34,24 +34,25 @@ class BrevoContactAdapter(
     private val brevoClient: BrevoContactClient
 ) : ContactSyncAdapter {
 
-    override fun syncContact(userId: Long, contactData: ContactData): String {
+    override fun syncContact(userId: Long, contactId: String?, contactData: ContactData): String {
         log.info("Syncing contact for user {}: {}", userId, contactData.email)
 
         return try {
             // Check if contact exists in Brevo
-            val existingContactId = brevoClient.getContactIdByEmail(contactData.email)
+            val contactId = contactId ?: brevoClient.getContactIdByEmail(contactData.email)
 
             val attributes = buildAttributes(contactData)
             val externalId = userId.toString()
 
-            if (existingContactId != null) {
+            if (contactId != null) {
                 // Contact exists - update it
                 brevoClient.updateContact(
+                    contactId = contactId.toString(),
                     email = contactData.email,
                     externalId = externalId,
                     attributes = attributes
                 )
-                existingContactId.toString()
+                contactId.toString()
             } else {
                 // Contact doesn't exist - create it
                 val createdId = brevoClient.createContact(

--- a/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/BrevoContactClient.kt
+++ b/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/BrevoContactClient.kt
@@ -87,6 +87,7 @@ class BrevoContactClient(
      */
     @Throws(RestClientResponseException::class)
     fun updateContact(
+        contactId: String,
         email: String,
         externalId: String,
         attributes: Map<String, Any>
@@ -96,7 +97,7 @@ class BrevoContactClient(
         updateContact.extId = externalId
         @Suppress("UNCHECKED_CAST")
         updateContact.attributes = attributes as @Valid Map<String?, CreateContactRequestAttributesValue?>?
-        contactsApi.updateContact(email, updateContact, "email_id")
+        contactsApi.updateContact(contactId, updateContact, "contact_id")
     }
 
     /**

--- a/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/job/SyncContactJob.kt
+++ b/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/job/SyncContactJob.kt
@@ -27,7 +27,7 @@ class SyncContactJob(
         val contactData = user.toContactData()
 
         // Sync contact and update user's contact ID if needed
-        val contactId = contactAdapter.syncContact(user.id!!, contactData)
+        val contactId = contactAdapter.syncContact(user.id!!, user.contactId?.toString(), contactData)
         val syncedContactId = contactId.toLong()
         if (user.contactId != syncedContactId) {
             users.updateContactLink(user, syncedContactId)

--- a/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/job/SyncListMembershipJob.kt
+++ b/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/job/SyncListMembershipJob.kt
@@ -57,7 +57,7 @@ class SyncListMembershipJob(
             // Ensure user has a contactId (sync contact if null)
             val contactId = if (user.contactId == null) {
                 val contactData = user.toContactData()
-                val syncedContactId = contactAdapter.syncContact(user.id!!, contactData)
+                val syncedContactId = contactAdapter.syncContact(user.id!!, null, contactData)
                 users.updateContactLink(user, syncedContactId.toLong())
                 syncedContactId
             } else {

--- a/api/src/main/kotlin/net/blueshell/api/platform/integration/mock/MockContactAdapter.kt
+++ b/api/src/main/kotlin/net/blueshell/api/platform/integration/mock/MockContactAdapter.kt
@@ -25,10 +25,11 @@ class MockContactAdapter : ContactSyncAdapter {
     private val contactIdSequence = AtomicLong(1000)
     private val listIdSequence = AtomicLong(2000)
 
-    override fun syncContact(userId: Long, contactData: ContactData): String {
+    override fun syncContact(userId: Long, contactId: String?, contactData: ContactData): String {
         log.info("Mock: Syncing contact for user {}: {}", userId, contactData.email)
 
-        val existingContact = contacts.values.find { it.email == contactData.email }
+        val existingContact = (if (contactId != null) contacts[contactId] else null)
+            ?: contacts.values.find { it.email == contactData.email }
 
         return if (existingContact != null) {
             // Update existing contact

--- a/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/BrevoContactAdapterLiveIT.kt
+++ b/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/BrevoContactAdapterLiveIT.kt
@@ -4,7 +4,6 @@ import net.blueshell.api.domain.user.application.contact.ContactData
 import net.blueshell.api.domain.user.application.contact.ContactSyncAdapter
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.*
-import org.junit.jupiter.api.Tag
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
@@ -56,7 +55,7 @@ class BrevoContactAdapterLiveIT {
     @Test
     @Order(1)
     fun `create contact succeeds - verifies listIds is serialised as array`() {
-        contactId = adapter.syncContact(testUserId, contactData())
+        contactId = adapter.syncContact(testUserId, contactId, contactData())
         assertThat(contactId).isNotNull().isNotBlank()
     }
 
@@ -64,7 +63,7 @@ class BrevoContactAdapterLiveIT {
     @Order(2)
     fun `update contact succeeds for existing contact`() {
         assumeContactExists()
-        val updatedId = adapter.syncContact(testUserId, contactData("Updated"))
+        val updatedId = adapter.syncContact(testUserId, contactId, contactData("Updated"))
         assertThat(updatedId).isEqualTo(contactId)
     }
 

--- a/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/job/DeleteContactJobIT.kt
+++ b/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/job/DeleteContactJobIT.kt
@@ -37,6 +37,7 @@ class DeleteContactJobIT : UserTestSupport() {
 
         val contactId = mockContactAdapter.syncContact(
             user.id!!,
+            null,
             ContactData(
                 email = user.email,
                 firstName = user.firstName,
@@ -67,6 +68,7 @@ class DeleteContactJobIT : UserTestSupport() {
 
         val contactId = mockContactAdapter.syncContact(
             user.id!!,
+            null,
             ContactData(
                 email = user.email,
                 firstName = user.firstName,

--- a/api/src/test/kotlin/net/blueshell/api/platform/integration/mock/MockContactAdapterTest.kt
+++ b/api/src/test/kotlin/net/blueshell/api/platform/integration/mock/MockContactAdapterTest.kt
@@ -17,7 +17,7 @@ class MockContactAdapterTest {
 
     @Test
     fun `syncContact creates contact when email is new`() {
-        val contactId = adapter.syncContact(1L, contactData(email = "new@example.com"))
+        val contactId = adapter.syncContact(1L, null,contactData(email = "new@example.com"))
 
         assertThat(contactId).isNotBlank()
         assertThat(adapter.getAllContacts()).hasSize(1)
@@ -30,9 +30,10 @@ class MockContactAdapterTest {
 
     @Test
     fun `syncContact updates existing contact when email already exists`() {
-        val originalId = adapter.syncContact(2L, contactData(email = "same@example.com", firstName = "Old", isMember = false))
+        val originalId = adapter.syncContact(2L, null, contactData(email = "same@example.com", firstName = "Old", isMember = false))
         val updatedId = adapter.syncContact(
             2L,
+            null,
             contactData(
                 email = "same@example.com",
                 firstName = "Updated",
@@ -58,7 +59,7 @@ class MockContactAdapterTest {
 
     @Test
     fun `getContactId returns id for known email and null for unknown email`() {
-        val createdId = adapter.syncContact(3L, contactData(email = "known@example.com"))
+        val createdId = adapter.syncContact(3L, null, contactData(email = "known@example.com"))
 
         assertThat(adapter.getContactId(3L, "known@example.com")).isEqualTo(createdId)
         assertThat(adapter.getContactId(3L, "unknown@example.com")).isNull()
@@ -78,7 +79,7 @@ class MockContactAdapterTest {
 
     @Test
     fun `addToList adds existing contact to existing list`() {
-        val contactId = adapter.syncContact(4L, contactData(email = "list@example.com"))
+        val contactId = adapter.syncContact(4L, null, contactData(email = "list@example.com"))
         val listId = adapter.createList("Members", "Main")
 
         adapter.addToList(listId, contactId)
@@ -88,7 +89,7 @@ class MockContactAdapterTest {
 
     @Test
     fun `addToList throws when list does not exist`() {
-        val contactId = adapter.syncContact(5L, contactData(email = "missing-list@example.com"))
+        val contactId = adapter.syncContact(5L, null, contactData(email = "missing-list@example.com"))
 
         assertThatThrownBy { adapter.addToList("missing-list", contactId) }
             .isInstanceOf(IllegalArgumentException::class.java)
@@ -106,7 +107,7 @@ class MockContactAdapterTest {
 
     @Test
     fun `removeFromList removes existing relation and keeps list`() {
-        val contactId = adapter.syncContact(6L, contactData(email = "remove@example.com"))
+        val contactId = adapter.syncContact(6L, null, contactData(email = "remove@example.com"))
         val listId = adapter.createList("Participants", "Main")
         adapter.addToList(listId, contactId)
         assertThat(adapter.getAllLists()[listId]!!.contactIds).contains(contactId)
@@ -118,7 +119,7 @@ class MockContactAdapterTest {
 
     @Test
     fun `removeFromList throws when contact is not in the list`() {
-        val contactId = adapter.syncContact(7L, contactData(email = "other@example.com"))
+        val contactId = adapter.syncContact(7L, null, contactData(email = "other@example.com"))
         val listId = adapter.createList("NotJoined", "Main")
 
         assertThatThrownBy { adapter.removeFromList(listId, contactId) }
@@ -135,7 +136,7 @@ class MockContactAdapterTest {
 
     @Test
     fun `clear removes all contacts and lists`() {
-        adapter.syncContact(8L, contactData(email = "a@example.com"))
+        adapter.syncContact(8L, null, contactData(email = "a@example.com"))
         adapter.createList("ListA", "FolderA")
         assertThat(adapter.getAllContacts()).isNotEmpty
         assertThat(adapter.getAllLists()).isNotEmpty

--- a/api/src/test/kotlin/net/blueshell/api/platform/integration/queue/JobAutoDispatchIT.kt
+++ b/api/src/test/kotlin/net/blueshell/api/platform/integration/queue/JobAutoDispatchIT.kt
@@ -146,6 +146,7 @@ class JobAutoDispatchIT : UserTestSupport() {
         val user = createUserWithRole(Role.MEMBER)
         val contactId = mockContactAdapter.syncContact(
             user.id!!,
+            null,
             ContactData(
                 email = user.email,
                 firstName = user.firstName,


### PR DESCRIPTION
This pull request updates the contact synchronization logic to improve how contact IDs are handled throughout the codebase. The main change is that the `syncContact` method now explicitly accepts an optional `contactId` parameter, allowing for more precise updates and creation of contacts. This affects both the main implementation and all related adapters, jobs, and tests.

**Contact synchronization improvements:**

* The `ContactSyncAdapter.syncContact` method signature now includes an optional `contactId` parameter, allowing callers to specify the external contact ID when syncing, which helps avoid unnecessary lookups and ensures updates are targeted correctly.
* The `BrevoContactAdapter` and `MockContactAdapter` implementations have been updated to use the new `contactId` parameter, preferring it when provided and falling back to email-based lookup otherwise. [[1]](diffhunk://#diff-9f131be376cee363b84344762cc0fbf23af815bb55143935de91bdf23f687319L37-R55) [[2]](diffhunk://#diff-2550f641305f95ab2831e4422f87932526e71dde1349be29592dd578cae9f226L28-R32)

**Integration with external contact system:**

* The `BrevoContactClient.updateContact` method now requires a `contactId` and uses it for updates, replacing the previous approach that used the email as the identifier. This ensures updates are performed using the unique contact ID, reducing ambiguity. [[1]](diffhunk://#diff-07a8000037dc9fb9be3151b3090f670245924d542fb8cbbbfd7bf33277a5d6e4R90) [[2]](diffhunk://#diff-07a8000037dc9fb9be3151b3090f670245924d542fb8cbbbfd7bf33277a5d6e4L99-R100)

**Job and workflow updates:**

* All jobs that synchronize contacts (`SyncContactJob`, `SyncListMembershipJob`) have been updated to pass the `contactId` where available, or `null` otherwise, to the updated `syncContact` method. [[1]](diffhunk://#diff-ad1b0e5a43ccb59cd6d4abb8f0810e123683a5cbda9ad8a8d7ca2d0e96fb88f6L30-R30) [[2]](diffhunk://#diff-2d9298297bedacad23da831b10656950fa02e6c8cbb4670397ce9cdb127887f3L60-R60)

**Test updates:**

* All relevant tests and test utilities have been updated to use the new `syncContact` method signature, ensuring that the correct `contactId` is passed or omitted as appropriate. [[1]](diffhunk://#diff-af101d0a442e8005d218211bc1b3eaa52ff00cb9504510627b303c8dba49fac4L20-R20) [[2]](diffhunk://#diff-af101d0a442e8005d218211bc1b3eaa52ff00cb9504510627b303c8dba49fac4L33-R36) [[3]](diffhunk://#diff-af101d0a442e8005d218211bc1b3eaa52ff00cb9504510627b303c8dba49fac4L61-R62) [[4]](diffhunk://#diff-af101d0a442e8005d218211bc1b3eaa52ff00cb9504510627b303c8dba49fac4L81-R82) [[5]](diffhunk://#diff-af101d0a442e8005d218211bc1b3eaa52ff00cb9504510627b303c8dba49fac4L91-R92) [[6]](diffhunk://#diff-af101d0a442e8005d218211bc1b3eaa52ff00cb9504510627b303c8dba49fac4L109-R110) [[7]](diffhunk://#diff-af101d0a442e8005d218211bc1b3eaa52ff00cb9504510627b303c8dba49fac4L121-R122) [[8]](diffhunk://#diff-af101d0a442e8005d218211bc1b3eaa52ff00cb9504510627b303c8dba49fac4L138-R139) [[9]](diffhunk://#diff-71fc9e7dd417066728ecd64fca24ee03390684f3cf76f299f3f9bb7d1f443759R40) [[10]](diffhunk://#diff-71fc9e7dd417066728ecd64fca24ee03390684f3cf76f299f3f9bb7d1f443759R71) [[11]](diffhunk://#diff-fc5d582d188cddc2660c00c006623ee3e73a6fa93d5db15776e292a0018af228R149) [[12]](diffhunk://#diff-3d6aa810614a11abf9696a89d922848f57eadeaa8bdcf5faa35155d79fff7de9L59-R66)

These changes collectively improve the reliability and clarity of contact synchronization by making the use of contact IDs explicit and consistent throughout the codebase.