### PR TITLE
feat(platform): GHCR pull secret for private ghcr.io/esa-blueshell images

### DIFF
--- a/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
+++ b/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
@@ -83,7 +83,8 @@ EOF
 # VSO reads here to mint k8s Secrets in the namespaces of apps that need
 # them — platform/edge (Cloudflare DNS-01 token for cert-manager and
 # external-dns), platform/api (api secrets), platform/listmonk (listmonk
-# admin + SMTP), platform/mail (stalwart admin + DKIM).
+# admin + SMTP), platform/mail (stalwart admin + DKIM),
+# platform/ghcr (GitHub PAT for pulling private ghcr.io images).
 cat <<'EOF' >/tmp/vso.hcl
 path "secret/data/platform/edge" {
   capabilities = ["read"]
@@ -98,6 +99,10 @@ path "secret/data/listmonk" {
 }
 
 path "secret/data/platform/mail" {
+  capabilities = ["read"]
+}
+
+path "secret/data/platform/ghcr" {
   capabilities = ["read"]
 }
 EOF

--- a/platform/cluster/flux/apps/stateless/api/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/api/deployment.yaml
@@ -69,6 +69,11 @@ spec:
           {{- end }}
     spec:
       serviceAccountName: api
+      # ghcr.io/esa-blueshell/api is a private package; the pull secret
+      # is materialised by VSO from Vault (secret/platform/ghcr) — see
+      # platform/cluster/flux/apps/vso-secrets/ghcr.yaml.
+      imagePullSecrets:
+        - name: ghcr-pull-secret
       containers:
         - name: api
           image: ghcr.io/esa-blueshell/api:latest

--- a/platform/cluster/flux/apps/stateless/frontend/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/frontend/deployment.yaml
@@ -18,6 +18,11 @@ spec:
       labels:
         app.kubernetes.io/name: frontend
     spec:
+      # ghcr.io/esa-blueshell/frontend is a private package; the pull
+      # secret is materialised by VSO from Vault (secret/platform/ghcr)
+      # — see platform/cluster/flux/apps/vso-secrets/ghcr.yaml.
+      imagePullSecrets:
+        - name: ghcr-pull-secret
       containers:
         - name: frontend
           image: ghcr.io/esa-blueshell/frontend:latest

--- a/platform/cluster/flux/apps/vso-secrets/ghcr.yaml
+++ b/platform/cluster/flux/apps/vso-secrets/ghcr.yaml
@@ -1,0 +1,39 @@
+# ghcr-pull-secret: dockerconfigjson Secret that the api and frontend
+# Deployments reference via `imagePullSecrets`. The source of truth is
+# Vault at `secret/platform/ghcr` with two fields:
+#
+#   username  GitHub username that owns the PAT
+#   token     GitHub PAT with read:packages scope on ESA-Blueshell/*
+#
+# VSO reads those two fields and, via the `.dockerconfigjson`
+# transformation template below, emits a Kubernetes Secret of type
+# `kubernetes.io/dockerconfigjson` in the `default` namespace. The
+# Secret is idempotently re-rendered on every VSO refresh, so rotating
+# the PAT only requires a `vault kv put secret/platform/ghcr …` —
+# pods pick up the new token automatically on their next pull.
+#
+# ghcr.io/esa-blueshell/{api,frontend} are private GHCR packages, so
+# anonymous pulls return 401 from the registry and the Deployments
+# hit ImagePullBackOff on first rollout. This Secret plus the two
+# imagePullSecrets references in the Deployments closes that gap.
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: ghcr-pull-secret
+  namespace: default
+spec:
+  vaultAuthRef: vso-system/default
+  type: kv-v2
+  mount: secret
+  path: platform/ghcr
+  destination:
+    name: ghcr-pull-secret
+    create: true
+    type: kubernetes.io/dockerconfigjson
+    transformation:
+      templates:
+        .dockerconfigjson:
+          text: |
+            {{- $auth := printf "%s:%s" (get .Secrets "username") (get .Secrets "token") | b64enc -}}
+            {"auths":{"ghcr.io":{"username":"{{ get .Secrets "username" }}","password":"{{ get .Secrets "token" }}","auth":"{{ $auth }}"}}}
+  refreshAfter: 1h

--- a/platform/cluster/flux/apps/vso-secrets/kustomization.yaml
+++ b/platform/cluster/flux/apps/vso-secrets/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - api-secrets.yaml
   - listmonk-secrets.yaml
   - stalwart-secrets.yaml
+  - ghcr.yaml

--- a/platform/docs/vault-bootstrap.md
+++ b/platform/docs/vault-bootstrap.md
@@ -118,6 +118,25 @@ vault kv put secret/api \
 `vault-oidc-client-secret` is the shared secret the Vault OIDC auth method uses
 when calling back to the api. Generate with `openssl rand -hex 32`.
 
+### GHCR pull credential (api + frontend Deployments)
+
+`ghcr.io/esa-blueshell/{api,frontend}` are private packages. VSO
+materialises `default/ghcr-pull-secret` (type
+`kubernetes.io/dockerconfigjson`) from this Vault path; both
+Deployments reference it via `imagePullSecrets`.
+
+```bash
+vault kv put secret/platform/ghcr \
+  username=<github-username> \
+  token=<github-pat-with-read:packages>
+```
+
+The PAT needs **only** `read:packages` scope (fine-grained PAT: repo
+access to `ESA-Blueshell`, permission `Packages: read-only`). Rotate by
+re-running the same `kv put` with a new token — VSO re-renders the
+dockerconfigjson within one refresh cycle (1 h) and pods pick up the
+new auth on their next pull.
+
 ## 5. Confirm VSO sync
 
 After seeding, force a VSO reconcile and verify secrets appear:


### PR DESCRIPTION
Adds a VSO-managed `kubernetes.io/dockerconfigjson` Secret backed by Vault path `secret/platform/ghcr`, and references it as `imagePullSecrets` from the api + frontend Deployments. Closes the 401 from anonymous GHCR pulls on first install. See commit message + `platform/docs/vault-bootstrap.md` new section for seeding. Depends on the already-merged #137.