### PR TITLE
fix(platform): pull listmonk-db postgres chart via OCI-typed HelmRepository

### DIFF
--- a/platform/cluster/flux/apps/data/bitnami-oci-source.yaml
+++ b/platform/cluster/flux/apps/data/bitnami-oci-source.yaml
@@ -1,0 +1,15 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: bitnami-oci
+  namespace: data-system
+spec:
+  # Bitnami migrated several charts (postgresql, redis, …) from their
+  # HTTP index at charts.bitnami.com to an OCI-only registry at
+  # registry-1.docker.io/bitnamicharts. The existing `bitnami`
+  # HelmRepository here is HTTP-typed and can't follow the `oci://`
+  # URLs those charts now advertise, so we declare a second OCI-typed
+  # source and route migrated charts through this one.
+  type: oci
+  interval: 1h
+  url: oci://registry-1.docker.io/bitnamicharts

--- a/platform/cluster/flux/apps/data/kustomization.yaml
+++ b/platform/cluster/flux/apps/data/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - bitnami-source.yaml
+  - bitnami-oci-source.yaml
   - vault
   - mariadb
   - listmonk-db

--- a/platform/cluster/flux/apps/data/listmonk-db/release.yaml
+++ b/platform/cluster/flux/apps/data/listmonk-db/release.yaml
@@ -9,9 +9,13 @@ spec:
     spec:
       chart: postgresql
       version: "16.x"
+      # Bitnami moved postgresql to an OCI-only registry; the legacy
+      # HTTP index at charts.bitnami.com advertises an `oci://` URL that
+      # the HTTP-typed `bitnami` HelmRepository can't follow. Use the
+      # OCI-typed source declared in bitnami-oci-source.yaml.
       sourceRef:
         kind: HelmRepository
-        name: bitnami
+        name: bitnami-oci
         namespace: data-system
   values:
     auth:


### PR DESCRIPTION
While bringing up the cluster, apps-data's listmonk-db HelmRelease
failed to pull its chart:

```
HelmChart 'data-system/data-system-listmonk-db' is not ready:
  chart pull error: failed to download chart for remote reference:
  Get "oci://registry-1.docker.io/bitnamicharts/postgresql:16.7.27":
  unsupported protocol scheme "oci"
```

Bitnami migrated several charts — including postgresql — from their
legacy HTTP index at `https://charts.bitnami.com/bitnami` to an
OCI-only registry at `oci://registry-1.docker.io/bitnamicharts`. The
HTTP index still lists the charts but each entry's `urls[]` now points
at an `oci://` reference. Flux's HTTP-typed `HelmRepository` can only
do plain HTTP downloads, so source-controller errors out on the
unsupported scheme.

## Fix

- Add `platform/cluster/flux/apps/data/bitnami-oci-source.yaml` — a
  second HelmRepository named `bitnami-oci` with `spec.type: oci`
  pointing at `oci://registry-1.docker.io/bitnamicharts`.
- Switch `apps/data/listmonk-db/release.yaml`'s `sourceRef` from the
  HTTP `bitnami` HelmRepository to `bitnami-oci`.
- Leave the HTTP `bitnami` HelmRepository in place. MariaDB is still
  being served through the HTTP index at install time; migrating it
  is a separate, reversible change for when/if Bitnami drops the
  MariaDB HTTP artifact too.

Unblocks `apps-data`, which transitively unblocks `apps-vso-secrets` /
`apps-mail` / `apps-stateless`.

## Test plan

- [ ] CI: Flux kustomize build passes
- [ ] After merge + reconcile: `flux get sources helm -A` shows
      `bitnami-oci` Ready, `flux get helmreleases -A` shows
      `data-system/listmonk-db` Ready within a couple of minutes