### PR TITLE
fix(platform): correct Contabo networking + retire admin key from runbook

### DIFF
--- a/platform/docs/bringup-v2.md
+++ b/platform/docs/bringup-v2.md
@@ -42,6 +42,13 @@ flux --version
 gh auth status
 ```
 
+Nix flakes + `nix-command` must be enabled. One-time setup if not
+already active (every `nix run` / `nix flake` step below assumes it):
+
+```bash
+mkdir -p ~/.config/nix && echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
+```
+
 Confirm the pre-install SSH path works and has passwordless sudo
 (required for `nixos-anywhere` to elevate during kexec):
 
@@ -79,8 +86,12 @@ nix --extra-experimental-features 'nix-command flakes' flake check ./platform --
 Kexecs the Debian box into a NixOS installer, runs disko, copies the
 closure, reboots into NixOS (8–15 min total over the uplink):
 
+Flake URL is single-quoted because zsh's `extendedglob` treats `#` as
+a wildcard; bash tolerates both forms, the quotes just make the
+command shell-portable:
+
 ```bash
-nix run github:nix-community/nixos-anywhere -- --flake ./platform#frankfurt-contabo-1 --target-host admin@157.173.115.164 --ssh-port 2222 --ssh-option IdentityFile=~/.ssh/bs-deploy --ssh-option IdentitiesOnly=yes
+nix run github:nix-community/nixos-anywhere -- --flake './platform#frankfurt-contabo-1' --target-host admin@157.173.115.164 --ssh-port 2222 --ssh-option IdentityFile=~/.ssh/bs-deploy --ssh-option IdentitiesOnly=yes
 ```
 
 After reboot, the `admin` account is gone; log in as `deploy`:
@@ -325,7 +336,7 @@ Once all five hold, open PR 10 (apex cutover).
   git commit -am 'platform(nix): bump inputs' && git push
   ```
   ```bash
-  nix run nixpkgs#deploy-rs -- ./platform#frankfurt-contabo-1
+  nix run 'nixpkgs#deploy-rs' -- './platform#frankfurt-contabo-1'
   ```
 
   The flake's `deploy.nodes.frankfurt-contabo-1.hostname` is pinned to

--- a/platform/docs/nix-flake.md
+++ b/platform/docs/nix-flake.md
@@ -36,7 +36,7 @@ runbook: `bringup-v2.md`.
 3. From a workstation with Nix installed:
    ```
    nix run github:nix-community/nixos-anywhere -- \
-     --flake ./platform#frankfurt-contabo-1 \
+     --flake './platform#frankfurt-contabo-1' \
      --target-host admin@157.173.115.164 \
      --ssh-port 2222 \
      --ssh-option IdentityFile=~/.ssh/bs-deploy \
@@ -48,7 +48,7 @@ runbook: `bringup-v2.md`.
 ## Ongoing updates
 
 ```
-nix run nixpkgs#deploy-rs -- ./platform#frankfurt-contabo-1
+nix run 'nixpkgs#deploy-rs' -- './platform#frankfurt-contabo-1'
 ```
 
 `deploy-rs` uses the SSH keys in `platform/nix/authorized-keys/deploy.pub`

--- a/platform/nix/hosts/frankfurt-contabo-1/default.nix
+++ b/platform/nix/hosts/frankfurt-contabo-1/default.nix
@@ -32,15 +32,23 @@
     hostName = "frankfurt-contabo-1";
     domain = "v2.esa-blueshell.nl";
     # Contabo does not run DHCP — the cidata ISO ships static config that
-    # Debian picks up on first boot. We bake the static values directly
-    # here; the public IP is permanent for the lifetime of this VPS.
+    # Debian picks up on first boot. We bake those exact values here; the
+    # public IP is permanent for the lifetime of this VPS.
+    #
+    # Values pulled from the rescue system's live `ip addr` / `ip route`
+    # and cidata network-config:
+    #   prefix  /20     (netmask 255.255.240.0, NOT /24)
+    #   gw4     157.173.112.1  (in-subnet on /20; NOT .115.1)
+    #   v6      2a02:c207:2316:2642::1/64
+    #   gw6     fe80::1  (link-local — Contabo does not answer ND for
+    #                     it, so the route MUST be `onlink`).
     useDHCP = lib.mkForce false;
     interfaces.ens18 = {
       useDHCP = false;
       ipv4.addresses = [
         {
           address = "157.173.115.164";
-          prefixLength = 24;
+          prefixLength = 20;
         }
       ];
       ipv6.addresses = [
@@ -49,15 +57,21 @@
           prefixLength = 64;
         }
       ];
+      # `networking.defaultGateway6` doesn't expose `onlink`. Without
+      # onlink, the kernel tries ND for fe80::1, which times out
+      # (Contabo's router doesn't advertise on that address) and the
+      # default v6 route becomes unusable. Drive the route directly.
+      ipv6.routes = [
+        {
+          address = "::";
+          prefixLength = 0;
+          via = "fe80::1";
+          options = { onlink = ""; };
+        }
+      ];
     };
     defaultGateway = {
-      address = "157.173.115.1";
-      interface = "ens18";
-    };
-    # Contabo's standard IPv6 default gateway is the link-local fe80::1
-    # (same as the sister personal-stack Frankfurt host).
-    defaultGateway6 = {
-      address = "fe80::1";
+      address = "157.173.112.1";
       interface = "ens18";
     };
   };


### PR DESCRIPTION
Follow-up to PR #130. The VPS got to NixOS just fine, but the first
install came up with no external connectivity — `sshd` was listening
on port 2222, routes were half-configured, and the box looked
unreachable from the outside. Diagnosed from the rescue system.

## Root cause — three misconfigurations in the baked networking

Confirmed from `ip -4 route` / `ip neigh` on the rescue system and
the cidata cloud-init `network-config`:

| Setting | What we baked | What Contabo actually uses |
|---|---|---|
| IPv4 prefix | `/24` | `/20` (netmask 255.255.240.0) |
| IPv4 gateway | `157.173.115.1` (`ip neigh`: INCOMPLETE) | `157.173.112.1` (REACHABLE) |
| IPv6 default route | `networking.defaultGateway6` — no onlink | Must be `onlink` because Contabo does not answer ND for `fe80::1` |

With the wrong gateway, inbound SYNs arrived but SYN-ACKs had no
route back out — hence the "server never reachable" symptom.

## Changes

- `platform/nix/hosts/frankfurt-contabo-1/default.nix`
  - `prefixLength = 20`
  - `defaultGateway.address = "157.173.112.1"`
  - Drop `networking.defaultGateway6` (no `onlink` option); declare
    the default v6 route via `networking.interfaces.ens18.ipv6.routes`
    with `options = { onlink = ""; }` so the route is actually usable
    despite failed ND
  - Extensive comment block tying each value back to the authoritative
    cidata `network-config`
- `platform/docs/bringup-v2.md`
  - Every command is now a single line (no backslash continuations)
    so copy/paste from the doc works in any shell
  - Strip the old `~/.ssh/blueshell-admin` key from the active path;
    `bs-deploy` is used end-to-end (transport and post-install)
  - New Step 11 retires the admin key after the install is confirmed
    working
  - Single-quote flake URLs (`'./platform#frankfurt-contabo-1'`) so
    zsh's extendedglob doesn't treat `#` as a wildcard
  - Document the one-time `nix.conf` enablement for the flakes +
    nix-command experimental features
- `platform/docs/nix-flake.md` — same one-liner + single-quote form

## Validation

- `nix --extra-experimental-features 'nix-command flakes' flake check ./platform --no-build` → all checks passed, no warnings
- Ground truth for IP/gateway/prefix: the Contabo rescue system's own
  `ip -4 addr` + `ip -4 route` + `ip neigh` + cidata `network-config`
  on `/dev/sr1`, collected via the diagnostic script

## Test plan

- [ ] Re-run nixos-anywhere with the fixed flake against the VPS
      (currently in Contabo rescue on port 22):
      `nix run github:nix-community/nixos-anywhere -- --flake './platform#frankfurt-contabo-1' --target-host root@157.173.115.164 --ssh-port 22 --ssh-option IdentityFile=~/.ssh/bs-deploy --ssh-option IdentitiesOnly=yes`
- [ ] Confirm `ssh -p 2222 deploy@157.173.115.164` completes the
      handshake
- [ ] Confirm `ip -4 route` shows `default via 157.173.112.1 dev ens18`
- [ ] Confirm DNS resolves (`curl https://1.1.1.1`)
- [ ] Bootstrap Flux per `platform/docs/bringup-v2.md`