### PR TITLE
fix(platform): break the apps-core bootstrap deadlock (VSO + external-dns)

### DIFF
--- a/platform/cluster/flux/apps/core/external-dns/release.yaml
+++ b/platform/cluster/flux/apps/core/external-dns/release.yaml
@@ -12,6 +12,20 @@ spec:
         kind: HelmRepository
         name: external-dns
         namespace: external-dns
+  # The Deployment references secret `cloudflare-api-token` which is
+  # materialised by VSO from Vault. During cluster bootstrap that
+  # Secret doesn't exist yet (Vault isn't installed until apps-data,
+  # and apps-data depends on apps-core). If the initial Helm install
+  # runs before an operator pre-seeds the Secret, the Deployment never
+  # becomes Ready and Flux's default single-retry stalls the
+  # HelmRelease permanently. Infinite retries let it self-heal once
+  # the Secret lands, no manual `flux reconcile --force` needed.
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
   values:
     provider:
       name: cloudflare

--- a/platform/cluster/flux/apps/core/vso/release.yaml
+++ b/platform/cluster/flux/apps/core/vso/release.yaml
@@ -12,6 +12,30 @@ spec:
         kind: HelmRepository
         name: hashicorp
         namespace: vso-system
+  # The chart ships a default VaultConnection CR pointing at
+  # vault.data-system.svc.cluster.local. VSO itself runs the controller
+  # that reports Ready on that CR, but it can only report Ready once
+  # Vault is reachable — which doesn't happen until apps-data installs
+  # Vault, which in turn depends on apps-core (this Kustomization) being
+  # Ready. Classic bootstrap deadlock.
+  #
+  # disableWait tells Flux not to block HelmRelease readiness on the
+  # health of the rendered resources (the VaultConnection). The VSO
+  # Deployment itself is what matters; it reconciles the VaultConnection
+  # asynchronously once Vault exists. Once that happens the connection
+  # goes Ready on its own — we just don't gate apps-core's Ready on it.
+  #
+  # remediation.retries -1 tells helm-controller to retry indefinitely
+  # instead of giving up after one attempt and parking the HelmRelease
+  # in Stalled=RetriesExceeded.
+  install:
+    disableWait: true
+    remediation:
+      retries: -1
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: -1
   values:
     # Vault itself lives in the data-system namespace and is deployed in
     # the VSO / Vault PR that follows. The default connection is set


### PR DESCRIPTION
After #132 unblocked the Headlamp URL 404, bringing up a fresh cluster
still hits a permanent stall on two more HelmReleases in apps-core:

```
external-dns   1.20.0  False  Helm install failed ... timeout waiting for:
                                [Deployment/external-dns/external-dns status: 'InProgress']
                                Stalled: True, RetriesExceeded

vault-secrets-  1.3.0  False  Helm upgrade failed ... timeout waiting for:
   operator                    [VaultConnection/vso-system/default status: 'InProgress']
                                Stalled: True, RetriesExceeded
```

Both are bootstrap-deadlock artefacts:

1. **VSO** — the Hashicorp chart ships a default `VaultConnection` CR
   pointing at `vault.data-system.svc.cluster.local`. VSO itself owns
   that CR's status, but it can only report Ready once Vault is
   reachable — which happens in `apps-data`, which depends on
   `apps-core` going Ready. Circular.
2. **external-dns** — Deployment references `cloudflare-api-token`
   Secret, normally materialised by VSO from Vault. Same chain. Unless
   the operator pre-seeds the Secret before the first install, the
   Deployment never becomes Ready.

With Flux's default of a single install retry, both hit
`RetriesExceeded` and park in `Stalled=True`, which health-check fails
the whole `apps-core` Kustomization and blocks every downstream
Kustomization forever on `DependencyNotReady`.

## Fix

- `vso-system/vault-secrets-operator`:
  - `spec.install.disableWait: true` + `spec.upgrade.disableWait: true`
    so Flux's Helm wait doesn't block on the chart's `VaultConnection`
    CR. The Deployment itself is what matters; the connection
    reconciles asynchronously once Vault exists.
  - `spec.{install,upgrade}.remediation.retries: -1` — never park
    Stalled; retry indefinitely.
- `external-dns/external-dns`:
  - `spec.{install,upgrade}.remediation.retries: -1`. The Deployment
    is still waited on (correct — it's what proves DNS serving is
    live), but infinite retry lets the HelmRelease self-heal the
    moment the operator pre-seeds `cloudflare-api-token` (documented
    bootstrap step in `platform/docs/bringup-v2.md` step 6).

No change to what the charts deploy; only changes Flux's behaviour
around install retries and wait semantics.

## Test plan

- [ ] CI: Flux kustomize build passes
- [ ] After merge + a `flux reconcile source git flux-system`:
  - apps-core flips to Ready (VSO no longer blocks on VaultConnection)
  - external-dns HelmRelease self-heals (Secret pre-seeded manually)
  - apps-data / apps-edge / apps-vso-secrets start installing
- [ ] Manual intervention still needed once on the current cluster to
      delete the already-Stalled HelmRelease CRs so they get re-created
      with the new spec:
      `kubectl -n external-dns delete helmrelease external-dns`
      `kubectl -n vso-system delete helmrelease vault-secrets-operator`