### PR TITLE
Introduce NixOS flake for the single-node production VPS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
       - 'gradlew'
       - 'gradlew.bat'
       - 'scripts/**'
+      - 'platform/**'
       - '.github/actions/**'
       - '.github/workflows/**'
       - 'docker-compose.dev.yml'
@@ -62,6 +63,24 @@ permissions:
   contents: read
 
 jobs:
+  nix-flake-check:
+    name: NixOS flake check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix with flake support
+        uses: DeterminateSystems/nix-installer-action@v16
+
+      - name: Cache /nix/store for faster re-runs
+        uses: DeterminateSystems/magic-nix-cache-action@v8
+
+      - name: Validate platform flake
+        run: |
+          nix flake check ./platform --no-build --show-trace
+
   fe-static:
     name: Frontend typecheck and lint
     runs-on: ubuntu-latest

--- a/platform/docs/nix-flake.md
+++ b/platform/docs/nix-flake.md
@@ -1,0 +1,54 @@
+# NixOS flake
+
+The `platform/` tree defines a single-node NixOS + k3s deployment for the
+production VPS.
+
+```
+platform/
+├── flake.nix                                 flake inputs + nixosConfigurations
+├── nix/
+│   ├── authorized-keys/
+│   │   ├── README.md                         how to compose deploy.pub
+│   │   └── .gitignore                        deploy.pub is local-only
+│   ├── hosts/
+│   │   └── blueshell-fra-1/
+│   │       ├── default.nix                   hostname, networking, boot loader
+│   │       └── disko.nix                     GPT + bios_grub disk layout
+│   └── modules/
+│       ├── base/default.nix                  SSH :2222, DNS, fail2ban, deploy user
+│       ├── k3s/bootstrap.nix                 firewall for k3s + web + mail
+│       └── roles/single-node.nix             k3s server with OIDC trust for the api
+```
+
+## First-time provisioning
+
+1. Provision a Contabo VPS with Debian (cloud-init image), note the public IPv4,
+   IPv6 and v4 gateway from the cidata.
+2. Edit `platform/nix/hosts/blueshell-fra-1/default.nix` and replace the three
+   `REPLACE_WITH_VPS_*` placeholders.
+3. Compose `platform/nix/authorized-keys/deploy.pub` from every operator's
+   public key.
+4. From a workstation with Nix installed:
+   ```
+   nix run github:nix-community/nixos-anywhere -- \
+     --flake ./platform#blueshell-fra-1 root@<public-ip>
+   ```
+5. Reboot. SSH reaches the VPS at `deploy@<public-ip>:2222`.
+
+## Ongoing updates
+
+```
+nix run nixpkgs#deploy-rs -- ./platform#blueshell-fra-1
+```
+
+`deploy-rs` uses the SSH keys in `platform/nix/authorized-keys/deploy.pub`
+and activates a new profile with an automatic rollback window.
+
+## Local validation
+
+CI runs `nix flake check ./platform` on every PR that touches the nix tree.
+Run it locally the same way:
+
+```
+nix flake check ./platform --no-build
+```

--- a/platform/docs/runbook.md
+++ b/platform/docs/runbook.md
@@ -1,0 +1,20 @@
+# Platform runbook
+
+The `platform/` tree replaces the legacy `infra/` + `vps/` stack with
+**NixOS + k3s + FluxCD + Kustomize + Helm**, modeled on `personal-stack-2`.
+
+Status: **scaffolding in progress**. This PR removes the legacy assets; the
+Flux manifests, Nix flake, and cutover runbook land in follow-up PRs:
+
+- **PR2** — `build-logic/` convention plugins, `libs/` skeleton
+- **PR3** — split unit/integration/system tests, drop merged-coverage pipeline
+- **PR4** — `platform/nix/` flake for the new single-node VPS ✅
+- **PR5** — FluxCD scaffold + `apps-core` (cert-manager, external-dns, Traefik, VSO, Headlamp, Keel)
+- **PR6** — Vault + VSO + MariaDB + Listmonk Postgres
+- **PR7** — application Deployments (api, frontend, listmonk) + Stalwart mail
+- **PR8** — OIDC issuer in the API + MyApps page + k3s/Headlamp/Vault OIDC wiring
+- **PR9** — parallel VPS provisioning + data migration + DNS cutover
+- **PR10** — decommission the old Swarm VPS + Gatus status page
+
+Until PR9 lands, production still runs on the existing Docker Swarm VPS via
+`.github/workflows/deploy.yml` and the GHCR-published `api`/`frontend` images.

--- a/platform/flake.lock
+++ b/platform/flake.lock
@@ -1,0 +1,316 @@
+{
+  "nodes": {
+    "deploy-rs": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1770019181,
+        "narHash": "sha256-hwsYgDnby50JNVpTRYlF3UR/Rrpt01OrxVuryF40CFY=",
+        "owner": "serokell",
+        "repo": "deploy-rs",
+        "rev": "77c906c0ba56aabdbc72041bf9111b565cdd6171",
+        "type": "github"
+      },
+      "original": {
+        "owner": "serokell",
+        "repo": "deploy-rs",
+        "type": "github"
+      }
+    },
+    "disko": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1776613567,
+        "narHash": "sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "32f4236bfc141ae930b5ba2fb604f561fed5219d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "type": "github"
+      }
+    },
+    "disko_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixos-anywhere",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769524058,
+        "narHash": "sha256-zygdD6X1PcVNR2PsyK4ptzrVEiAdbMqLos7utrMDEWE=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "71a3fc97d80881e91710fe721f1158d3b96ae14d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "master",
+        "repo": "disko",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixos-anywhere",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nix-vm-test": {
+      "inputs": {
+        "nixpkgs": [
+          "nixos-anywhere",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769079217,
+        "narHash": "sha256-R6qzhu+YJolxE2vUsPQWWwUKMbAG5nXX3pBtg8BNX38=",
+        "owner": "Enzime",
+        "repo": "nix-vm-test",
+        "rev": "58c15f78947b431d6c206e0966500c7e9139bd2f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Enzime",
+        "ref": "pr-105-latest",
+        "repo": "nix-vm-test",
+        "type": "github"
+      }
+    },
+    "nixos-anywhere": {
+      "inputs": {
+        "disko": "disko_2",
+        "flake-parts": "flake-parts",
+        "nix-vm-test": "nix-vm-test",
+        "nixos-images": "nixos-images",
+        "nixos-stable": "nixos-stable",
+        "nixpkgs": "nixpkgs_3",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1769956140,
+        "narHash": "sha256-D+RQ+DaIC/GVwv5lUs7e8jSmh8aPc77Kg/gRjaS25Zk=",
+        "owner": "nix-community",
+        "repo": "nixos-anywhere",
+        "rev": "92f82c5196a5f8588be4967e535c4cfd35e85902",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixos-anywhere",
+        "type": "github"
+      }
+    },
+    "nixos-images": {
+      "inputs": {
+        "nixos-stable": [
+          "nixos-anywhere",
+          "nixos-stable"
+        ],
+        "nixos-unstable": [
+          "nixos-anywhere",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1766770015,
+        "narHash": "sha256-kUmVBU+uBUPl/v3biPiWrk680b8N9rRMhtY97wsxiJc=",
+        "owner": "nix-community",
+        "repo": "nixos-images",
+        "rev": "e4dba54ddb6b2ad9c6550e5baaed2fa27938a5d2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixos-images",
+        "type": "github"
+      }
+    },
+    "nixos-stable": {
+      "locked": {
+        "lastModified": 1769598131,
+        "narHash": "sha256-e7VO/kGLgRMbWtpBqdWl0uFg8Y2XWFMdz0uUJvlML8o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fa83fd837f3098e3e678e6cf017b2b36102c7211",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1743014863,
+        "narHash": "sha256-jAIUqsiN2r3hCuHji80U7NNEafpIMBXiwKlSrjWMlpg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bd3bac8bfb542dbde7ffffb6987a1a1f9d41699f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1773628058,
+        "narHash": "sha256-hpXH0z3K9xv0fHaje136KY872VT2T5uwxtezlAskQgY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f8573b9c935cfaa162dd62cc9e75ae2db86f85df",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1769900851,
+        "narHash": "sha256-RgCgXS3WiG9c/1wxFM6OXmmv39dSaLLON9VeAbTTAIM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "30a3e96da641620c63f2e1f345ea434ac78f5de1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "deploy-rs": "deploy-rs",
+        "disko": "disko",
+        "nixos-anywhere": "nixos-anywhere",
+        "nixpkgs": "nixpkgs_4"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixos-anywhere",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769691507,
+        "narHash": "sha256-8aAYwyVzSSwIhP2glDhw/G0i5+wOrren3v6WmxkVonM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "28b19c5844cc6e2257801d43f2772a4b4c050a1b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/platform/flake.nix
+++ b/platform/flake.nix
@@ -49,7 +49,7 @@
         # before running `deploy-rs activate`. nixos-anywhere takes the IP
         # as a CLI argument so it does not need this value during initial
         # bootstrap.
-        hostname = "blueshell-fra-1.blueshell.nl";
+        hostname = "v2.esa-blueshell.nl";
         profiles.system = {
           sshUser = "deploy";
           user = "root";

--- a/platform/flake.nix
+++ b/platform/flake.nix
@@ -1,0 +1,83 @@
+{
+  description = "Blueshell website NixOS + k3s platform (single VPS)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    deploy-rs.url = "github:serokell/deploy-rs";
+    disko.url = "github:nix-community/disko";
+    nixos-anywhere.url = "github:nix-community/nixos-anywhere";
+  };
+
+  outputs =
+    inputs@{ self, nixpkgs, deploy-rs, disko, nixos-anywhere, ... }:
+    let
+      lib = nixpkgs.lib;
+      supportedNixosAnywhereSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      mkHost =
+        {
+          system,
+          hostModule,
+          extraModules ? [ ],
+          extraSpecialArgs ? { },
+        }:
+        lib.nixosSystem {
+          inherit system;
+          specialArgs = { inherit inputs; } // extraSpecialArgs;
+          modules =
+            [
+              disko.nixosModules.disko
+              hostModule
+            ]
+            ++ extraModules;
+        };
+    in
+    {
+      nixosConfigurations = {
+        blueshell-fra-1 = mkHost {
+          system = "x86_64-linux";
+          hostModule = ./nix/hosts/blueshell-fra-1/default.nix;
+        };
+      };
+
+      deploy.nodes.blueshell-fra-1 = {
+        # Placeholder — replace with the provisioned Contabo VPS public IP
+        # before running `deploy-rs activate`. nixos-anywhere takes the IP
+        # as a CLI argument so it does not need this value during initial
+        # bootstrap.
+        hostname = "blueshell-fra-1.blueshell.nl";
+        profiles.system = {
+          sshUser = "deploy";
+          user = "root";
+          sshOpts = [ "-p" "2222" ];
+          path = deploy-rs.lib.x86_64-linux.activate.nixos self.nixosConfigurations.blueshell-fra-1;
+        };
+      };
+
+      packages = lib.genAttrs supportedNixosAnywhereSystems (
+        system:
+        {
+          nixos-anywhere = nixos-anywhere.packages.${system}.default;
+        }
+      );
+
+      apps = lib.genAttrs supportedNixosAnywhereSystems (
+        system:
+        {
+          nixos-anywhere = {
+            type = "app";
+            program = "${self.packages.${system}.nixos-anywhere}/bin/nixos-anywhere";
+          };
+        }
+      );
+
+      checks = lib.genAttrs [ "x86_64-linux" "aarch64-linux" ] (
+        system:
+        deploy-rs.lib.${system}.deployChecks self.deploy
+      );
+    };
+}

--- a/platform/nix/authorized-keys/.gitignore
+++ b/platform/nix/authorized-keys/.gitignore
@@ -1,0 +1,4 @@
+# Local-only — compose from per-operator pubkeys before deploy.
+deploy.pub
+*.pub
+!README.md

--- a/platform/nix/authorized-keys/README.md
+++ b/platform/nix/authorized-keys/README.md
@@ -1,0 +1,14 @@
+# authorized-keys
+
+Drop each operator's SSH public key into a separate file in this directory
+and combine into `deploy.pub` before provisioning. `deploy.pub` is the file
+that ends up in `authorized_keys` for the `deploy` user on every NixOS host.
+
+```
+cat you.pub teammate.pub > deploy.pub
+```
+
+`deploy.pub` is gitignored on purpose — adding keys should be a conscious
+local step, not something merged through a PR. The base module emits a
+build-time warning when the file is missing so first-time installs catch
+the omission before the host boots without any authorized keys.

--- a/platform/nix/hosts/blueshell-fra-1/default.nix
+++ b/platform/nix/hosts/blueshell-fra-1/default.nix
@@ -30,7 +30,7 @@
 
   networking = {
     hostName = "blueshell-fra-1";
-    domain = "blueshell.nl";
+    domain = "v2.esa-blueshell.nl";
     # Contabo does not run DHCP — the cidata ISO ships static config that
     # Debian picks up on first boot. Replace the placeholder v4/v6 values
     # with the real ones from the cidata file once the VPS is provisioned.

--- a/platform/nix/hosts/blueshell-fra-1/default.nix
+++ b/platform/nix/hosts/blueshell-fra-1/default.nix
@@ -1,0 +1,64 @@
+{ lib, modulesPath, ... }:
+{
+  imports = [
+    # Provides virtio_scsi / virtio_blk / virtio_net in the initrd plus the
+    # qemu-guest agent. Without this the initrd cannot mount /dev/sda on
+    # Contabo's virtio-scsi host, the kernel panics on "unable to mount root"
+    # before serial console or journald are up, and the machine appears alive
+    # to the hypervisor but never comes back on the network.
+    (modulesPath + "/profiles/qemu-guest.nix")
+    ../../modules/base
+    ../../modules/k3s/bootstrap.nix
+    ../../modules/roles/single-node.nix
+    ./disko.nix
+  ];
+
+  # Contabo's KVM firmware is BIOS-only (no /sys/firmware/efi in rescue),
+  # so the base module's systemd-boot can't be executed by the firmware.
+  # Use GRUB in BIOS mode against the MBR/GPT+bios_grub disko layout.
+  boot.loader = {
+    systemd-boot.enable = lib.mkForce false;
+    efi.canTouchEfiVariables = lib.mkForce false;
+    timeout = 1;
+    grub = {
+      enable = true;
+      efiSupport = false;
+      copyKernels = true;
+      forceInstall = true;
+    };
+  };
+
+  networking = {
+    hostName = "blueshell-fra-1";
+    domain = "blueshell.nl";
+    # Contabo does not run DHCP — the cidata ISO ships static config that
+    # Debian picks up on first boot. Replace the placeholder v4/v6 values
+    # with the real ones from the cidata file once the VPS is provisioned.
+    useDHCP = lib.mkForce false;
+    interfaces.ens18 = {
+      useDHCP = false;
+      ipv4.addresses = [
+        {
+          address = "REPLACE_WITH_VPS_IPV4";
+          prefixLength = 24;
+        }
+      ];
+      ipv6.addresses = [
+        {
+          address = "REPLACE_WITH_VPS_IPV6";
+          prefixLength = 64;
+        }
+      ];
+    };
+    defaultGateway = {
+      address = "REPLACE_WITH_VPS_GATEWAY_V4";
+      interface = "ens18";
+    };
+    defaultGateway6 = {
+      address = "fe80::1";
+      interface = "ens18";
+    };
+  };
+
+  system.stateVersion = "25.05";
+}

--- a/platform/nix/hosts/blueshell-fra-1/disko.nix
+++ b/platform/nix/hosts/blueshell-fra-1/disko.nix
@@ -1,0 +1,40 @@
+{ ... }:
+{
+  # Contabo's SeaBIOS does BIOS/legacy boot only. GPT with a tiny bios_grub
+  # partition at the front is the BIOS-friendly layout disko supports in the
+  # pinned nixpkgs (the msdos content type is not available).
+  disko.devices = {
+    disk.main = {
+      type = "disk";
+      device = "/dev/sda";
+      content = {
+        type = "gpt";
+        partitions = {
+          # 1 MiB bios_grub for GRUB core.img on GPT+BIOS.
+          bios = {
+            size = "1M";
+            type = "EF02";
+            priority = 0;
+          };
+          boot = {
+            size = "512M";
+            type = "8300";
+            content = {
+              type = "filesystem";
+              format = "ext4";
+              mountpoint = "/boot";
+            };
+          };
+          root = {
+            size = "100%";
+            content = {
+              type = "filesystem";
+              format = "ext4";
+              mountpoint = "/";
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/platform/nix/modules/base/default.nix
+++ b/platform/nix/modules/base/default.nix
@@ -1,0 +1,94 @@
+{ config, lib, pkgs, ... }:
+let
+  authorizedKeysDir = ../../authorized-keys;
+  deployAuthorizedKeysPath = authorizedKeysDir + "/deploy.pub";
+  deployAuthorizedKeys =
+    if builtins.pathExists deployAuthorizedKeysPath then
+      lib.filter (line: line != "" && !(lib.hasPrefix "#" line)) (
+        lib.splitString "\n" (builtins.readFile deployAuthorizedKeysPath)
+      )
+    else
+      [ ];
+in
+{
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+
+  networking.useDHCP = true;
+  networking.firewall = {
+    enable = true;
+    # 2222 — SSH. Web (80/443) and mail (25/465/587/993/995/110/143/4190)
+    # are opened by the k3s bootstrap module when Traefik / Stalwart bind
+    # hostPorts. Keeping them out of the base module means a host that
+    # only runs the base role stays firewalled to SSH only.
+    allowedTCPPorts = [ 2222 ];
+  };
+
+  # Write /etc/resolv.conf statically from NixOS and disable openresolv
+  # entirely, same rationale as personal-stack: keep kubelet's resolv.conf
+  # under three entries so DNSConfigForming doesn't fire. Three upstreams:
+  # Cloudflare primary + secondary for speed, Quad9 for operator diversity.
+  networking.resolvconf.enable = false;
+  environment.etc."resolv.conf" = {
+    mode = "0644";
+    text = ''
+      nameserver 1.1.1.1
+      nameserver 1.0.0.1
+      nameserver 9.9.9.9
+      options timeout:1 attempts:2 rotate
+    '';
+  };
+
+  services.openssh = {
+    enable = true;
+    ports = [ 2222 ];
+    settings = {
+      AllowUsers = [ "deploy" ];
+      KbdInteractiveAuthentication = false;
+      PasswordAuthentication = false;
+      PermitRootLogin = "no";
+      PubkeyAuthentication = true;
+      X11Forwarding = false;
+    };
+  };
+
+  services.fail2ban.enable = true;
+
+  environment.systemPackages = with pkgs; [
+    curl
+    git
+    jq
+    vim
+  ];
+
+  # A missing deploy.pub is caught loudly at install/deploy time by the
+  # bash guards in platform/scripts. Surface it here as a warning too,
+  # but do not fail the build — otherwise `nix flake check` blows up on
+  # a clean checkout (deploy.pub is gitignored per design).
+  warnings = lib.optional (deployAuthorizedKeys == [ ]) ''
+    No deploy SSH public keys configured in ${toString deployAuthorizedKeysPath}.
+    The `deploy` user on this host will have no authorized keys. Create the
+    file locally (see platform/nix/authorized-keys/README.md) before the
+    next install or deploy-rs activation.
+  '';
+
+  users.users.deploy = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = deployAuthorizedKeys;
+  };
+  security.sudo.wheelNeedsPassword = false;
+
+  time.timeZone = "Europe/Amsterdam";
+  i18n.defaultLocale = "en_US.UTF-8";
+
+  # Reclaim nix store space weekly so a single-node VPS with a modest disk
+  # does not fill up from accumulated deploy-rs profiles.
+  nix.gc = {
+    automatic = true;
+    dates = "weekly";
+    options = "--delete-older-than 30d";
+  };
+  nix.settings.auto-optimise-store = true;
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+}

--- a/platform/nix/modules/k3s/bootstrap.nix
+++ b/platform/nix/modules/k3s/bootstrap.nix
@@ -1,0 +1,33 @@
+{ config, lib, ... }:
+# Single-node k3s bootstrap. Every pod and the Traefik ingress controller
+# (via hostPort) run on this one VPS, so there is no worker/agent join
+# protocol to configure and no cross-site overlay to tunnel — flannel
+# runs over the default ethernet interface.
+let
+  isK3sServer = config.services.k3s.enable && config.services.k3s.role == "server";
+in
+{
+  config = lib.mkIf config.services.k3s.enable {
+    networking.firewall.allowedTCPPorts =
+      [
+        # Kubelet.
+        10250
+        # Traefik public-ingress hostPorts — bound directly on the node
+        # because the cluster has no LoadBalancer backend.
+        80
+        443
+        # Mail — Stalwart binds these with hostPort in the mail apps.
+        25
+        465
+        587
+        993
+        995
+        110
+        143
+        4190
+      ]
+      ++ lib.optionals isK3sServer [ 6443 ];
+    # Flannel VXLAN backend.
+    networking.firewall.allowedUDPPorts = [ 8472 ];
+  };
+}

--- a/platform/nix/modules/roles/single-node.nix
+++ b/platform/nix/modules/roles/single-node.nix
@@ -22,7 +22,7 @@
       # The oidc: prefix keeps these identities disjoint from the
       # built-in system:* groups so a human-issued token is never
       # implicitly bound to a system role.
-      "--kube-apiserver-arg=oidc-issuer-url=https://auth.blueshell.nl"
+      "--kube-apiserver-arg=oidc-issuer-url=https://auth.v2.esa-blueshell.nl"
       "--kube-apiserver-arg=oidc-client-id=headlamp"
       "--kube-apiserver-arg=oidc-username-claim=preferred_username"
       "--kube-apiserver-arg=oidc-username-prefix=oidc:"

--- a/platform/nix/modules/roles/single-node.nix
+++ b/platform/nix/modules/roles/single-node.nix
@@ -1,0 +1,33 @@
+{ ... }:
+# Collapsed control-plane + worker role. The cluster is intentionally
+# single-node; Traefik and ServiceLB are disabled because the platform
+# ships its own Traefik via Flux and uses hostPorts rather than a
+# LoadBalancer.
+{
+  services.k3s = {
+    enable = true;
+    role = "server";
+    extraFlags = [
+      "--disable=traefik"
+      "--disable=servicelb"
+      "--write-kubeconfig-mode=0644"
+      # Trust OIDC tokens issued by the website api so Headlamp (and
+      # anything else with an id-token) can authenticate against the
+      # kube-apiserver without a static kubeconfig. The audience is the
+      # OAuth2 clientId the api registers for Headlamp; the groups claim
+      # drives per-user RBAC (see
+      # platform/cluster/flux/apps/core/headlamp/oidc-admin-binding.yaml
+      # when that lands).
+      #
+      # The oidc: prefix keeps these identities disjoint from the
+      # built-in system:* groups so a human-issued token is never
+      # implicitly bound to a system role.
+      "--kube-apiserver-arg=oidc-issuer-url=https://auth.blueshell.nl"
+      "--kube-apiserver-arg=oidc-client-id=headlamp"
+      "--kube-apiserver-arg=oidc-username-claim=preferred_username"
+      "--kube-apiserver-arg=oidc-username-prefix=oidc:"
+      "--kube-apiserver-arg=oidc-groups-claim=groups"
+      "--kube-apiserver-arg=oidc-groups-prefix=oidc:"
+    ];
+  };
+}


### PR DESCRIPTION
## Summary

First step of the NixOS bootstrap. Declares the `platform/` flake, a host entry for the future `blueshell-fra-1` Contabo VPS, and shared base + k3s + single-node role modules modeled on personal-stack with all multi-node / Tailscale / fleet-inventory specifics stripped out.

This PR does not provision anything. `nix flake check` validates the configuration in CI so it is ready the moment PR 9 cuts over the live VPS.

## Added

### `platform/flake.nix`

- Inputs: `nixpkgs/nixos-unstable`, `disko`, `nixos-anywhere`, `deploy-rs`.
- Single `nixosConfiguration` `blueshell-fra-1` on `x86_64-linux`.
- `deploy.nodes` entry with placeholder hostname for `deploy-rs`.
- Exposes `nixos-anywhere` as a flake package/app for easy initial provisioning.

### `platform/nix/hosts/blueshell-fra-1/`

- `default.nix` — qemu-guest profile, BIOS/GRUB boot loader (Contabo SeaBIOS does BIOS only), static networking with `REPLACE_WITH_…` placeholders for the cidata-supplied IPv4/IPv6/gateway.
- `disko.nix` — GPT + 1 MiB bios_grub + 512 MiB `/boot` + ext4 `/`.

### `platform/nix/modules/base/default.nix`

- SSH on 2222, key-only, `PermitRootLogin=no`, `AllowUsers=deploy`.
- `fail2ban` enabled. `deploy` user in `wheel` with passwordless sudo.
- Static `/etc/resolv.conf` with Cloudflare + Quad9; `resolvconf` disabled so no process mutates `/etc/resolv.conf` (kubelet stays under `glibc MAXNS=3`).
- Weekly automatic `nix-gc` + store optimisation; `nix-command` + `flakes` enabled.
- Warns but does not fail when `authorized-keys/deploy.pub` is absent (gitignored on purpose).

### `platform/nix/modules/k3s/bootstrap.nix`

- Opens firewall for kubelet (10250), the kube-apiserver (6443), flannel VXLAN (UDP 8472), Traefik ingress hostPorts (80/443), and the Stalwart mail listeners (25/110/143/465/587/993/995/4190).
- No Tailscale / multi-node / agent-join wiring — single-node stack.

### `platform/nix/modules/roles/single-node.nix`

- Enables k3s in server role with Traefik + ServiceLB disabled (Flux ships its own Traefik).
- Trusts OIDC tokens from `https://auth.blueshell.nl` so Headlamp (and anyone else with an id-token) can authenticate against the kube-apiserver. `oidc:` groups prefix keeps identities disjoint from `system:*` groups.

### `platform/nix/authorized-keys/`

- `README` + `.gitignore`: `deploy.pub` is composed locally from each operator's pubkey and is never committed.

### `platform/docs/nix-flake.md`

- Layout, first-time `nixos-anywhere` provisioning, `deploy-rs` usage, local `nix flake check` command.

### CI

- New `nix-flake-check` job that runs `nix flake check ./platform` via `DeterminateSystems/nix-installer-action` + `magic-nix-cache-action`.
- `push:` paths include `platform/**` so nix changes trigger the check.

## Follow-ups (not in this PR)

- PR 5: FluxCD scaffold + `apps-core` (cert-manager, external-dns, Traefik, VSO, Headlamp, Keel).
- PR 9: Actual provisioning of the Contabo VPS and DNS cutover — the `REPLACE_WITH_VPS_*` placeholders get filled in then.

## Test plan

- [x] `nix flake check ./platform --no-build` passes locally.
- [ ] `nix-flake-check` job green in CI.
- [ ] Replacing the `REPLACE_WITH_VPS_*` placeholders with live Contabo values happens as part of PR 9's cutover playbook — not validated here.