### PR TITLE
fix(platform): override listmonk-db postgres image to bitnamilegacy

### DIFF
--- a/platform/cluster/flux/apps/data/listmonk-db/release.yaml
+++ b/platform/cluster/flux/apps/data/listmonk-db/release.yaml
@@ -30,6 +30,15 @@ spec:
     remediation:
       retries: -1
   values:
+    # Bitnami moved all free-tier container images from docker.io/bitnami
+    # to docker.io/bitnamilegacy in August 2025 (paid subscription now
+    # required for the original namespace). The chart still pins the
+    # `bitnami/postgresql:<version>` reference, so without overriding
+    # image.repository the StatefulSet pod hits an image pull 404.
+    # The tags themselves still exist under `bitnamilegacy/postgresql`.
+    # Same fix as the mariadb HelmRelease in this Kustomization.
+    image:
+      repository: bitnamilegacy/postgresql
     auth:
       database: listmonk
       username: listmonk


### PR DESCRIPTION
Same Bitnami registry migration (free-tier containers moved from
`docker.io/bitnami` → `docker.io/bitnamilegacy` in August 2025) that
#135 addressed for MariaDB, but the postgresql chart used by
`listmonk-db` was missed. Pod fails to start:

```
Failed to pull image 'docker.io/bitnami/postgresql:17.6.0-debian-12-r4':
  failed to resolve reference: ... not found
```

## Fix

Override `image.repository` to `bitnamilegacy/postgresql` in the
listmonk-db HelmRelease values — the tag the chart pins still exists
under the legacy namespace. Matches the pattern in the mariadb
HelmRelease from #135.

## Test plan

- [ ] CI: Flux kustomize build passes
- [ ] After merge + reconcile: `listmonk-db-postgresql-0` pulls from
      `bitnamilegacy/postgresql` successfully, StatefulSet goes Ready,
      `apps-data` Kustomization flips Ready