### PR TITLE
Add Cloudflare zone file for esa-blueshell.nl

### DIFF
--- a/infra/dns/README.md
+++ b/infra/dns/README.md
@@ -1,0 +1,36 @@
+# DNS zones
+
+Authoritative zone files, one per domain. Imported into Cloudflare via
+**Dashboard → DNS → Records → Import and Export → Import**.
+
+## esa-blueshell.nl
+
+- Zone: [`esa-blueshell.nl.zone`](./esa-blueshell.nl.zone)
+- Migrated off TransIP on 2026-04-21.
+- Apex `esa-blueshell.nl` continues to serve the legacy single-VPS stack at
+  `136.144.191.63`.
+- The new NixOS + k3s platform lives under `v2.esa-blueshell.nl` and the
+  `*.v2` wildcard (`157.173.115.164` / `2a02:c207:2316:2642::1`). Every
+  service hostname the platform advertises (`api.v2`, `kube.v2`, `vault.v2`,
+  `mail.v2`, `auth.v2`, `status.v2`, …) resolves through that wildcard.
+- Once the v2 stack is validated end-to-end the apex A/AAAA records flip
+  to the v2 backend and the `v2` label retires.
+
+## Proxy status
+
+After import, toggle the orange cloud per record:
+
+| Record                       | Proxy | Reason                                                 |
+| ---------------------------- | ----- | ------------------------------------------------------ |
+| `@`, `www`                   | on    | Public HTTP(S) behind Cloudflare.                      |
+| `@` (MX target)              | off   | Mail cannot be proxied.                                |
+| `minecraft`                  | off   | Game traffic — Cloudflare proxy is HTTP(S) only.       |
+| `ftp`                        | off   | Non-HTTP protocol.                                     |
+| `v2`, `*.v2`                 | off   | Different backend; wildcard wildcard-cert via DNS-01.  |
+
+## ACME / Let's Encrypt
+
+Wildcard `*.v2.esa-blueshell.nl` is issued via DNS-01. cert-manager writes
+the challenge TXT record at `_acme-challenge.v2.esa-blueshell.nl` through
+the Cloudflare API. The API token needs `Zone:DNS:Edit` scoped to this
+zone.

--- a/infra/dns/esa-blueshell.nl.zone
+++ b/infra/dns/esa-blueshell.nl.zone
@@ -1,0 +1,38 @@
+; Zone file for esa-blueshell.nl
+; Import into Cloudflare via Dashboard → DNS → Records → Import
+; Source: migrated from TransIP DNS (2026-04-21)
+;
+; Notes on proxy status (set after import in Cloudflare UI):
+;   - Proxy ON  (orange cloud): @, www
+;   - Proxy OFF (grey cloud, "DNS only"):
+;       * MX target (esa-blueshell.nl itself cannot be proxied for mail)
+;       * minecraft  (game traffic — Cloudflare proxy is HTTP/S only)
+;       * ftp        (non-HTTP protocol)
+;       * v2, *.v2   (different backend IP; proxy only if it serves HTTP(S))
+;
+; Apex / website ----------------------------------------------------------
+; No wildcard at the apex — only the explicit hostnames below resolve.
+@           1   IN  A       136.144.191.63
+@           1   IN  AAAA    2a01:7c8:aacb:1e5::101:55
+@           1   IN  MX  10  esa-blueshell.nl.
+
+; www ---------------------------------------------------------------------
+www         1   IN  CNAME   esa-blueshell.nl.
+
+; ftp ---------------------------------------------------------------------
+ftp         1   IN  CNAME   esa-blueshell.nl.
+
+; Minecraft server --------------------------------------------------------
+minecraft   1   IN  A       162.33.20.159
+
+; v2 backend (different host than apex) -----------------------------------
+v2          1   IN  A       157.173.115.164
+v2          1   IN  AAAA    2a02:c207:2316:2642::1
+
+; Wildcard for *.v2.esa-blueshell.nl → v2 backend -------------------------
+; ACME DNS-01 for the *.v2 wildcard cert uses a TXT record at
+; _acme-challenge.v2.esa-blueshell.nl, written dynamically by the ACME
+; client via the Cloudflare API (token needs Zone:DNS:Edit on this zone).
+; No conflict with these A/AAAA records — TXT lives at a different label.
+*.v2        1   IN  A       157.173.115.164
+*.v2        1   IN  AAAA    2a02:c207:2316:2642::1


### PR DESCRIPTION
## Summary

Captures the authoritative zone content for `esa-blueshell.nl` migrated off TransIP on 2026-04-21. Imported into Cloudflare via **Dashboard → DNS → Records → Import and Export → Import**.

## Records

- **Apex + www + ftp** — continue to serve the legacy single-VPS stack at `136.144.191.63` (MX also points here).
- **minecraft** — game server at `162.33.20.159`.
- **v2 + \*.v2** — new NixOS + k3s cluster backend at `157.173.115.164` / `2a02:c207:2316:2642::1`.

Every service the platform advertises (`api.v2`, `kube.v2`, `vault.v2`, `mail.v2`, `auth.v2`, `status.v2`, …) resolves through the `*.v2` wildcard. Once the v2 stack is validated end-to-end the apex A/AAAA records flip to the v2 backend and the `v2` label retires.

## Proxy flags (applied in the Cloudflare UI after import)

- Orange cloud: `@`, `www`
- Grey cloud: MX target (mail), `minecraft`, `ftp`, `v2`, `*.v2`

## ACME

Wildcard cert for `*.v2.esa-blueshell.nl` uses DNS-01. cert-manager (which lands with the FluxCD scaffold) writes the TXT at `_acme-challenge.v2.esa-blueshell.nl` through the Cloudflare API. Token scope: `Zone:DNS:Edit` on this zone.