### PR TITLE
docs: drop references to personal-stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Built with **Spring Boot 4 (Kotlin)** backend and **Vue.js 3 (TypeScript)** fron
 
 > **Platform migration in progress.** The repository is moving from a Docker Swarm
 > deployment on a Contabo VPS to a single-node **NixOS + k3s + FluxCD + Kustomize + Helm**
-> stack, mirroring the `personal-stack-2` backbone. Swarm-era assets (`infra/`, `vps/`,
-> `docker-stack.yml`, `deploy.sh`, `rotator`, `mailserver`) have been removed in this
-> branch. The new `platform/` tree will land in follow-up PRs.
+> stack. Swarm-era assets (`infra/`, `vps/`, `docker-stack.yml`, `deploy.sh`, `rotator`,
+> `mailserver`) have been removed in this branch. The new `platform/` tree will land in
+> follow-up PRs.
 
 ---
 

--- a/platform/docs/runbook.md
+++ b/platform/docs/runbook.md
@@ -1,7 +1,7 @@
 # Platform runbook
 
 The `platform/` tree replaces the legacy `infra/` + `vps/` stack with
-**NixOS + k3s + FluxCD + Kustomize + Helm**, modeled on `personal-stack-2`.
+**NixOS + k3s + FluxCD + Kustomize + Helm**.
 
 Status: **scaffolding in progress**. This PR removes the legacy assets; the
 Flux manifests, Nix flake, and cutover runbook land in follow-up PRs:

--- a/platform/nix/modules/base/default.nix
+++ b/platform/nix/modules/base/default.nix
@@ -25,9 +25,9 @@ in
   };
 
   # Write /etc/resolv.conf statically from NixOS and disable openresolv
-  # entirely, same rationale as personal-stack: keep kubelet's resolv.conf
-  # under three entries so DNSConfigForming doesn't fire. Three upstreams:
-  # Cloudflare primary + secondary for speed, Quad9 for operator diversity.
+  # entirely: keep kubelet's resolv.conf under three entries so
+  # DNSConfigForming doesn't fire. Three upstreams: Cloudflare primary
+  # + secondary for speed, Quad9 for operator diversity.
   networking.resolvconf.enable = false;
   environment.etc."resolv.conf" = {
     mode = "0644";


### PR DESCRIPTION
## Summary

The README, the platform runbook, and a Nix comment all referenced `personal-stack-2` / \"personal-stack\" as the design inspiration. That repo is unrelated to this project; the mentions were historical design-origin notes and don't help a reader understand the Blueshell codebase.

Removed three references:

- \`README.md\` — the platform-migration note no longer claims to mirror \`personal-stack-2\`.
- \`platform/docs/runbook.md\` — same, drop the \"modeled on …\" clause.
- \`platform/nix/modules/base/default.nix\` — rewrite the \`resolv.conf\` comment so it justifies itself (\"keep kubelet's resolv.conf under three entries so DNSConfigForming doesn't fire\") without referencing the other repo.

## Test plan

- [ ] \`grep -rin 'personal-stack\\|personal_stack' README.md platform/ services/\` returns no matches