### PR TITLE
fix(platform): unblock external-dns + 2m reconcile intervals

### DIFF
--- a/platform/cluster/flux/apps/edge/ingressroutes/frontend.yaml
+++ b/platform/cluster/flux/apps/edge/ingressroutes/frontend.yaml
@@ -13,8 +13,15 @@ spec:
   entryPoints:
     - websecure
   routes:
+    # `www.v2.esa-blueshell.nl` is intentionally NOT served. Cloudflare
+    # already holds an operator-managed CNAME at that name, and
+    # external-dns cannot CREATE an A/AAAA record next to a CNAME — the
+    # whole reconcile batch 400s with error 81054, which in turn blocks
+    # every other subdomain from being created in the same run. The
+    # `www.` alias can come back (or get routed via a CF page-rule
+    # redirect) at PR 10 apex cutover.
     - kind: Rule
-      match: Host(`v2.esa-blueshell.nl`) || Host(`www.v2.esa-blueshell.nl`)
+      match: Host(`v2.esa-blueshell.nl`)
       services:
         - name: frontend
           namespace: default

--- a/platform/cluster/flux/clusters/production/flux-system/gotk-sync.yaml
+++ b/platform/cluster/flux/clusters/production/flux-system/gotk-sync.yaml
@@ -22,7 +22,7 @@ metadata:
   name: flux-system
   namespace: flux-system
 spec:
-  interval: 10m0s
+  interval: 2m0s
   path: ./platform/cluster/flux/clusters/production
   prune: true
   sourceRef:

--- a/platform/cluster/flux/clusters/production/kustomizations.yaml
+++ b/platform/cluster/flux/clusters/production/kustomizations.yaml
@@ -12,7 +12,7 @@ metadata:
   name: apps-core
   namespace: flux-system
 spec:
-  interval: 10m0s
+  interval: 2m0s
   path: ./platform/cluster/flux/apps/core
   prune: true
   wait: true
@@ -27,7 +27,7 @@ metadata:
   name: apps-data
   namespace: flux-system
 spec:
-  interval: 10m0s
+  interval: 2m0s
   path: ./platform/cluster/flux/apps/data
   prune: true
   wait: true
@@ -44,7 +44,7 @@ metadata:
   name: apps-vso-secrets
   namespace: flux-system
 spec:
-  interval: 10m0s
+  interval: 2m0s
   path: ./platform/cluster/flux/apps/vso-secrets
   prune: true
   dependsOn:
@@ -60,7 +60,7 @@ metadata:
   name: apps-edge
   namespace: flux-system
 spec:
-  interval: 10m0s
+  interval: 2m0s
   path: ./platform/cluster/flux/apps/edge
   prune: true
   dependsOn:
@@ -75,7 +75,7 @@ metadata:
   name: apps-utility-system
   namespace: flux-system
 spec:
-  interval: 10m0s
+  interval: 2m0s
   path: ./platform/cluster/flux/apps/utility-system
   prune: true
   dependsOn:
@@ -90,7 +90,7 @@ metadata:
   name: apps-mail
   namespace: flux-system
 spec:
-  interval: 10m0s
+  interval: 2m0s
   path: ./platform/cluster/flux/apps/mail
   prune: true
   dependsOn:
@@ -106,7 +106,7 @@ metadata:
   name: apps-stateless
   namespace: flux-system
 spec:
-  interval: 10m0s
+  interval: 2m0s
   path: ./platform/cluster/flux/apps/stateless
   prune: true
   dependsOn:


### PR DESCRIPTION
## Summary

Two small fixes bundled so the second can land.

### 1. external-dns blocked by `www.v2` CNAME clash (the blocker)

The frontend IngressRoute matches `Host(v2.esa-blueshell.nl) || Host(www.v2.esa-blueshell.nl)`. Cloudflare already holds an operator-managed CNAME at `www.v2.esa-blueshell.nl`, and Cloudflare's API rejects an A/AAAA CREATE next to an existing CNAME (error 81054). external-dns submits records in one batch — when any record in the batch 400s the entire batch is aborted, so `status.esa-blueshell.nl` (and any future new host) never gets created. Logs on the cluster right now show the retry loop on `www.v2` A/AAAA failing every 60s:

```
error 81054 — A CNAME record with that host already exists
Failed to do run once: soft error (consecutive soft errors: 5)
```

Drop `www.v2.esa-blueshell.nl` from the IngressRoute match. It's not needed during staged v2 bringup; the alias can come back — or be handled by a CF page-rule redirect — at PR 10 apex cutover.

### 2. Tighten Kustomization reconcile intervals to 2m

- `Kustomization.spec.interval`: 10m → 2m across all eight (flux-system + seven apps-*).
- `GitRepository.spec.interval`: already 1m (< 2m, leave).
- Keel image polling: already `@every 2m` on api + frontend Deployments.
- HelmRelease / HelmRepository intervals stay at 30m / 1h — chart-level drift is uncommon.

A merged PR now lands in ≤ 1m (git pull) + ≤ 2m (kustomize reconcile) = under 3 minutes end-to-end.

## Test plan

- [ ] After merge + reconcile, `kubectl -n external-dns logs -l app.kubernetes.io/name=external-dns --tail=30` shows no more 81054 errors
- [ ] `dig +short status.esa-blueshell.nl` returns a Cloudflare proxy IP
- [ ] `curl -I https://status.esa-blueshell.nl/` returns 200
- [ ] `flux get kustomizations` shows all eight Kustomizations with 2m interval after the next reconcile