### PR TITLE
fix(platform): listmonk DB hostname (…-postgresql suffix missing)

### DIFF
--- a/platform/cluster/flux/apps/stateless/listmonk/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/listmonk/deployment.yaml
@@ -40,7 +40,9 @@ spec:
             - name: LISTMONK_app__address
               value: '0.0.0.0:9000'
             - name: LISTMONK_db__host
-              value: listmonk-db.data-system.svc.cluster.local
+              # Bitnami postgresql chart exposes the primary as
+              # <release-name>-postgresql, not the bare release name.
+              value: listmonk-db-postgresql.data-system.svc.cluster.local
             - name: LISTMONK_db__port
               value: '5432'
             - name: LISTMONK_db__user

--- a/platform/cluster/flux/apps/utility-system/gatus/gatus-endpoints-configmap.yaml
+++ b/platform/cluster/flux/apps/utility-system/gatus/gatus-endpoints-configmap.yaml
@@ -106,7 +106,7 @@ data:
       - "[CONNECTED] == true"
     - name: "listmonk-db"
       group: "internal"
-      url: "tcp://listmonk-db.data-system.svc.cluster.local:5432"
+      url: "tcp://listmonk-db-postgresql.data-system.svc.cluster.local:5432"
       interval: "60s"
       conditions:
       - "[CONNECTED] == true"


### PR DESCRIPTION
Bitnami's postgresql chart creates the primary Service as `<release-name>-postgresql` (and a headless `<release-name>-postgresql-hl`), not the bare release name. Our chart release is `listmonk-db`, so the service is `listmonk-db-postgresql` — but listmonk's Deployment was configured to reach `listmonk-db.data-system.svc.cluster.local`:

```
error connecting to DB:
  dial tcp: lookup listmonk-db.data-system.svc.cluster.local on 10.43.0.10:53: no such host
```

Same typo in the Gatus monitor. Fix both.