### PR TITLE
fix(platform): drop token_reviewer_jwt so Vault's K8s auth doesn't expire after 1h

### DIFF
--- a/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
+++ b/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
@@ -11,9 +11,19 @@ if ! vault auth list -format=json | grep -q '"kubernetes/"'; then
   vault auth enable kubernetes
 fi
 
+# Deliberately do NOT pass token_reviewer_jwt. If set, Vault uses that
+# literal JWT to call TokenReview, and projected service account tokens
+# expire after 1 h by default — the first time the role is exercised
+# past that window, every incoming auth login returns
+# "Code: 403. * permission denied" with no obvious diagnostic. When
+# token_reviewer_jwt is unset, Vault uses its own pod's SA token
+# (kubelet auto-rotates it), so the config never goes stale.
+#
+# The Vault SA has system:auth-delegator via the vault-server-binding
+# ClusterRoleBinding created by the Vault Helm chart, so it's already
+# authorised to call TokenReview.
 vault write auth/kubernetes/config \
   kubernetes_host="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS}" \
-  token_reviewer_jwt="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
   kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 
 # kv-v2 at `secret/` is Vault's conventional default. Services read


### PR DESCRIPTION
The bootstrap Job wrote Vault's `auth/kubernetes/config` with a literal `token_reviewer_jwt` sourced from its own pod SA token. Projected tokens default to **1 h TTL** — kubelet auto-rotates on the live pod but the JWT bytes stored in Vault's config do not. Result: every VaultStaticSecret login starts failing with `Code: 403. * permission denied` about an hour after the Job last ran.

The VSO pod kept working from its own cached Vault token, so the break was invisible until a routine VSO restart. Then every VSS went `Synced=False` at once.

**Fix**: omit `token_reviewer_jwt`. When unset, Vault uses its own pod's SA token to call TokenReview — and *that* token IS the live, kubelet-rotated projected token on the Vault pod. So the config never goes stale.

The Vault SA already has `system:auth-delegator` via the `vault-server-binding` ClusterRoleBinding created by the Helm chart, so it's authorised to call TokenReview — confirmed via `kubectl get clusterrolebinding vault-server-binding`.

## Test plan

- [ ] CI: Flux kustomize build passes
- [ ] After merge + next bootstrap Job run, `vault read auth/kubernetes/config` shows no `token_reviewer_jwt` field
- [ ] VSO VaultStaticSecret syncs continue to work > 1 h past the last Job run
- [ ] After a forced VSO restart, all VaultStaticSecrets reach Ready=True within 60 s without needing the Job to re-run