### PR TITLE
fix(api+platform): let api boot when google calendar creds are absent

### DIFF
--- a/platform/cluster/flux/apps/stateless/api/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/api/deployment.yaml
@@ -48,10 +48,14 @@ spec:
           BREVO_FOLDER_CONTRIBUTION_PERIODS_ID={{ index .Data.data "brevo-folder-contribution-periods-id" }}
           MOLLIE_API_KEY={{ index .Data.data "mollie-api-key" }}
           GOOGLE_CALENDAR_ID={{ index .Data.data "google-calendar-id" }}
-          GOOGLE_CALENDAR_CLIENT_ID={{ index .Data.data "google-calendar-client-id" }}
-          GOOGLE_CALENDAR_CLIENT_EMAIL={{ index .Data.data "google-calendar-client-email" }}
-          GOOGLE_CALENDAR_PRIVATE_KEY_PKCS8={{ index .Data.data "google-calendar-private-key-pkcs8" }}
-          GOOGLE_CALENDAR_PRIVATE_KEY_ID={{ index .Data.data "google-calendar-private-key-id" }}
+          # application.yaml binds ${GOOGLE_CALENDAR_SA_JSON} directly
+          # into google.calendar.serviceAccountJson. Single-quote the
+          # value so the shell tolerates the braces, double quotes and
+          # backslash-n escapes that appear in a Google service-account
+          # JSON. Google-generated JSON doesn't contain single quotes;
+          # if a future rotation does, base64-encode it in Vault and
+          # decode in the start script.
+          GOOGLE_CALENDAR_SA_JSON='{{ index .Data.data "google-calendar-sa-json" }}'
           FACEBOOK_PAGE_ID={{ index .Data.data "facebook-page-id" }}
           FACEBOOK_ACCESS_TOKEN={{ index .Data.data "facebook-access-token" }}
           X_API_KEY={{ index .Data.data "x-api-key" }}

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/calendar/adapter/GoogleCalendarClient.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/calendar/adapter/GoogleCalendarClient.kt
@@ -40,12 +40,34 @@ class GoogleCalendarClient {
     @Value($$"${google.calendar.serviceAccountJson}")
     private lateinit var serviceAccountJson: String
 
-    private lateinit var service: Calendar
+    private var service: Calendar? = null
     private lateinit var htmlRenderer: HtmlRenderer
     private lateinit var htmlParser: Parser
 
     @PostConstruct
     fun init() {
+        // Markdown → HTML renderer is cheap and has no external deps;
+        // set it up regardless so the no-credentials branch below can
+        // still fail operations with clear errors rather than NPE.
+        val options = MutableDataSet()
+        options.set(
+            Parser.EXTENSIONS, listOf(TablesExtension.create(), StrikethroughExtension.create())
+        )
+        htmlParser = Parser.builder(options).build()
+        htmlRenderer = HtmlRenderer.builder(options).build()
+
+        // Running the prod profile without Google Calendar creds must
+        // not block api startup — other features (OIDC, API endpoints,
+        // the frontend) should work. Operations that *actually* need
+        // the client will throw below instead.
+        if (serviceAccountJson.isBlank()) {
+            log.warn(
+                "google.calendar.serviceAccountJson is blank; calendar sync is disabled. " +
+                "Seed secret/api.google-calendar-sa-json in Vault to enable it."
+            )
+            return
+        }
+
         try {
             val httpTransport = GoogleNetHttpTransport.newTrustedTransport()
 
@@ -60,13 +82,6 @@ class GoogleCalendarClient {
             ).setApplicationName(APPLICATION_NAME)
                 .build()
 
-            val options = MutableDataSet()
-            options.set(
-                Parser.EXTENSIONS, listOf(TablesExtension.create(), StrikethroughExtension.create())
-            )
-            htmlParser = Parser.builder(options).build()
-            htmlRenderer = HtmlRenderer.builder(options).build()
-
             log.info("Initialized Google Calendar client for calendarId={}", calendarId)
         } catch (e: GeneralSecurityException) {
             log.error("Failed to initialize GoogleCalendarService", e)
@@ -76,6 +91,11 @@ class GoogleCalendarClient {
             throw IllegalStateException("GoogleCalendarService initialization failed", e)
         }
     }
+
+    private fun requireService(): Calendar = service ?: throw IllegalStateException(
+        "Google Calendar client is not configured — seed google-calendar-sa-json in Vault " +
+        "and restart the api pod before invoking calendar operations."
+    )
 
     /**
      * Add an event to Google Calendar.
@@ -91,7 +111,7 @@ class GoogleCalendarClient {
     ): GoogleCalendarEventResult {
         val googleEvent = toGoogleEvent(title, location, description, startTime, endTime)
         try {
-            val result = service.events()
+            val result = requireService().events()
                 .insert(calendarId, googleEvent)
                 .execute()
             log.info("Added event to Google Calendar: {}", result.htmlLink)
@@ -119,7 +139,7 @@ class GoogleCalendarClient {
     ) {
         val googleEvent = toGoogleEvent(title, location, description, startTime, endTime)
         try {
-            service.events()
+            requireService().events()
                 .update(calendarId, googleEventId, googleEvent)
                 .execute()
             log.info("Updated Google Calendar event: {}", googleEventId)
@@ -135,7 +155,7 @@ class GoogleCalendarClient {
     @Throws(IOException::class)
     fun removeEvent(googleEventId: String) {
         try {
-            service.events().delete(calendarId, googleEventId).execute()
+            requireService().events().delete(calendarId, googleEventId).execute()
             log.info("Removed event from Google Calendar: {}", googleEventId)
         } catch (e: GoogleJsonResponseException) {
             log.error("Google Calendar API returned HTTP code {} during removal", e.statusCode, e)


### PR DESCRIPTION
## Summary

Prod api crashloops at startup with:

\`\`\`
Error creating bean with name 'googleCalendarClient': Invocation of init method failed
Caused by: java.lang.IllegalArgumentException: no JSON input found
  at com.google.auth.oauth2.GoogleCredentials.fromStream(...)
\`\`\`

Two bugs stack here:

1. **\`GoogleCalendarClient.init()\` hard-fails on empty \`serviceAccountJson\`** — a missing/invalid Google SA JSON tanks the whole Spring context, so the api never serves anything (including the OIDC discovery endpoint Gatus probes).

2. **The Vault-agent inject template feeds five env vars the app doesn't read.** \`application.yaml\` binds \`google.calendar.serviceAccountJson\` to \`\${GOOGLE_CALENDAR_SA_JSON}\`. The template (in \`deployment.yaml\`) populates \`GOOGLE_CALENDAR_ID\`, \`GOOGLE_CALENDAR_CLIENT_ID\`, \`GOOGLE_CALENDAR_CLIENT_EMAIL\`, \`GOOGLE_CALENDAR_PRIVATE_KEY_PKCS8\`, \`GOOGLE_CALENDAR_PRIVATE_KEY_ID\` — none of which Spring binds anywhere. So even if the operator seeded \`secret/api.google-calendar-sa-json\`, it would never reach the app.

## Changes

### \`GoogleCalendarClient\`

- Split the Markdown-HTML renderer setup (no external deps) from the Google SDK setup; renderer always runs so the fallback path still has it.
- If \`serviceAccountJson.isBlank()\`, log a warning and leave \`service\` null. Boot continues.
- New \`requireService()\` guard gives calendar operations a clear error message instead of NPE when invoked without credentials.

Same shape as the earlier \`BrevoContactAdapter\` fix (#146) — another prod bean that crashed startup on missing creds.

### Vault agent template

- Replace the five dead Google env vars with a single \`GOOGLE_CALENDAR_SA_JSON\` line sourced from the \`google-calendar-sa-json\` key in \`secret/api\`.
- Single-quoted in the \`.env\` so the shell tolerates the braces / double quotes / \`\\n\` escapes in Google-generated SA JSON. A comment flags the base64 fallback if a future rotation contains a literal single quote.

### Operator follow-up (not part of the PR)

After merge, seed the real value and roll the pod:

\`\`\`bash
vault kv patch secret/api google-calendar-sa-json='<single-line-json>'
kubectl -n default annotate vaultstaticsecret api-secrets \\
  vso.secrets.hashicorp.com/force-refresh=\"\$(date +%s)\" --overwrite
kubectl -n default delete pod -l app.kubernetes.io/name=api
\`\`\`

Until the seed lands, calendar sync is a no-op with warnings in the logs; the rest of the api functions normally.

## Test plan

- [x] \`./gradlew :services:api:compileKotlin\` green (verified locally)
- [ ] After this PR merges but before Vault is reseeded, the api pod reaches 1/1 Ready; logs contain the \"calendar sync is disabled\" warning
- [ ] \`Blueshell OIDC Discovery\` probe on https://status.esa-blueshell.nl/ turns green
- [ ] After seeding real JSON + rolling the pod, logs show \`Initialized Google Calendar client for calendarId=…\` and calendar sync jobs run successfully