### PR TITLE
fix(platform): unblock apps-data (MariaDB image + retries)

### DIFF
--- a/platform/cluster/flux/apps/data/listmonk-db/release.yaml
+++ b/platform/cluster/flux/apps/data/listmonk-db/release.yaml
@@ -17,6 +17,18 @@ spec:
         kind: HelmRepository
         name: bitnami-oci
         namespace: data-system
+  # The StatefulSet references existingSecret `listmonk-db-credentials`
+  # which is materialised by VSO from Vault (apps/vso-secrets/listmonk-secrets.yaml).
+  # During bootstrap that Secret doesn't exist yet and the pod stays in
+  # ContainerCreating until it appears. retries: -1 makes Flux retry
+  # the Helm install until the Secret shows up, rather than parking
+  # Stalled after one failure.
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
   values:
     auth:
       database: listmonk

--- a/platform/cluster/flux/apps/data/mariadb/release.yaml
+++ b/platform/cluster/flux/apps/data/mariadb/release.yaml
@@ -13,7 +13,25 @@ spec:
         kind: HelmRepository
         name: bitnami
         namespace: data-system
+  # Bitnami moved all free-tier container images from docker.io/bitnami
+  # to docker.io/bitnamilegacy in August 2025 (paid subscription now
+  # required for the original namespace). The chart still pins the old
+  # `bitnami/mariadb:...` reference, so without overriding image.repository
+  # the StatefulSet pod hits ImagePullBackOff. The tag itself still
+  # exists under bitnamilegacy.
+  #
+  # retries: -1 — never park Stalled on a transient install race
+  # (first boot sometimes hits a client rate limiter from helm-controller
+  # and the default maxRetries=1 gives up too early).
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
   values:
+    image:
+      repository: bitnamilegacy/mariadb
     auth:
       database: blueshell
       # Root password and api user password are seeded into Vault at


### PR DESCRIPTION
After #134 fixed the listmonk-db chart pull, apps-data still couldn't
reach Ready because of two more bootstrap gotchas:

## Problem 1 — MariaDB pod in ImagePullBackOff

```
Back-off pulling image 'docker.io/bitnami/mariadb:11.3.2-debian-12-r9'
Error: ImagePullBackOff
```

Bitnami moved all free-tier container images from `docker.io/bitnami`
to `docker.io/bitnamilegacy` in August 2025 — paid subscription now
required for the original namespace. The MariaDB chart still pins the
old `bitnami/mariadb:…` reference, so the StatefulSet pod can't pull.

**Fix**: override `image.repository` in the HelmRelease values to
`bitnamilegacy/mariadb`. The tag `11.3.2-debian-12-r9` still resolves
on the legacy registry.

## Problem 2 — listmonk-db HelmRelease Stalled=RetriesExceeded

The postgresql chart now pulls fine (thanks to #134), but the first
install timed out waiting for the StatefulSet to become Ready. The
StatefulSet can't come up until VSO materialises the
`listmonk-db-credentials` Secret, which itself needs Vault to be
unsealed and seeded. Flux's default single install retry parked the
HelmRelease in `Stalled=RetriesExceeded` and never looked back.

**Fix**: `install.remediation.retries=-1` and
`upgrade.remediation.retries=-1` on both the `mariadb` and
`listmonk-db` HelmReleases. Same pattern we applied to external-dns
and VSO in #133 — indefinite retries let the HelmReleases self-heal
the moment the missing piece appears (image registry fix for mariadb,
operator-seeded Vault secret for listmonk-db).

Unblocks `apps-data`, which transitively unblocks `apps-vso-secrets`
/ `apps-mail` / `apps-stateless`.

## Test plan

- [ ] CI: Flux kustomize build passes
- [ ] After merge + reconcile: `mariadb` pod pulls image from
      `bitnamilegacy/mariadb`, reaches Running. `flux get helmreleases`
      shows both `data-system/mariadb` and `data-system/listmonk-db`
      transitioning towards Ready (listmonk-db still needs the Vault
      bootstrap + seeding to complete, per the documented
      `platform/docs/vault-bootstrap.md` runbook)