### PR TITLE
fix(platform): grant VSO read on secret/data/platform/mariadb

### DIFF
--- a/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
+++ b/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
@@ -115,6 +115,10 @@ path "secret/data/platform/mail" {
 path "secret/data/platform/ghcr" {
   capabilities = ["read"]
 }
+
+path "secret/data/platform/mariadb" {
+  capabilities = ["read"]
+}
 EOF
 
 vault policy write api /tmp/api.hcl


### PR DESCRIPTION
The `vso` Vault policy in `bootstrap-auth.sh` listed every path VSO's VaultStaticSecrets read from — except `secret/data/platform/mariadb`, the one backing `mariadb-credentials` in the `data-system` namespace. VSO authenticated and then 403'd on the read:

```
URL: GET /v1/secret/data/platform/mariadb
Code: 403. * permission denied
```

`apps/vso-secrets/mariadb-credentials.yaml` specifies `path: platform/mariadb`; the policy must match. Add it.

## Test plan

- [ ] CI: Flux kustomize build passes
- [ ] After merge + next bootstrap Job run (or `vault policy write vso` live): `kubectl -n data-system get vaultstaticsecret mariadb-credentials` → Ready=True