### PR TITLE
platform: add data layer (Vault, MariaDB, Postgres) and VSO secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,8 @@ services/**/*.env
 
 # infra secrets
 /infra/.infra.env
+
+# platform/ is the GitOps tree and must always be fully tracked;
+# negate the broad patterns above that would otherwise eat it.
+!platform/
+!platform/**

--- a/platform/cluster/flux/apps/data/bitnami-source.yaml
+++ b/platform/cluster/flux/apps/data/bitnami-source.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: bitnami
+  namespace: data-system
+spec:
+  interval: 1h
+  url: https://charts.bitnami.com/bitnami

--- a/platform/cluster/flux/apps/data/kustomization.yaml
+++ b/platform/cluster/flux/apps/data/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - bitnami-source.yaml
+  - vault
+  - mariadb
+  - listmonk-db

--- a/platform/cluster/flux/apps/data/listmonk-db/kustomization.yaml
+++ b/platform/cluster/flux/apps/data/listmonk-db/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - release.yaml

--- a/platform/cluster/flux/apps/data/listmonk-db/release.yaml
+++ b/platform/cluster/flux/apps/data/listmonk-db/release.yaml
@@ -1,0 +1,29 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: listmonk-db
+  namespace: data-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: postgresql
+      version: "16.x"
+      sourceRef:
+        kind: HelmRepository
+        name: bitnami
+        namespace: data-system
+  values:
+    auth:
+      database: listmonk
+      username: listmonk
+      # Credentials seeded into Vault at secret/listmonk by the operator,
+      # then synced here by VSO (see apps/vso-secrets/listmonk-secrets.yaml).
+      existingSecret: listmonk-db-credentials
+      secretKeys:
+        adminPasswordKey: postgres-password
+        userPasswordKey: password
+    primary:
+      persistence:
+        enabled: true
+        size: 5Gi

--- a/platform/cluster/flux/apps/data/mariadb/kustomization.yaml
+++ b/platform/cluster/flux/apps/data/mariadb/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - release.yaml

--- a/platform/cluster/flux/apps/data/mariadb/release.yaml
+++ b/platform/cluster/flux/apps/data/mariadb/release.yaml
@@ -1,0 +1,28 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mariadb
+  namespace: data-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: mariadb
+      version: "18.x"
+      sourceRef:
+        kind: HelmRepository
+        name: bitnami
+        namespace: data-system
+  values:
+    auth:
+      database: blueshell
+      # Root password and api user password are seeded into Vault at
+      # secret/platform/mariadb by the operator before first apply, then
+      # synced here by VSO (see apps/vso-secrets/mariadb-credentials.yaml).
+      existingSecret: mariadb-credentials
+    primary:
+      persistence:
+        enabled: true
+        size: 10Gi
+    secondary:
+      replicaCount: 0

--- a/platform/cluster/flux/apps/data/namespace.yaml
+++ b/platform/cluster/flux/apps/data/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: data-system

--- a/platform/cluster/flux/apps/data/vault/bootstrap-auth-job.yaml
+++ b/platform/cluster/flux/apps/data/vault/bootstrap-auth-job.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-bootstrap-auth
+  namespace: data-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vault-bootstrap-auth-token-reviewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: vault-bootstrap-auth
+    namespace: data-system
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: vault-bootstrap-auth
+  namespace: data-system
+  # Job.spec.template is immutable, so when the hashed vault-bootstrap-auth
+  # ConfigMap name changes (content hash drift on bootstrap-auth.sh), a
+  # plain `kubectl apply` would fail with "field is immutable". This
+  # annotation tells the Flux Kustomization controller to delete and
+  # recreate the Job when its spec diverges — the whole point of the
+  # configMapGenerator hash is that every bootstrap-auth.sh edit forces
+  # a fresh Job run.
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vault-bootstrap-auth
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: vault-bootstrap-auth
+      containers:
+        - name: bootstrap
+          image: hashicorp/vault
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - /bootstrap/bootstrap.sh
+          env:
+            - name: VAULT_ADDR
+              value: http://vault.data-system.svc.cluster.local:8200
+            - name: VAULT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: vault-bootstrap-token
+                  key: token
+          volumeMounts:
+            - name: bootstrap
+              mountPath: /bootstrap
+              readOnly: true
+      volumes:
+        - name: bootstrap
+          configMap:
+            name: vault-bootstrap-auth
+            defaultMode: 493

--- a/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
+++ b/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env sh
+set -eu
+
+# Idempotent Vault bootstrap for the website. Runs on every Flux apply;
+# re-running against an already-configured Vault mutates the narrow set
+# of resources below without disturbing sealed state or data.
+
+# --- Auth + KV engine ----------------------------------------------------
+
+if ! vault auth list -format=json | grep -q '"kubernetes/"'; then
+  vault auth enable kubernetes
+fi
+
+vault write auth/kubernetes/config \
+  kubernetes_host="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS}" \
+  token_reviewer_jwt="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+# kv-v2 at `secret/` is Vault's conventional default. Services read
+# secret/data/<path>, the kv-v2 engine rewrites to <path>.
+if ! vault secrets list -format=json | grep -q '"secret/"'; then
+  vault secrets enable -path=secret kv-v2
+fi
+
+# --- Transit engine for JWT signing -------------------------------------
+
+if ! vault secrets list -format=json | grep -q '"transit/"'; then
+  vault secrets enable transit
+fi
+
+if ! vault read transit/keys/api-jwt >/dev/null 2>&1; then
+  vault write transit/keys/api-jwt type="rsa-2048"
+fi
+
+# --- Policies -----------------------------------------------------------
+
+cat <<'EOF' >/tmp/api.hcl
+path "secret/data/api" {
+  capabilities = ["read"]
+}
+
+path "secret/data/api/*" {
+  capabilities = ["read"]
+}
+
+path "database/creds/api" {
+  capabilities = ["read"]
+}
+
+path "transit/sign/api-jwt" {
+  capabilities = ["update"]
+}
+
+path "transit/keys/api-jwt" {
+  capabilities = ["read"]
+}
+EOF
+
+cat <<'EOF' >/tmp/listmonk.hcl
+path "secret/data/listmonk" {
+  capabilities = ["read"]
+}
+
+path "secret/data/listmonk/*" {
+  capabilities = ["read"]
+}
+
+path "database/creds/listmonk" {
+  capabilities = ["read"]
+}
+EOF
+
+cat <<'EOF' >/tmp/stalwart.hcl
+path "secret/data/platform/mail" {
+  capabilities = ["read"]
+}
+
+path "secret/data/platform/edge" {
+  capabilities = ["read"]
+}
+EOF
+
+# VSO reads here to mint k8s Secrets in the namespaces of apps that need
+# them — platform/edge (Cloudflare DNS-01 token for cert-manager and
+# external-dns), platform/api (api secrets), platform/listmonk (listmonk
+# admin + SMTP), platform/mail (stalwart admin + DKIM).
+cat <<'EOF' >/tmp/vso.hcl
+path "secret/data/platform/edge" {
+  capabilities = ["read"]
+}
+
+path "secret/data/api" {
+  capabilities = ["read"]
+}
+
+path "secret/data/listmonk" {
+  capabilities = ["read"]
+}
+
+path "secret/data/platform/mail" {
+  capabilities = ["read"]
+}
+EOF
+
+vault policy write api /tmp/api.hcl
+vault policy write listmonk /tmp/listmonk.hcl
+vault policy write stalwart /tmp/stalwart.hcl
+vault policy write vso /tmp/vso.hcl
+
+# --- Kubernetes auth roles ---------------------------------------------
+
+vault write auth/kubernetes/role/api \
+  bound_service_account_names="api" \
+  bound_service_account_namespaces="default" \
+  policies="api" \
+  ttl="1h"
+
+vault write auth/kubernetes/role/listmonk \
+  bound_service_account_names="listmonk" \
+  bound_service_account_namespaces="default" \
+  policies="listmonk" \
+  ttl="1h"
+
+vault write auth/kubernetes/role/stalwart \
+  bound_service_account_names="stalwart" \
+  bound_service_account_namespaces="mail-system" \
+  policies="stalwart" \
+  ttl="1h"
+
+vault write auth/kubernetes/role/vso \
+  bound_service_account_names="vault-secrets-operator" \
+  bound_service_account_namespaces="vso-system,cert-manager,external-dns,default,mail-system" \
+  policies="vso" \
+  ttl="1h"
+
+# --- MariaDB dynamic secrets (database engine) --------------------------
+#
+# The api reads DB creds from Vault via `database/creds/api`. The
+# engine itself is configured lazily because the mariadb chart does not
+# expose an admin password via a Kubernetes Secret VSO can mint — an
+# operator seeds it via `secret/platform/mariadb.{user,password}` the
+# first time, then this block picks it up. The block short-circuits
+# until that secret exists so a fresh Vault install does not block the
+# bootstrap Job on an unsatisfiable precondition.
+
+if ! vault secrets list -format=json | grep -q '"database/"'; then
+  vault secrets enable database
+fi
+
+if vault kv get secret/platform/mariadb >/dev/null 2>&1; then
+  DB_ADMIN_USER=$(vault kv get -field=user secret/platform/mariadb)
+  DB_ADMIN_PASS=$(vault kv get -field=password secret/platform/mariadb)
+
+  vault write database/config/mariadb \
+    plugin_name=mysql-database-plugin \
+    allowed_roles="api" \
+    connection_url="{{username}}:{{password}}@tcp(mariadb.data-system.svc.cluster.local:3306)/" \
+    username="${DB_ADMIN_USER}" \
+    password="${DB_ADMIN_PASS}" \
+    verify_connection=true
+
+  vault write database/roles/api \
+    db_name=mariadb \
+    default_ttl="72h" \
+    max_ttl="168h" \
+    creation_statements="CREATE USER '{{name}}'@'%' IDENTIFIED BY '{{password}}'; GRANT ALL ON blueshell.* TO '{{name}}'@'%';"
+
+  unset DB_ADMIN_USER DB_ADMIN_PASS
+else
+  echo "secret/platform/mariadb not seeded yet — skipping database/config/mariadb."
+  echo "Seed with: vault kv put secret/platform/mariadb user=<admin> password=<secret>"
+fi

--- a/platform/cluster/flux/apps/data/vault/kustomization.yaml
+++ b/platform/cluster/flux/apps/data/vault/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - source.yaml
+  - release.yaml
+  - bootstrap-auth-job.yaml
+
+# Generate the bootstrap-auth ConfigMap from the extracted shell script.
+# Kustomize appends a content hash to the generated name (e.g.
+# vault-bootstrap-auth-abc123), and built-in name references rewrite
+# bootstrap-auth-job.yaml's volumes.configMap.name to match. Any edit to
+# bootstrap-auth.sh produces a new hash, which flips the Job's spec and
+# triggers Flux's force-replace (kustomize.toolkit.fluxcd.io/force:
+# enabled on the Job) so the bootstrap Job re-runs automatically instead
+# of quietly holding stale Vault role/policy state forever.
+configMapGenerator:
+  - name: vault-bootstrap-auth
+    namespace: data-system
+    files:
+      - bootstrap.sh=bootstrap-auth.sh

--- a/platform/cluster/flux/apps/data/vault/release.yaml
+++ b/platform/cluster/flux/apps/data/vault/release.yaml
@@ -1,0 +1,56 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vault
+  namespace: data-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: vault
+      sourceRef:
+        kind: HelmRepository
+        name: hashicorp
+        namespace: data-system
+  values:
+    ui:
+      enabled: true
+    injector:
+      enabled: true
+    csi:
+      enabled: true
+    server:
+      readinessProbe:
+        enabled: true
+        timeoutSeconds: 10
+      dataStorage:
+        enabled: true
+        size: 5Gi
+      auditStorage:
+        enabled: true
+        size: 5Gi
+      # Single-replica HA + Raft is the simplest Vault topology that
+      # still produces a Raft cluster; a future node addition is a
+      # `peer add` away without data migration. Standalone mode is
+      # deliberately avoided because it cannot later be promoted to
+      # HA without a fresh init.
+      ha:
+        enabled: true
+        replicas: 1
+        raft:
+          enabled: true
+          setNodeId: true
+          config: |
+            ui = true
+
+            listener "tcp" {
+              address = "[::]:8200"
+              cluster_address = "[::]:8201"
+              tls_disable = 1
+            }
+
+            storage "raft" {
+              path = "/vault/data"
+            }
+
+            service_registration "kubernetes" {}

--- a/platform/cluster/flux/apps/data/vault/source.yaml
+++ b/platform/cluster/flux/apps/data/vault/source.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: hashicorp
+  namespace: data-system
+spec:
+  interval: 1h
+  url: https://helm.releases.hashicorp.com

--- a/platform/cluster/flux/apps/vso-secrets/api-secrets.yaml
+++ b/platform/cluster/flux/apps/vso-secrets/api-secrets.yaml
@@ -1,0 +1,18 @@
+# api reads api-secrets at runtime for third-party integrations (Brevo,
+# Mollie, Google Calendar SA, Facebook, X). The api Vault policy also
+# allows reading database/creds/api (dynamic MariaDB creds) and
+# transit/sign/api-jwt directly — those are not synced via VSO.
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: api-secrets
+  namespace: default
+spec:
+  vaultAuthRef: vso-system/default
+  type: kv-v2
+  mount: secret
+  path: api
+  destination:
+    name: api-secrets
+    create: true
+  refreshAfter: 1h

--- a/platform/cluster/flux/apps/vso-secrets/cloudflare.yaml
+++ b/platform/cluster/flux/apps/vso-secrets/cloudflare.yaml
@@ -1,0 +1,52 @@
+# cert-manager reads cloudflare-api-token.api-token to satisfy DNS-01
+# challenges for *.v2.esa-blueshell.nl. external-dns reads the same secret
+# shape to manage A/AAAA records. VSO syncs both from the same Vault path.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-secrets-operator
+  namespace: cert-manager
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: cloudflare-api-token
+  namespace: cert-manager
+spec:
+  vaultAuthRef: vso-system/default
+  type: kv-v2
+  mount: secret
+  path: platform/edge
+  destination:
+    name: cloudflare-api-token
+    create: true
+    transformation:
+      templates:
+        api-token:
+          text: '{{- get .Secrets "cloudflare.dns_api_token" -}}'
+  refreshAfter: 1h
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-secrets-operator
+  namespace: external-dns
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: cloudflare-api-token
+  namespace: external-dns
+spec:
+  vaultAuthRef: vso-system/default
+  type: kv-v2
+  mount: secret
+  path: platform/edge
+  destination:
+    name: cloudflare-api-token
+    create: true
+    transformation:
+      templates:
+        api-token:
+          text: '{{- get .Secrets "cloudflare.dns_api_token" -}}'
+  refreshAfter: 1h

--- a/platform/cluster/flux/apps/vso-secrets/kustomization.yaml
+++ b/platform/cluster/flux/apps/vso-secrets/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - cloudflare.yaml
+  - mariadb-credentials.yaml
+  - api-secrets.yaml
+  - listmonk-secrets.yaml
+  - stalwart-secrets.yaml

--- a/platform/cluster/flux/apps/vso-secrets/listmonk-secrets.yaml
+++ b/platform/cluster/flux/apps/vso-secrets/listmonk-secrets.yaml
@@ -1,0 +1,37 @@
+# listmonk-db-credentials: Bitnami PostgreSQL chart reads these at startup.
+# listmonk-secrets: Listmonk app config (admin credentials, SMTP password).
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: listmonk-db-credentials
+  namespace: data-system
+spec:
+  vaultAuthRef: vso-system/default
+  type: kv-v2
+  mount: secret
+  path: listmonk
+  destination:
+    name: listmonk-db-credentials
+    create: true
+    transformation:
+      templates:
+        postgres-password:
+          text: '{{- get .Secrets "db-admin-password" -}}'
+        password:
+          text: '{{- get .Secrets "db-password" -}}'
+  refreshAfter: 1h
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: listmonk-secrets
+  namespace: default
+spec:
+  vaultAuthRef: vso-system/default
+  type: kv-v2
+  mount: secret
+  path: listmonk
+  destination:
+    name: listmonk-secrets
+    create: true
+  refreshAfter: 1h

--- a/platform/cluster/flux/apps/vso-secrets/mariadb-credentials.yaml
+++ b/platform/cluster/flux/apps/vso-secrets/mariadb-credentials.yaml
@@ -1,0 +1,30 @@
+# Bitnami MariaDB chart reads mariadb-credentials.mariadb-root-password
+# and mariadb-credentials.mariadb-password at startup. VSO syncs from
+# secret/platform/mariadb which the operator seeds once before first apply
+# (see platform/docs/vault-bootstrap.md).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-secrets-operator
+  namespace: data-system
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: mariadb-credentials
+  namespace: data-system
+spec:
+  vaultAuthRef: vso-system/default
+  type: kv-v2
+  mount: secret
+  path: platform/mariadb
+  destination:
+    name: mariadb-credentials
+    create: true
+    transformation:
+      templates:
+        mariadb-root-password:
+          text: '{{- get .Secrets "root-password" -}}'
+        mariadb-password:
+          text: '{{- get .Secrets "password" -}}'
+  refreshAfter: 1h

--- a/platform/cluster/flux/apps/vso-secrets/stalwart-secrets.yaml
+++ b/platform/cluster/flux/apps/vso-secrets/stalwart-secrets.yaml
@@ -1,0 +1,18 @@
+# stalwart-secrets: admin credentials and DKIM private key for the mail
+# server. Stalwart reads these via Vault Agent injection (see PR7 manifests)
+# rather than a k8s Secret, but VSO is used to create the Secret that
+# Stalwart's initContainer uses on first boot.
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: stalwart-secrets
+  namespace: mail-system
+spec:
+  vaultAuthRef: vso-system/default
+  type: kv-v2
+  mount: secret
+  path: platform/mail
+  destination:
+    name: stalwart-secrets
+    create: true
+  refreshAfter: 1h

--- a/platform/cluster/flux/clusters/production/kustomizations.yaml
+++ b/platform/cluster/flux/clusters/production/kustomizations.yaml
@@ -2,10 +2,10 @@
 # Layered Kustomizations so Helm-owned CRDs install before any CR that
 # depends on them. apps-core installs charts (cert-manager, Traefik,
 # external-dns, VSO) and waits for the HelmReleases to report Ready.
-# Every other domain dependsOn apps-core. The data / mail / stateless
-# domains are added in their own PRs; their Kustomization entries are
-# declared here upfront so the dependency graph does not shift when
-# they land.
+# apps-data depends on apps-core (Vault HelmRelease needs the VSO CRDs
+# present first). apps-vso-secrets depends on both so the VaultStaticSecret
+# CRs are only applied after Vault is running and the VSO default auth
+# method is wired up.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -17,6 +17,39 @@ spec:
   prune: true
   wait: true
   timeout: 15m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps-data
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./platform/cluster/flux/apps/data
+  prune: true
+  wait: true
+  timeout: 15m
+  dependsOn:
+    - name: apps-core
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps-vso-secrets
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./platform/cluster/flux/apps/vso-secrets
+  prune: true
+  dependsOn:
+    - name: apps-core
+    - name: apps-data
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/platform/docs/vault-bootstrap.md
+++ b/platform/docs/vault-bootstrap.md
@@ -1,0 +1,142 @@
+# Vault bootstrap
+
+One-time steps after a fresh cluster. Run these in order; the `apps-data`
+Kustomization converges without them but Vault starts sealed and most
+secrets remain unsynced until you complete the sequence.
+
+## 1. Initialize and unseal Vault
+
+```bash
+kubectl exec -n data-system vault-0 -- vault operator init \
+  -key-shares=1 -key-threshold=1 \
+  -format=json > /tmp/vault-init.json
+
+# Store both values somewhere safe (password manager).
+UNSEAL_KEY=$(jq -r '.unseal_keys_b64[0]' /tmp/vault-init.json)
+ROOT_TOKEN=$(jq -r '.root_token'          /tmp/vault-init.json)
+
+kubectl exec -n data-system vault-0 -- vault operator unseal "$UNSEAL_KEY"
+```
+
+Single-replica Raft, so one unseal is enough. You must unseal again after
+every Vault pod restart (e.g. node reboot). Automate with
+[vault-unseal](https://github.com/lrstanley/vault-unseal) or store the
+unseal key in a cloud KMS later.
+
+## 2. Seed the bootstrap token
+
+The bootstrap Job reads its Vault root token from `vault-bootstrap-token`.
+Create that secret before applying the Job (or Flux will stall on the Job
+with a missing secret error):
+
+```bash
+kubectl create secret generic vault-bootstrap-token \
+  -n data-system \
+  --from-literal=token="$ROOT_TOKEN"
+```
+
+## 3. Run the bootstrap Job
+
+Flux applies the Job automatically once `apps-data` reconciles. If it has
+not run yet, trigger it manually:
+
+```bash
+flux reconcile kustomization apps-data --timeout=5m
+```
+
+Watch progress:
+
+```bash
+kubectl logs -n data-system -l app.kubernetes.io/name=vault-bootstrap-auth -f
+```
+
+The Job is idempotent — you can re-run it safely after editing
+`bootstrap-auth.sh` (kustomize content-hash triggers a force-replace).
+
+## 4. Seed static secrets
+
+These paths must exist in Vault before the corresponding VSO
+`VaultStaticSecret` CRs can sync. The VSO CRs loop on a 1h refresh and
+will eventually succeed once the paths are present; there is no need to
+unseal+re-bootstrap after seeding.
+
+### Cloudflare DNS token (cert-manager + external-dns)
+
+```bash
+vault kv put secret/platform/edge \
+  cloudflare.dns_api_token=<token-with-Zone:DNS:Edit>
+```
+
+### MariaDB credentials
+
+```bash
+vault kv put secret/platform/mariadb \
+  root-password=<strong-password> \
+  user=blueshell \
+  password=<app-password>
+```
+
+The bootstrap Job's MariaDB dynamic-secrets block reads `user` and
+`password` from this path to configure the `database/` secrets engine.
+It is safe to run the Job before seeding — the block short-circuits and
+prints a reminder.
+
+### Listmonk
+
+```bash
+vault kv put secret/listmonk \
+  db-admin-password=<postgres-superuser-password> \
+  db-password=<listmonk-user-password> \
+  admin-user=listmonk-admin \
+  admin-password=<listmonk-ui-password> \
+  smtp-password=<smtp-password>
+```
+
+### Stalwart mail server
+
+```bash
+vault kv put secret/platform/mail \
+  admin-password=<stalwart-admin-password> \
+  dkim-private-key=<base64-encoded-rsa-2048-pem>
+```
+
+### API third-party secrets
+
+```bash
+vault kv put secret/api \
+  brevo-api-key=<key> \
+  mollie-api-key=<key> \
+  google-calendar-sa-json=<base64-json> \
+  facebook-app-secret=<secret> \
+  x-api-secret=<secret>
+```
+
+## 5. Confirm VSO sync
+
+After seeding, force a VSO reconcile and verify secrets appear:
+
+```bash
+flux reconcile kustomization apps-vso-secrets --timeout=3m
+kubectl get secret -n cert-manager cloudflare-api-token
+kubectl get secret -n data-system  mariadb-credentials
+kubectl get secret -n data-system  listmonk-db-credentials
+kubectl get secret -n default      api-secrets
+kubectl get secret -n default      listmonk-secrets
+kubectl get secret -n mail-system  stalwart-secrets
+```
+
+## 6. Rotate the root token
+
+The `vault-bootstrap-token` secret holds the root token. Revoke the root
+token once initial setup is complete and store the unseal key offline:
+
+```bash
+vault token revoke "$ROOT_TOKEN"
+kubectl delete secret -n data-system vault-bootstrap-token
+```
+
+You can regenerate a new root token at any time from the unseal key:
+
+```bash
+vault operator generate-root -init
+```


### PR DESCRIPTION
Lands `apps-data` and `apps-vso-secrets`, completing the credential and
storage infrastructure that `apps-stateless` and `apps-mail` depend on.

## apps/data

**Vault** — HA single-replica Raft HelmRelease (5 Gi data + audit PVCs,
UI + injector + CSI enabled). An idempotent bootstrap Job (force-replaced
whenever `bootstrap-auth.sh` changes via kustomize content-hash) initialises:

- Kubernetes auth method + k8s roles for `api`, `listmonk`, `stalwart`, `vso`
- Transit secrets engine with `api-jwt` RSA-2048 signing key
- kv-v2 at `secret/`
- Policies for each service
- MariaDB dynamic secrets engine (conditional — activates once the operator
  seeds `secret/platform/mariadb` in Vault; safe to reconcile before seeding)

**MariaDB** — Bitnami 10.11 HelmRelease, 10 Gi PVC, initial DB `blueshell`.
Reads root + app credentials from the `mariadb-credentials` secret synced by
VSO.

**PostgreSQL** — Bitnami 16 HelmRelease for Listmonk only, 5 Gi PVC. Reads
credentials from `listmonk-db-credentials` synced by VSO.

A shared `bitnami` HelmRepository lives at the `data` layer so both charts
can reference it.

## apps/vso-secrets

`VaultStaticSecret` CRs sync from Vault into Kubernetes Secrets:

| CR | Vault path | Target namespace |
|----|-----------|-----------------|
| `cloudflare-api-token` | `secret/platform/edge` | `cert-manager`, `external-dns` |
| `mariadb-credentials` | `secret/platform/mariadb` | `data-system` |
| `api-secrets` | `secret/api` | `default` |
| `listmonk-db-credentials` + `listmonk-secrets` | `secret/listmonk` | `data-system` / `default` |
| `stalwart-secrets` | `secret/platform/mail` | `mail-system` |

All reference `vso-system/default` VaultAuth, created by the VSO
`defaultAuthMethod` Helm values already in `apps-core`.

## Kustomization graph

`apps-data` is added with `dependsOn: apps-core` and `wait: true` (15 m
timeout). `apps-vso-secrets` depends on both `apps-core` and `apps-data`
so the `VaultStaticSecret` CRs are only applied after Vault is running and
the VSO auth method is wired up.

## .gitignore fix

The bare `data` and `*.md` patterns were swallowing the `platform/` tree.
Added `!platform/` + `!platform/**` negations at the end of `.gitignore`.

## Operator runbook

`platform/docs/vault-bootstrap.md` covers: init/unseal, bootstrap token
creation, static secret seeding order, VSO sync verification, and root
token rotation after first boot.

## Test plan

- [x] `kubectl kustomize platform/cluster/flux/apps/data > /dev/null`
- [x] `kubectl kustomize platform/cluster/flux/apps/vso-secrets > /dev/null`
- [x] `kubectl kustomize platform/cluster/flux/clusters/production > /dev/null`