### PR TITLE
fix(platform): pin MariaDB to 10.11.10 to match migration history

### DIFF
--- a/platform/cluster/flux/apps/data/mariadb/release.yaml
+++ b/platform/cluster/flux/apps/data/mariadb/release.yaml
@@ -32,6 +32,15 @@ spec:
   values:
     image:
       repository: bitnamilegacy/mariadb
+      # Pin MariaDB 10.11 LTS to match the old VPS and the rest of the
+      # codebase (docker-compose.yml, CI workflows, services/api/docker-
+      # compose.dev.yml — all pinned to mariadb:10.11.10). Bitnami chart
+      # 18.x defaults to MariaDB 11.x, which tightened a number of DDL
+      # rules (e.g. refusing `MODIFY COLUMN` on a column referenced by a
+      # foreign key — ERROR 1832) that our Flyway V28 migration
+      # `constraints-cleanup-hibernate-realignment` relies on. Without
+      # this pin the api crashloops on first boot against a fresh DB.
+      tag: 10.11.10-debian-12-r4
     auth:
       database: blueshell
       # Root password and api user password are seeded into Vault at


### PR DESCRIPTION
## Summary

Bitnami chart `mariadb` 18.x defaults to MariaDB **11.x**, which tightened DDL semantics and refuses `MODIFY COLUMN` on a column referenced by a foreign key (MariaDB error **1832**). Our Flyway V28 migration `constraints-cleanup-hibernate-realignment` relies on that exact pattern:

```sql
ALTER TABLE sponsors
    MODIFY logo_id BIGINT NOT NULL;   -- fk_sponsors_logo_id references this column
```

On a clean 11.3 database the migration gets 95% of the way through V28, then fails on this statement, leaves a `success=0` row in `flyway_schema_history`, and the api crashloops on every subsequent boot with `Detected failed migration to version 28`.

Every other MariaDB reference in the repo is already pinned to `10.11.10`:

- `.github/workflows/ci.yml` → 3 occurrences of `image: mariadb:10.11.10`
- `docker-compose.yml` → `image: mariadb:10.11.10`
- `services/api/docker-compose.dev.yml` → `image: mariadb:10.11.10`

Aligning the Helm chart to the same family lets the 28 existing migrations run unchanged, and matches what the old-VPS data to be migrated was authored against. This is a one-line image-tag override; no chart-version change, no migration rewrites, no checksum churn.

## Test plan

- [ ] `flux reconcile kustomization apps-data` picks up the new image tag
- [ ] Operator wipes the PVC so the StatefulSet comes up fresh (downgrading an InnoDB system tablespace across major versions is not supported in-place):
      ```
      kubectl -n data-system scale sts mariadb --replicas=0
      kubectl -n data-system delete pvc data-mariadb-0
      kubectl -n data-system scale sts mariadb --replicas=1
      ```
- [ ] After new pod is Ready, `kubectl -n data-system exec mariadb-0 -- mariadb --version` reports 10.11
- [ ] `kubectl -n default delete pod -l app.kubernetes.io/name=api` — api pod boots cleanly, Flyway applies V1..V28 to success, pod goes 1/1 Ready
- [ ] `kubectl -n data-system exec mariadb-0 -- env MYSQL_PWD="$(kubectl -n data-system get secret mariadb-credentials -o jsonpath='{.data.mariadb-root-password}' | base64 -d)" mariadb -uroot blueshell -e 'SELECT MAX(CAST(version AS UNSIGNED)), SUM(success=0) FROM flyway_schema_history'` returns `28, 0`
- [ ] External smoke: `curl -I https://api.v2.esa-blueshell.nl/health` returns 200