### PR TITLE
platform: add stateless apps, Stalwart mail, and IngressRoutes

### DIFF
--- a/platform/cluster/flux/apps/edge/ingressroutes/api.yaml
+++ b/platform/cluster/flux/apps/edge/ingressroutes/api.yaml
@@ -1,0 +1,20 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: api
+  namespace: edge-system
+  annotations:
+    external-dns.alpha.kubernetes.io/target: v2.esa-blueshell.nl
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: 'true'
+    kubernetes.io/ingress.class: traefik-public
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`api.v2.esa-blueshell.nl`)
+      services:
+        - name: api
+          namespace: default
+          port: 8080
+  tls: {}

--- a/platform/cluster/flux/apps/edge/ingressroutes/frontend.yaml
+++ b/platform/cluster/flux/apps/edge/ingressroutes/frontend.yaml
@@ -1,0 +1,20 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: frontend
+  namespace: edge-system
+  annotations:
+    external-dns.alpha.kubernetes.io/target: v2.esa-blueshell.nl
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: 'true'
+    kubernetes.io/ingress.class: traefik-public
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`v2.esa-blueshell.nl`) || Host(`www.v2.esa-blueshell.nl`)
+      services:
+        - name: frontend
+          namespace: default
+          port: 3000
+  tls: {}

--- a/platform/cluster/flux/apps/edge/ingressroutes/headlamp.yaml
+++ b/platform/cluster/flux/apps/edge/ingressroutes/headlamp.yaml
@@ -1,0 +1,23 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: headlamp
+  namespace: edge-system
+  annotations:
+    external-dns.alpha.kubernetes.io/target: v2.esa-blueshell.nl
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: 'true'
+    kubernetes.io/ingress.class: traefik-public
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`kube.v2.esa-blueshell.nl`)
+      middlewares:
+        - name: forward-auth
+          namespace: edge-system
+      services:
+        - name: headlamp
+          namespace: utility-system
+          port: 80
+  tls: {}

--- a/platform/cluster/flux/apps/edge/ingressroutes/kustomization.yaml
+++ b/platform/cluster/flux/apps/edge/ingressroutes/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - api.yaml
+  - frontend.yaml
+  - listmonk.yaml
+  - headlamp.yaml
+  - stalwart-admin.yaml

--- a/platform/cluster/flux/apps/edge/ingressroutes/listmonk.yaml
+++ b/platform/cluster/flux/apps/edge/ingressroutes/listmonk.yaml
@@ -1,0 +1,23 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: listmonk
+  namespace: edge-system
+  annotations:
+    external-dns.alpha.kubernetes.io/target: v2.esa-blueshell.nl
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: 'true'
+    kubernetes.io/ingress.class: traefik-public
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`mail-admin.v2.esa-blueshell.nl`)
+      middlewares:
+        - name: forward-auth
+          namespace: edge-system
+      services:
+        - name: listmonk
+          namespace: default
+          port: 9000
+  tls: {}

--- a/platform/cluster/flux/apps/edge/ingressroutes/stalwart-admin.yaml
+++ b/platform/cluster/flux/apps/edge/ingressroutes/stalwart-admin.yaml
@@ -1,0 +1,23 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: stalwart-admin
+  namespace: edge-system
+  annotations:
+    external-dns.alpha.kubernetes.io/target: v2.esa-blueshell.nl
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: 'true'
+    kubernetes.io/ingress.class: traefik-public
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`mail-admin.v2.esa-blueshell.nl`) && PathPrefix(`/webadmin`)
+      middlewares:
+        - name: forward-auth
+          namespace: edge-system
+      services:
+        - name: stalwart
+          namespace: mail-system
+          port: 8080
+  tls: {}

--- a/platform/cluster/flux/apps/edge/kustomization.yaml
+++ b/platform/cluster/flux/apps/edge/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - cluster-issuer-cloudflare.yaml
   - traefik-default-tls.yaml
   - traefik-forward-auth-middleware.yaml
+  - ingressroutes

--- a/platform/cluster/flux/apps/mail/kustomization.yaml
+++ b/platform/cluster/flux/apps/mail/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - stalwart

--- a/platform/cluster/flux/apps/mail/namespace.yaml
+++ b/platform/cluster/flux/apps/mail/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mail-system

--- a/platform/cluster/flux/apps/mail/stalwart/config-template-configmap.yaml
+++ b/platform/cluster/flux/apps/mail/stalwart/config-template-configmap.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stalwart-config-template
+  namespace: mail-system
+data:
+  config.toml: |
+    server.hostname = "%{env:STALWART_HOSTNAME}%"
+
+    server.listener.smtp.bind = "[::]:25"
+    server.listener.smtp.protocol = "smtp"
+
+    server.listener.submission.bind = "[::]:587"
+    server.listener.submission.protocol = "smtp"
+    server.listener.submission.tls.starttls = true
+
+    server.listener.submissions.bind = "[::]:465"
+    server.listener.submissions.protocol = "smtp"
+    server.listener.submissions.tls.implicit = true
+
+    server.listener.imap.bind = "[::]:143"
+    server.listener.imap.protocol = "imap"
+
+    server.listener.imaptls.bind = "[::]:993"
+    server.listener.imaptls.protocol = "imap"
+    server.listener.imaptls.tls.implicit = true
+
+    server.listener.pop3.bind = "[::]:110"
+    server.listener.pop3.protocol = "pop3"
+
+    server.listener.pop3s.bind = "[::]:995"
+    server.listener.pop3s.protocol = "pop3"
+    server.listener.pop3s.tls.implicit = true
+
+    server.listener.sieve.bind = "[::]:4190"
+    server.listener.sieve.protocol = "managesieve"
+
+    server.listener.http.bind = "[::]:8080"
+    server.listener.http.protocol = "http"
+
+    acme."letsencrypt".directory = "https://acme-v02.api.letsencrypt.org/directory"
+    acme."letsencrypt".challenge = "dns-01"
+    acme."letsencrypt".contact = ["postmaster@%{env:STALWART_DOMAIN}%"]
+    acme."letsencrypt".domains = ["%{env:STALWART_HOSTNAME}%"]
+    acme."letsencrypt".cache = "/opt/stalwart/etc/acme"
+    acme."letsencrypt".renew-before = "30d"
+    acme."letsencrypt".default = true
+    acme."letsencrypt".dns.provider = "cloudflare"
+    acme."letsencrypt".dns.secret = "%{env:CF_DNS_API_TOKEN}%"
+
+    storage.data = "rocksdb"
+    storage.fts = "rocksdb"
+    storage.blob = "rocksdb"
+    storage.lookup = "rocksdb"
+    storage.directory = "internal"
+
+    store.rocksdb.type = "rocksdb"
+    store.rocksdb.path = "/opt/stalwart/data"
+    store.rocksdb.compression = "lz4"
+
+    directory.internal.type = "internal"
+    directory.internal.store = "rocksdb"
+
+    authentication.fallback-admin.user = "%{env:STALWART_ADMIN_USER}%"
+    authentication.fallback-admin.secret = "%{env:STALWART_ADMIN_SECRET}%"
+
+    metrics.prometheus.enable = true
+
+    tracer.log.type = "log"
+    tracer.log.level = "info"
+    tracer.log.path = "/opt/stalwart/logs"
+    tracer.log.prefix = "stalwart.log"
+    tracer.log.rotate = "daily"
+    tracer.log.ansi = false
+    tracer.log.enable = true

--- a/platform/cluster/flux/apps/mail/stalwart/deployment.yaml
+++ b/platform/cluster/flux/apps/mail/stalwart/deployment.yaml
@@ -1,0 +1,164 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stalwart
+  namespace: mail-system
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: stalwart-data
+  namespace: mail-system
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stalwart
+  namespace: mail-system
+spec:
+  replicas: 1
+  # Mail server state lives in the RocksDB PVC; two replicas would race
+  # on the same files. Recreate is correct for single-replica stateful pods.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: stalwart
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: stalwart
+      annotations:
+        vault.hashicorp.com/agent-inject: 'true'
+        vault.hashicorp.com/agent-inject-token: 'true'
+        # Pre-populate only: Stalwart reads env on startup; we don't need
+        # the agent refreshing creds while the server is running.
+        vault.hashicorp.com/agent-pre-populate-only: 'true'
+        vault.hashicorp.com/role: stalwart
+        vault.hashicorp.com/agent-inject-secret-stalwart.env: secret/data/platform/mail
+        vault.hashicorp.com/agent-inject-template-stalwart.env: |
+          {{- with secret "secret/data/platform/mail" -}}
+          STALWART_ADMIN_USER={{ index .Data.data "admin-user" }}
+          STALWART_ADMIN_SECRET={{ index .Data.data "admin-password" }}
+          {{- end }}
+          {{- with secret "secret/data/platform/edge" }}
+          CF_DNS_API_TOKEN={{ index .Data.data "cloudflare.dns_api_token" }}
+          {{- end }}
+          STALWART_HOSTNAME=mail.v2.esa-blueshell.nl
+          STALWART_DOMAIN=v2.esa-blueshell.nl
+    spec:
+      serviceAccountName: stalwart
+      containers:
+        - name: stalwart
+          image: stalwartlabs/stalwart:v0.15.5
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              set -a
+              . /vault/secrets/stalwart.env
+              set +a
+              mkdir -p /opt/stalwart/etc
+              cp /config/config.toml /opt/stalwart/etc/config.toml
+              exec /usr/local/bin/entrypoint.sh /usr/local/bin/stalwart
+          # Mail protocols are raw TCP and cannot traverse Cloudflare's HTTP
+          # proxy. mail.v2.esa-blueshell.nl is a non-proxied A record pointing
+          # directly at the VPS IP. Each mail port binds on the host via
+          # hostPort so the pod answers directly without MetalLB.
+          ports:
+            - containerPort: 25
+              hostPort: 25
+              name: smtp
+            - containerPort: 110
+              hostPort: 110
+              name: pop3
+            - containerPort: 143
+              hostPort: 143
+              name: imap
+            - containerPort: 465
+              hostPort: 465
+              name: submissions
+            - containerPort: 587
+              hostPort: 587
+              name: submission
+            - containerPort: 993
+              hostPort: 993
+              name: imaptls
+            - containerPort: 995
+              hostPort: 995
+              name: pop3s
+            - containerPort: 4190
+              hostPort: 4190
+              name: sieve
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            tcpSocket:
+              port: http
+          livenessProbe:
+            tcpSocket:
+              port: http
+          volumeMounts:
+            - name: stalwart-data
+              mountPath: /opt/stalwart
+            - name: stalwart-config-template
+              mountPath: /config/config.toml
+              subPath: config.toml
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+      volumes:
+        - name: stalwart-data
+          persistentVolumeClaim:
+            claimName: stalwart-data
+        - name: stalwart-config-template
+          configMap:
+            name: stalwart-config-template
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: stalwart
+  namespace: mail-system
+spec:
+  selector:
+    app.kubernetes.io/name: stalwart
+  ports:
+    - name: smtp
+      port: 25
+      targetPort: smtp
+    - name: pop3
+      port: 110
+      targetPort: pop3
+    - name: imap
+      port: 143
+      targetPort: imap
+    - name: submissions
+      port: 465
+      targetPort: submissions
+    - name: submission
+      port: 587
+      targetPort: submission
+    - name: imaptls
+      port: 993
+      targetPort: imaptls
+    - name: pop3s
+      port: 995
+      targetPort: pop3s
+    - name: sieve
+      port: 4190
+      targetPort: sieve
+    - name: http
+      port: 8080
+      targetPort: http

--- a/platform/cluster/flux/apps/mail/stalwart/kustomization.yaml
+++ b/platform/cluster/flux/apps/mail/stalwart/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - config-template-configmap.yaml
+  - deployment.yaml

--- a/platform/cluster/flux/apps/stateless/api/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/api/deployment.yaml
@@ -1,0 +1,187 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: api
+  namespace: default
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: default
+  annotations:
+    # Keel polls GHCR every 2 min for the :latest digest and rolls when it
+    # changes. match-tag scopes Keel to the tag already on the Deployment
+    # rather than scanning every tag in the repo and picking the "highest" —
+    # without it Keel would pin to an old :<sha> tag that sorts above latest.
+    keel.sh/policy: force
+    keel.sh/match-tag: 'true'
+    keel.sh/trigger: poll
+    keel.sh/pollSchedule: '@every 2m'
+spec:
+  replicas: 1
+  # maxSurge=0 avoids a second pod pending when the node is near capacity.
+  # The ~30 s gap is hidden behind Traefik's retry; the Spring Boot warm-up
+  # is fast enough that liveness/readiness gates catch any real failure.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: api
+      annotations:
+        vault.hashicorp.com/agent-inject: 'true'
+        vault.hashicorp.com/agent-inject-token: 'true'
+        vault.hashicorp.com/agent-pre-populate-only: 'true'
+        vault.hashicorp.com/role: api
+        vault.hashicorp.com/agent-inject-secret-api.env: secret/data/api
+        vault.hashicorp.com/agent-inject-template-api.env: |
+          {{- with secret "secret/data/api" -}}
+          JWT_SECRET={{ index .Data.data "jwt-secret" }}
+          BREVO_API_KEY={{ index .Data.data "brevo-api-key" }}
+          BREVO_FOLDER_CONTRIBUTION_PERIODS_ID={{ index .Data.data "brevo-folder-contribution-periods-id" }}
+          MOLLIE_API_KEY={{ index .Data.data "mollie-api-key" }}
+          GOOGLE_CALENDAR_ID={{ index .Data.data "google-calendar-id" }}
+          GOOGLE_CALENDAR_CLIENT_ID={{ index .Data.data "google-calendar-client-id" }}
+          GOOGLE_CALENDAR_CLIENT_EMAIL={{ index .Data.data "google-calendar-client-email" }}
+          GOOGLE_CALENDAR_PRIVATE_KEY_PKCS8={{ index .Data.data "google-calendar-private-key-pkcs8" }}
+          GOOGLE_CALENDAR_PRIVATE_KEY_ID={{ index .Data.data "google-calendar-private-key-id" }}
+          FACEBOOK_PAGE_ID={{ index .Data.data "facebook-page-id" }}
+          FACEBOOK_ACCESS_TOKEN={{ index .Data.data "facebook-access-token" }}
+          X_API_KEY={{ index .Data.data "x-api-key" }}
+          X_API_SECRET={{ index .Data.data "x-api-secret" }}
+          X_ACCESS_TOKEN={{ index .Data.data "x-access-token" }}
+          X_ACCESS_SECRET={{ index .Data.data "x-access-secret" }}
+          DISCORD_BOT_TOKEN={{ index .Data.data "discord-bot-token" }}
+          DISCORD_GUILD_ID={{ index .Data.data "discord-guild-id" }}
+          {{- end }}
+        vault.hashicorp.com/agent-inject-secret-db.env: database/creds/api
+        vault.hashicorp.com/agent-inject-template-db.env: |
+          {{- with secret "database/creds/api" -}}
+          MYSQL_USER={{ .Data.username }}
+          MYSQL_PASSWORD={{ .Data.password }}
+          {{- end }}
+    spec:
+      serviceAccountName: api
+      containers:
+        - name: api
+          image: ghcr.io/esa-blueshell/api:latest
+          imagePullPolicy: Always
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              set -a
+              . /vault/secrets/api.env
+              . /vault/secrets/db.env
+              set +a
+              exec java \
+                -XX:+UseZGC \
+                -XX:+AlwaysPreTouch \
+                -XX:MaxRAMPercentage=75 \
+                -jar /app/app.jar
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: prod
+            - name: MYSQL_HOST
+              value: mariadb.data-system.svc.cluster.local
+            - name: MYSQL_PORT
+              value: '3306'
+            - name: APP_URL
+              value: https://api.v2.esa-blueshell.nl
+            - name: FRONTEND_URL
+              value: https://v2.esa-blueshell.nl
+            - name: STORAGE_LOCATION
+              value: /home/storage
+            - name: LISTMONK_API_BASE_URL
+              value: http://listmonk.default.svc.cluster.local:9000/api
+            - name: LISTMONK_FROM_ADDRESS
+              value: no-reply@v2.esa-blueshell.nl
+            - name: LISTMONK_REPLY_TO_ADDRESS
+              value: sitecie@esa-blueshell.nl
+            - name: LISTMONK_BOUNCE_MAILBOX_ENABLED
+              value: 'true'
+            - name: LISTMONK_BOUNCE_MAILBOX_HOST
+              value: stalwart.mail-system.svc.cluster.local
+            - name: LISTMONK_BOUNCE_MAILBOX_PORT
+              value: '993'
+            - name: LISTMONK_BOUNCE_MAILBOX_TLS
+              value: 'true'
+            - name: LISTMONK_BOUNCE_MAILBOX_FOLDER
+              value: INBOX
+            - name: LISTMONK_BOUNCE_MAILBOX_RETURN_PATH
+              value: bounce@v2.esa-blueshell.nl
+            # Listmonk admin credentials synced from Vault via VSO
+            - name: LISTMONK_API_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: listmonk-secrets
+                  key: admin-user
+            - name: LISTMONK_API_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: listmonk-secrets
+                  key: admin-password
+            - name: LISTMONK_BOUNCE_MAILBOX_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: stalwart-secrets
+                  key: bounce-mailbox-user
+                  optional: true
+            - name: LISTMONK_BOUNCE_MAILBOX_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: stalwart-secrets
+                  key: bounce-mailbox-password
+                  optional: true
+          ports:
+            - containerPort: 8080
+              name: http
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 1500m
+              memory: 2Gi
+          volumeMounts:
+            - name: storage
+              mountPath: /home/storage
+      volumes:
+        - name: storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: default
+spec:
+  selector:
+    app.kubernetes.io/name: api
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/platform/cluster/flux/apps/stateless/api/kustomization.yaml
+++ b/platform/cluster/flux/apps/stateless/api/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml

--- a/platform/cluster/flux/apps/stateless/frontend/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/frontend/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: default
+  annotations:
+    keel.sh/policy: force
+    keel.sh/match-tag: 'true'
+    keel.sh/trigger: poll
+    keel.sh/pollSchedule: '@every 2m'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: frontend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/esa-blueshell/frontend:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: default
+spec:
+  selector:
+    app.kubernetes.io/name: frontend
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http

--- a/platform/cluster/flux/apps/stateless/frontend/kustomization.yaml
+++ b/platform/cluster/flux/apps/stateless/frontend/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml

--- a/platform/cluster/flux/apps/stateless/kustomization.yaml
+++ b/platform/cluster/flux/apps/stateless/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - api
+  - frontend
+  - listmonk

--- a/platform/cluster/flux/apps/stateless/listmonk/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/listmonk/deployment.yaml
@@ -1,0 +1,104 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: listmonk-uploads
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: listmonk
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: listmonk
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: listmonk
+    spec:
+      containers:
+        - name: listmonk
+          image: listmonk/listmonk:v4.1.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - |
+              ./listmonk --install --idempotent --yes &&
+              ./listmonk --upgrade --yes &&
+              exec ./listmonk
+          env:
+            - name: LISTMONK_app__address
+              value: '0.0.0.0:9000'
+            - name: LISTMONK_db__host
+              value: listmonk-db.data-system.svc.cluster.local
+            - name: LISTMONK_db__port
+              value: '5432'
+            - name: LISTMONK_db__user
+              value: listmonk
+            - name: LISTMONK_db__database
+              value: listmonk
+            - name: LISTMONK_db__ssl_mode
+              value: disable
+            - name: LISTMONK_db__password
+              valueFrom:
+                secretKeyRef:
+                  name: listmonk-secrets
+                  key: db-password
+            - name: LISTMONK_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: listmonk-secrets
+                  key: admin-user
+            - name: LISTMONK_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: listmonk-secrets
+                  key: admin-password
+          ports:
+            - containerPort: 9000
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: uploads
+              mountPath: /listmonk/uploads
+      volumes:
+        - name: uploads
+          persistentVolumeClaim:
+            claimName: listmonk-uploads
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: listmonk
+  namespace: default
+spec:
+  selector:
+    app.kubernetes.io/name: listmonk
+  ports:
+    - name: http
+      port: 9000
+      targetPort: http

--- a/platform/cluster/flux/apps/stateless/listmonk/kustomization.yaml
+++ b/platform/cluster/flux/apps/stateless/listmonk/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - setup-job.yaml
+
+# Generate the setup ConfigMap from the Python script. Content-hash drift
+# (any edit to setup.py) flips the Job's spec and triggers force-replace,
+# re-running the idempotent setup against the live Listmonk instance.
+configMapGenerator:
+  - name: listmonk-setup-script
+    namespace: default
+    files:
+      - setup.py

--- a/platform/cluster/flux/apps/stateless/listmonk/setup-job.yaml
+++ b/platform/cluster/flux/apps/stateless/listmonk/setup-job.yaml
@@ -1,0 +1,89 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: listmonk-setup
+  namespace: default
+  # force-replace so any edit to setup.py (content-hash change on the
+  # ConfigMap) triggers a re-run of the idempotent setup script.
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: listmonk-setup
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: setup
+          image: python:3.12-alpine
+          command:
+            - python
+            - /scripts/setup.py
+          env:
+            - name: LISTMONK_URL
+              value: http://listmonk.default.svc.cluster.local:9000
+            - name: LISTMONK_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: listmonk-secrets
+                  key: admin-user
+            - name: LISTMONK_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: listmonk-secrets
+                  key: admin-password
+            - name: LISTMONK_SMTP_HOST
+              value: stalwart.mail-system.svc.cluster.local
+            - name: LISTMONK_SMTP_PORT
+              value: '587'
+            - name: LISTMONK_SMTP_AUTH_PROTOCOL
+              value: login
+            - name: LISTMONK_SMTP_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: stalwart-secrets
+                  key: bounce-mailbox-user
+                  optional: true
+            - name: LISTMONK_SMTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: stalwart-secrets
+                  key: bounce-mailbox-password
+                  optional: true
+            - name: LISTMONK_SMTP_HELLO_HOSTNAME
+              value: mail.v2.esa-blueshell.nl
+            - name: LISTMONK_SMTP_TLS_TYPE
+              value: STARTTLS
+            - name: LISTMONK_BOUNCE_MAILBOX_ENABLED
+              value: 'true'
+            - name: LISTMONK_BOUNCE_MAILBOX_HOST
+              value: stalwart.mail-system.svc.cluster.local
+            - name: LISTMONK_BOUNCE_MAILBOX_PORT
+              value: '993'
+            - name: LISTMONK_BOUNCE_MAILBOX_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: stalwart-secrets
+                  key: bounce-mailbox-user
+                  optional: true
+            - name: LISTMONK_BOUNCE_MAILBOX_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: stalwart-secrets
+                  key: bounce-mailbox-password
+                  optional: true
+            - name: LISTMONK_BOUNCE_MAILBOX_TLS_ENABLED
+              value: 'true'
+            - name: LISTMONK_BOUNCE_MAILBOX_FOLDER
+              value: INBOX
+            - name: LISTMONK_BOUNCE_MAILBOX_RETURN_PATH
+              value: bounce@v2.esa-blueshell.nl
+          volumeMounts:
+            - name: setup-script
+              mountPath: /scripts
+      volumes:
+        - name: setup-script
+          configMap:
+            name: listmonk-setup-script

--- a/platform/cluster/flux/apps/stateless/listmonk/setup.py
+++ b/platform/cluster/flux/apps/stateless/listmonk/setup.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""
+Idempotent Listmonk first-time setup.
+
+Performs in order:
+  1. Admin account setup via the first-time setup wizard (if not yet configured)
+  2. API user — creates a type=api user and writes its token to the secrets volume
+  3. SMTP    — configures an outbound SMTP server (skipped if LISTMONK_SMTP_HOST unset)
+  4. Theme   — injects custom CSS from $THEME_CSS_PATH into app.custom_css
+  5. Bounce  — enables bounce processing and optionally configures an IMAP mailbox
+
+All steps are idempotent and safe to re-run.
+
+Authentication note
+-------------------
+Listmonk v4.1.0 distinguishes two user types:
+  - type=user  : web-UI admin (session-cookie auth only, basic auth NOT supported)
+  - type=api   : API-only user (basic auth with auto-generated password)
+
+This script uses session-cookie auth for all Listmonk API calls.
+It creates a type=api user whose auto-generated password is written to
+LISTMONK_API_TOKEN_FILE for the Spring Boot API service to consume.
+
+Required environment variables
+-------------------------------
+LISTMONK_URL               Base URL (default: http://listmonk:9000)
+LISTMONK_ADMIN_USERNAME    Admin username (must match LISTMONK_ADMIN_USER in the listmonk container)
+LISTMONK_ADMIN_PASSWORD    Admin password (must match LISTMONK_ADMIN_PASSWORD in the listmonk container)
+LISTMONK_ADMIN_EMAIL       Admin e-mail for first-time setup wizard (default: admin@listmonk.local)
+LISTMONK_ADMIN_API_USER    API username to create (default: api)
+LISTMONK_API_TOKEN_FILE    Where to write the API token (default: /secrets/api-token.env)
+
+Optional (SMTP outbound)
+LISTMONK_SMTP_HOST              SMTP host — step skipped if empty
+LISTMONK_SMTP_PORT              default: 25
+LISTMONK_SMTP_AUTH_PROTOCOL     none | plain | login | cram-md5 (default: none)
+LISTMONK_SMTP_USERNAME          default: empty
+LISTMONK_SMTP_PASSWORD          default: empty
+LISTMONK_SMTP_HELLO_HOSTNAME    EHLO hostname (default: empty — Listmonk uses its own)
+LISTMONK_SMTP_TLS_TYPE          none | starttls | tls (default: none)
+LISTMONK_SMTP_TLS_SKIP_VERIFY   default: false
+
+Optional (bounce mailbox)
+LISTMONK_BOUNCE_MAILBOX_ENABLED         true to configure IMAP (default: false)
+LISTMONK_BOUNCE_MAILBOX_HOST            IMAP host
+LISTMONK_BOUNCE_MAILBOX_PORT            IMAP port (default: 993)
+LISTMONK_BOUNCE_MAILBOX_USERNAME        IMAP username
+LISTMONK_BOUNCE_MAILBOX_PASSWORD        IMAP password
+LISTMONK_BOUNCE_MAILBOX_TLS_ENABLED     default: true
+LISTMONK_BOUNCE_MAILBOX_TLS_SKIP_VERIFY default: false
+LISTMONK_BOUNCE_MAILBOX_FOLDER          default: INBOX
+LISTMONK_BOUNCE_MAILBOX_RETURN_PATH     default: empty
+LISTMONK_BOUNCE_MAILBOX_SCAN_INTERVAL   default: 10m
+"""
+import http.cookiejar
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+LISTMONK_URL = os.environ.get("LISTMONK_URL", "http://listmonk:9000").rstrip("/")
+ADMIN_USER = os.environ.get("LISTMONK_ADMIN_USERNAME", "listmonk")
+ADMIN_PASS = os.environ.get("LISTMONK_ADMIN_PASSWORD", "listmonk")
+ADMIN_EMAIL = os.environ.get("LISTMONK_ADMIN_EMAIL", "admin@listmonk.local")
+API_USER = os.environ.get("LISTMONK_ADMIN_API_USER", "api")
+API_TOKEN_FILE = os.environ.get("LISTMONK_API_TOKEN_FILE", "/secrets/api-token.env")
+THEME_CSS_PATH = os.environ.get("THEME_CSS_PATH", "/theme.css")
+SMTP_HOST = os.environ.get("LISTMONK_SMTP_HOST", "")
+
+# ---------------------------------------------------------------------------
+# Session-based auth (type=user admin can only auth via session cookie)
+# ---------------------------------------------------------------------------
+_cookie_jar = http.cookiejar.CookieJar()
+_opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(_cookie_jar))
+_logged_in = False
+
+
+def _ensure_login() -> None:
+    global _logged_in
+    if _logged_in:
+        return
+    data = urllib.parse.urlencode({"username": ADMIN_USER, "password": ADMIN_PASS}).encode()
+    req = urllib.request.Request(
+        f"{LISTMONK_URL}/admin/login",
+        data=data,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with _opener.open(req):
+            pass
+    except urllib.error.HTTPError as exc:
+        if exc.code not in (200, 302):
+            raise RuntimeError(f"Admin login failed: HTTP {exc.code}")
+    _logged_in = True
+
+
+def _request(method: str, path: str, body=None) -> dict:
+    _ensure_login()
+    url = f"{LISTMONK_URL}{path}"
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"}, method=method)
+    with _opener.open(req) as resp:
+        content = resp.read()
+        return json.loads(content) if content else {}
+
+
+def api_get(path: str) -> dict:
+    return _request("GET", path)
+
+
+def api_post(path: str, body: dict) -> dict:
+    return _request("POST", path, body=body)
+
+
+def api_put(path: str, body: dict) -> dict:
+    return _request("PUT", path, body=body)
+
+
+def api_delete(path: str) -> None:
+    _request("DELETE", path)
+
+
+def _bool_env(name: str, default: bool) -> bool:
+    val = os.environ.get(name, "").lower()
+    if val in ("true", "1", "yes"):
+        return True
+    if val in ("false", "0", "no"):
+        return False
+    return default
+
+
+# ---------------------------------------------------------------------------
+# Step 1: Admin setup (first-time wizard)
+# ---------------------------------------------------------------------------
+
+def setup_admin() -> None:
+    global _logged_in
+    print("Checking Listmonk first-time setup status…")
+    try:
+        with urllib.request.urlopen(f"{LISTMONK_URL}/admin/login") as resp:
+            body = resp.read().decode(errors="replace")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+
+    if 'name="password2"' not in body:
+        print("Admin already configured — skipping first-time setup.")
+        return
+
+    print(f"Performing first-time admin setup (username: {ADMIN_USER})…")
+    data = urllib.parse.urlencode({
+        "email": ADMIN_EMAIL,
+        "username": ADMIN_USER,
+        "password": ADMIN_PASS,
+        "password2": ADMIN_PASS,
+    }).encode()
+    req = urllib.request.Request(
+        f"{LISTMONK_URL}/admin/login",
+        data=data,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with _opener.open(req) as resp:
+            status = resp.status
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+
+    if status in (200, 302):
+        print("Admin setup complete.")
+        _logged_in = True  # session cookie captured by _opener
+    else:
+        print(f"Admin setup failed: HTTP {status}", file=sys.stderr)
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Step 2: API user
+# ---------------------------------------------------------------------------
+
+def _read_token_file() -> str | None:
+    """Return the API token string from the token file, or None."""
+    try:
+        with open(API_TOKEN_FILE) as f:
+            for line in f:
+                if line.startswith("LISTMONK_ADMIN_API_TOKEN="):
+                    token = line.removeprefix("LISTMONK_ADMIN_API_TOKEN=").strip().strip('"')
+                    if token:
+                        return token
+    except FileNotFoundError:
+        pass
+    return None
+
+
+def ensure_api_user() -> None:
+    """
+    Create a type=api user for the Spring Boot API service.
+
+    On first run (fresh install): creates the user, writes token to API_TOKEN_FILE.
+    On subsequent runs: skips if token file is valid AND the user still exists.
+    If the user is gone but token file exists (e.g. DB was reset), recreates the user.
+    """
+    existing_token = _read_token_file()
+
+    try:
+        users = api_get("/api/users").get("data", [])
+    except urllib.error.HTTPError as exc:
+        print(f"WARNING: Could not list users: HTTP {exc.code} — skipping API user step.", file=sys.stderr)
+        return
+
+    api_user = next((u for u in users if u["username"] == API_USER and u["type"] == "api"), None)
+
+    if api_user and existing_token:
+        print(f"API user '{API_USER}' exists and token file is valid — skipping.")
+        return
+
+    if api_user and not existing_token:
+        print(f"API user '{API_USER}' exists but token file is missing — recreating user.")
+        try:
+            api_delete(f"/api/users/{api_user['id']}")
+        except urllib.error.HTTPError as exc:
+            print(f"WARNING: Could not delete stale API user: HTTP {exc.code}", file=sys.stderr)
+
+    print(f"Creating API user '{API_USER}'…")
+    try:
+        # Listmonk auto-generates the password for type=api users and returns it
+        # in the creation response — this is the only time the plaintext is available.
+        result = api_post("/api/users", {
+            "username": API_USER,
+            "type": "api",
+            "status": "enabled",
+            "name": "API User",
+            "user_role_id": 1,  # Super Admin role — always id=1 after --install
+        })
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        print(f"WARNING: Failed to create API user: HTTP {exc.code} — {body}", file=sys.stderr)
+        return
+
+    token = result.get("data", {}).get("password")
+    if not token:
+        print("WARNING: Listmonk did not return a password for the new API user.", file=sys.stderr)
+        return
+
+    try:
+        with open(API_TOKEN_FILE, "w") as f:
+            f.write(f"LISTMONK_ADMIN_API_TOKEN={token}\n")
+        print(f"API token written to {API_TOKEN_FILE}.")
+    except OSError as exc:
+        print(f"WARNING: Could not write token file '{API_TOKEN_FILE}': {exc}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Step 3: SMTP configuration
+# ---------------------------------------------------------------------------
+
+def configure_smtp() -> None:
+    if not SMTP_HOST:
+        print("LISTMONK_SMTP_HOST not set — skipping SMTP configuration.")
+        return
+
+    print(f"Configuring Listmonk SMTP ({SMTP_HOST})…")
+    try:
+        response = api_get("/api/settings")
+    except urllib.error.HTTPError as exc:
+        print(f"WARNING: Failed to fetch settings for SMTP config: HTTP {exc.code} — {exc.reason}", file=sys.stderr)
+        return
+
+    settings = response.get("data", response)
+    smtp_list = settings.get("smtp") or []
+
+    if any(s.get("enabled") for s in smtp_list):
+        print("SMTP already configured — skipping.")
+        return
+
+    smtp_entry = {
+        "enabled": True,
+        "host": SMTP_HOST,
+        "port": int(os.environ.get("LISTMONK_SMTP_PORT", "25")),
+        "auth_protocol": os.environ.get("LISTMONK_SMTP_AUTH_PROTOCOL", "none"),
+        "username": os.environ.get("LISTMONK_SMTP_USERNAME", ""),
+        "password": os.environ.get("LISTMONK_SMTP_PASSWORD", ""),
+        "hello_hostname": os.environ.get("LISTMONK_SMTP_HELLO_HOSTNAME", ""),
+        "tls_type": os.environ.get("LISTMONK_SMTP_TLS_TYPE", "none"),
+        "tls_skip_verify": _bool_env("LISTMONK_SMTP_TLS_SKIP_VERIFY", False),
+        "max_conns": int(os.environ.get("LISTMONK_SMTP_MAX_CONNS", "10")),
+        "idle_timeout": os.environ.get("LISTMONK_SMTP_IDLE_TIMEOUT", "15s"),
+        "wait_timeout": os.environ.get("LISTMONK_SMTP_WAIT_TIMEOUT", "5s"),
+        "retries": int(os.environ.get("LISTMONK_SMTP_RETRIES", "2")),
+    }
+
+    settings["smtp"] = [smtp_entry]
+
+    try:
+        api_put("/api/settings", settings)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        print(f"WARNING: Failed to configure SMTP: HTTP {exc.code} — {body}", file=sys.stderr)
+        return
+
+    print(f"SMTP configured: {SMTP_HOST}:{smtp_entry['port']}")
+
+
+# ---------------------------------------------------------------------------
+# Step 4: Theme
+# ---------------------------------------------------------------------------
+
+def apply_theme() -> None:
+    if not os.path.exists(THEME_CSS_PATH):
+        print(f"No theme CSS found at {THEME_CSS_PATH} — skipping theme.")
+        return
+
+    with open(THEME_CSS_PATH) as f:
+        css = f.read()
+
+    print("Fetching Listmonk settings to apply theme…")
+    try:
+        response = api_get("/api/settings")
+    except urllib.error.HTTPError as exc:
+        print(f"WARNING: Failed to fetch settings for theme: HTTP {exc.code} — {exc.reason}", file=sys.stderr)
+        return
+
+    settings = response.get("data", response)
+    # Listmonk v4.1.0 returns flat dotted keys (e.g. "appearance.admin.custom_css")
+    settings["appearance.admin.custom_css"] = css
+    settings["appearance.public.custom_css"] = css
+
+    try:
+        api_put("/api/settings", settings)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        print(f"WARNING: Failed to apply theme: HTTP {exc.code} — {body}", file=sys.stderr)
+        return
+
+    print("Theme applied.")
+
+
+# ---------------------------------------------------------------------------
+# Step 5: Bounce configuration
+# ---------------------------------------------------------------------------
+
+def configure_bounce() -> None:
+    print("Configuring Listmonk bounce settings…")
+    try:
+        response = api_get("/api/settings")
+    except urllib.error.HTTPError as exc:
+        print(f"WARNING: Failed to fetch settings for bounce config: HTTP {exc.code} — {exc.reason}", file=sys.stderr)
+        return
+
+    settings = response.get("data", response)
+    changed = False
+
+    if settings.get("bounce.enabled") is not True:
+        settings["bounce.enabled"] = True
+        changed = True
+        print("Enabling bounce processing.")
+
+    if _bool_env("LISTMONK_BOUNCE_MAILBOX_ENABLED", False):
+        host = os.environ.get("LISTMONK_BOUNCE_MAILBOX_HOST", "")
+        username = os.environ.get("LISTMONK_BOUNCE_MAILBOX_USERNAME", "")
+        if not host or not username:
+            print("LISTMONK_BOUNCE_MAILBOX_ENABLED=true but HOST/USERNAME not set — skipping.", file=sys.stderr)
+        elif settings.get("bounce.mailboxes"):
+            print("Bounce mailbox already configured — not overwriting.")
+        else:
+            settings["bounce.mailboxes"] = [{
+                "enabled": True,
+                "type": "imap",
+                "host": host,
+                "port": int(os.environ.get("LISTMONK_BOUNCE_MAILBOX_PORT", "993")),
+                "auth_protocol": "userpass",
+                "username": username,
+                "password": os.environ.get("LISTMONK_BOUNCE_MAILBOX_PASSWORD", ""),
+                "tls_enabled": _bool_env("LISTMONK_BOUNCE_MAILBOX_TLS_ENABLED", True),
+                "tls_skip_verify": _bool_env("LISTMONK_BOUNCE_MAILBOX_TLS_SKIP_VERIFY", False),
+                "folder": os.environ.get("LISTMONK_BOUNCE_MAILBOX_FOLDER", "INBOX"),
+                "return_path": os.environ.get("LISTMONK_BOUNCE_MAILBOX_RETURN_PATH", ""),
+                "scan_interval": os.environ.get("LISTMONK_BOUNCE_MAILBOX_SCAN_INTERVAL", "10m"),
+            }]
+            changed = True
+            print(f"Configuring IMAP bounce mailbox: {host}")
+
+    if not changed:
+        print("Bounce settings already up to date.")
+        return
+
+    try:
+        api_put("/api/settings", settings)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        print(f"WARNING: Failed to update bounce settings: HTTP {exc.code} — {body}", file=sys.stderr)
+        return
+
+    print("Bounce settings updated.")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    setup_admin()
+    ensure_api_user()
+    configure_smtp()
+    apply_theme()
+    configure_bounce()
+    print("Listmonk setup complete.")

--- a/platform/cluster/flux/clusters/production/kustomizations.yaml
+++ b/platform/cluster/flux/clusters/production/kustomizations.yaml
@@ -83,3 +83,37 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps-mail
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./platform/cluster/flux/apps/mail
+  prune: true
+  dependsOn:
+    - name: apps-core
+    - name: apps-vso-secrets
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps-stateless
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./platform/cluster/flux/apps/stateless
+  prune: true
+  dependsOn:
+    - name: apps-core
+    - name: apps-data
+    - name: apps-vso-secrets
+    - name: apps-edge
+  sourceRef:
+    kind: GitRepository
+    name: flux-system

--- a/platform/docs/vault-bootstrap.md
+++ b/platform/docs/vault-bootstrap.md
@@ -96,8 +96,11 @@ vault kv put secret/listmonk \
 
 ```bash
 vault kv put secret/platform/mail \
+  admin-user=admin \
   admin-password=<stalwart-admin-password> \
-  dkim-private-key=<base64-encoded-rsa-2048-pem>
+  dkim-private-key=<base64-encoded-rsa-2048-pem> \
+  bounce-mailbox-user=bounce@v2.esa-blueshell.nl \
+  bounce-mailbox-password=<bounce-mailbox-password>
 ```
 
 ### API third-party secrets


### PR DESCRIPTION
Lands `apps-stateless` (api, frontend, listmonk) and `apps-mail` (Stalwart) together with `IngressRoute`s for every public-facing host. This is the last purely-infra PR before the OIDC/MyApps work in PR8 and the VPS cutover in PR9.

## apps/stateless/api

Deployment (1 replica, `maxSurge=0`) with:
- **Keel** image polling: `ghcr.io/esa-blueshell/api:latest`, `@every 2m`, `match-tag: "true"`
- **Vault agent** pre-populate-only injection — two env files:
  - `api.env`: static KV secrets from `secret/data/api` (JWT_SECRET, Brevo, Mollie, Google Calendar, Facebook, X, Discord)
  - `db.env`: dynamic MariaDB creds from `database/creds/api` (TTL-rotated; pod restarts pick up fresh creds)
- Listmonk admin credentials sourced from the VSO-synced `listmonk-secrets` k8s Secret
- Bounce mailbox credentials from `stalwart-secrets` (optional — api skips bounce if absent)

## apps/stateless/frontend

Deployment with Keel polling (`ghcr.io/esa-blueshell/frontend:latest`). nginx-unprivileged, port 3000, `/healthz` readiness.

## apps/stateless/listmonk

- `Deployment` (listmonk/listmonk:v4.1.0), 5 Gi uploads PVC, credentials from `listmonk-secrets`.
- `listmonk-setup` Job — idempotent, force-replaced on `setup.py` content-hash drift. Configures SMTP (Stalwart submission, port 587), bounce IMAP mailbox (Stalwart, port 993), API user creation, and custom theme injection. `setup.py` copied into the kustomization root (kustomize cannot load files above its root).

## apps/mail/stalwart

Stalwart v0.15.5 with:
- 20 Gi RocksDB PVC, `Recreate` strategy (single-replica stateful)
- Vault agent pre-populate renders `stalwart.env` from `secret/data/platform/mail` (admin-user, admin-password, bounce-mailbox-*) and `secret/data/platform/edge` (CF_DNS_API_TOKEN for ACME DNS-01)
- All mail ports (25/110/143/465/587/993/995/4190) bind via `hostPort` — raw TCP bypasses Cloudflare's proxy, the node answers directly on the non-proxied `mail.v2.esa-blueshell.nl` A record

## apps/edge/ingressroutes

| Route | Host | Forward-auth |
|-------|------|-------------|
| `api.yaml` | `api.v2.esa-blueshell.nl` | no (API handles its own auth) |
| `frontend.yaml` | `v2.esa-blueshell.nl`, `www.v2.*` | no |
| `listmonk.yaml` | `mail-admin.v2.esa-blueshell.nl` | yes |
| `headlamp.yaml` | `kube.v2.esa-blueshell.nl` | yes |
| `stalwart-admin.yaml` | `mail-admin.v2.esa-blueshell.nl/webadmin` | yes |

## Kustomization graph additions

- `apps-mail` — `dependsOn: apps-core, apps-vso-secrets`
- `apps-stateless` — `dependsOn: apps-core, apps-data, apps-vso-secrets, apps-edge`

## Test plan

- [x] `kubectl kustomize platform/cluster/flux/apps/mail > /dev/null`
- [x] `kubectl kustomize platform/cluster/flux/apps/stateless > /dev/null`
- [x] `kubectl kustomize platform/cluster/flux/apps/edge > /dev/null`
- [x] `kubectl kustomize platform/cluster/flux/clusters/production > /dev/null`