### PR TITLE
fix(platform): complete VSO auth bindings + own mail-system namespace

### DIFF
--- a/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
+++ b/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
@@ -129,7 +129,7 @@ vault write auth/kubernetes/role/stalwart \
 
 vault write auth/kubernetes/role/vso \
   bound_service_account_names="vault-secrets-operator" \
-  bound_service_account_namespaces="vso-system,cert-manager,external-dns,default,mail-system" \
+  bound_service_account_namespaces="vso-system,cert-manager,external-dns,default,mail-system,data-system" \
   policies="vso" \
   ttl="1h"
 

--- a/platform/cluster/flux/apps/mail/kustomization.yaml
+++ b/platform/cluster/flux/apps/mail/kustomization.yaml
@@ -2,5 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - namespace.yaml
+  # mail-system namespace is created by apps-vso-secrets so the
+  # stalwart-secrets VaultStaticSecret has a namespace to land in before
+  # apps-mail reconciles (apps-mail depends on apps-vso-secrets).
   - stalwart

--- a/platform/cluster/flux/apps/mail/namespace.yaml
+++ b/platform/cluster/flux/apps/mail/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: mail-system

--- a/platform/cluster/flux/apps/vso-secrets/api-secrets.yaml
+++ b/platform/cluster/flux/apps/vso-secrets/api-secrets.yaml
@@ -2,6 +2,18 @@
 # Mollie, Google Calendar SA, Facebook, X). The api Vault policy also
 # allows reading database/creds/api (dynamic MariaDB creds) and
 # transit/sign/api-jwt directly — those are not synced via VSO.
+#
+# VSO looks up the ServiceAccount referenced by the VaultAuth
+# (vso-system/default → `vault-secrets-operator`) in the namespace of
+# this VaultStaticSecret. Without an SA in `default`, VSO reports
+# "ServiceAccount vault-secrets-operator not found" and never reaches
+# Vault.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-secrets-operator
+  namespace: default
+---
 apiVersion: secrets.hashicorp.com/v1beta1
 kind: VaultStaticSecret
 metadata:

--- a/platform/cluster/flux/apps/vso-secrets/stalwart-secrets.yaml
+++ b/platform/cluster/flux/apps/vso-secrets/stalwart-secrets.yaml
@@ -2,6 +2,27 @@
 # server. Stalwart reads these via Vault Agent injection (see PR7 manifests)
 # rather than a k8s Secret, but VSO is used to create the Secret that
 # Stalwart's initContainer uses on first boot.
+#
+# VSO needs the `vault-secrets-operator` ServiceAccount in the same
+# namespace as this VaultStaticSecret; apps-mail doesn't create this SA
+# itself and without it VSO reports "ServiceAccount vault-secrets-operator
+# not found".
+# apps-mail (which creates the stalwart Deployment/Service) depends on
+# apps-vso-secrets (this Kustomization) — meaning the mail-system
+# namespace must exist *before* apps-vso-secrets reconciles, not after.
+# Declare it here instead of in apps-mail; apps-mail adopts the existing
+# namespace when it reconciles.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mail-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-secrets-operator
+  namespace: mail-system
+---
 apiVersion: secrets.hashicorp.com/v1beta1
 kind: VaultStaticSecret
 metadata:


### PR DESCRIPTION
After the data-layer unblock (label-flip + HelmRelease delete) got
apps-data Ready and apps-vso-secrets applied its VaultStaticSecret
CRs, every VaultStaticSecret started failing with one of two errors:

```
# data-system/mariadb-credentials + data-system/listmonk-db-credentials
Failed to get Vault auth login: Error making API request.
Code: 403. * namespace not authorized
```

```
# default/api-secrets + default/listmonk-secrets + mail-system/stalwart-secrets
Failed to get cacheKey from obj:
  ServiceAccount "vault-secrets-operator" not found
```

## Three independent bugs, all traced to the same first-install path

### 1. Vault `vso` role doesn't allow `data-system`

`bootstrap-auth.sh` binds the `vso` role to SA
`vault-secrets-operator` in:

```
vso-system, cert-manager, external-dns, default, mail-system
```

Missing `data-system`. The data-system VaultStaticSecrets
(`mariadb-credentials`, `listmonk-db-credentials`) cannot authenticate
to Vault's Kubernetes auth plugin, so they stall on `Synced=False`.

Fix: add `data-system` to `bound_service_account_namespaces`.

### 2. `vault-secrets-operator` ServiceAccount missing in `default` and `mail-system`

VSO looks up the SA referenced by the VaultAuth (`vault-secrets-operator`)
in the *same* namespace as each VaultStaticSecret CR. The existing
vso-secrets tree declared the SA in cert-manager, external-dns, and
data-system (via `cloudflare.yaml` and `mariadb-credentials.yaml`).

Missing from:

- `default` — consumed by `api-secrets.yaml` and `listmonk-secrets.yaml`
- `mail-system` — consumed by `stalwart-secrets.yaml`

Fix: add the ServiceAccount declaration to `api-secrets.yaml` (covers
both VaultStaticSecrets in `default`) and to `stalwart-secrets.yaml`
(covers `mail-system`).

### 3. `mail-system` namespace created by `apps-mail`, not `apps-vso-secrets`

apps-mail depends on apps-vso-secrets — yet `mail-system` was declared
only in `apps-mail/namespace.yaml`. apps-vso-secrets therefore couldn't
apply the stalwart-secrets VaultStaticSecret on first reconciliation:
`namespaces "mail-system" not found`.

Fix: move the Namespace declaration into
`apps-vso-secrets/stalwart-secrets.yaml` (which is where it's first
needed) and drop it from `apps-mail/kustomization.yaml`. apps-mail
adopts the existing namespace when it reconciles.

## Files changed

- `platform/cluster/flux/apps/data/vault/bootstrap-auth.sh` — add
  `data-system` to the vso role's namespace binding
- `platform/cluster/flux/apps/vso-secrets/api-secrets.yaml` — prepend
  SA declaration for `default`
- `platform/cluster/flux/apps/vso-secrets/stalwart-secrets.yaml` —
  prepend Namespace + SA declarations for `mail-system`
- `platform/cluster/flux/apps/mail/namespace.yaml` — deleted
- `platform/cluster/flux/apps/mail/kustomization.yaml` — drop the
  reference to the deleted namespace.yaml

## Test plan

- [ ] CI: Flux kustomize build passes
- [ ] After merge + reconcile:
      - `kubectl get vaultstaticsecret -A` shows all 7 Ready=True
      - `kubectl get secret -A | grep -E 'api-secrets|listmonk|stalwart'`
        shows every consumed Secret
      - apps-mail + apps-stateless reach Ready

## Note for the current live cluster

The bootstrap Job only re-runs when its ConfigMap hash changes, which
this PR does (bootstrap-auth.sh text differs). Flux will trigger a
fresh Job run once the commit lands, and the role update + SA creations
in-cluster will be idempotent with what was applied manually during
recovery.