### PR TITLE
fix(api): tolerate malformed SA JSON, not just blank

### DIFF
--- a/libs/openapi-specs/brevo.yml
+++ b/libs/openapi-specs/brevo.yml
@@ -11297,6 +11297,36 @@ paths:
           name: price[ne]
           schema:
             type: number
+        - description: Alternative price filter for products less than and equals to particular amount
+          in: query
+          name: alternativePrice[lte]
+          schema:
+            type: number
+        - description: Alternative price filter for products greater than and equals to particular amount
+          in: query
+          name: alternativePrice[gte]
+          schema:
+            type: number
+        - description: Alternative price filter for products less than particular amount
+          in: query
+          name: alternativePrice[lt]
+          schema:
+            type: number
+        - description: Alternative price filter for products greater than particular amount
+          in: query
+          name: alternativePrice[gt]
+          schema:
+            type: number
+        - description: Alternative price filter for products equals to particular amount
+          in: query
+          name: alternativePrice[eq]
+          schema:
+            type: number
+        - description: Alternative price filter for products not equals to particular amount
+          in: query
+          name: alternativePrice[ne]
+          schema:
+            type: number
         - description: Filter by categories ids
           in: query
           name: categories
@@ -11353,6 +11383,7 @@ paths:
                         modifiedAt: '2022-06-30T10:29:16.078Z'
                         name: Alpina Panoma Classic
                         price: 49.95
+                        alternativePrice: 39.95
                         s3Original: https://img-ecom.mailinblue.com/path-to-original/img.jpg
                         s3ThumbAnalytics: https://img-ecom.mailinblue.com/path-to-analytics/img.jpg
                         s3ThumbEditor: https://img-ecom.mailinblue.com/path-to-editor/img.jpg
@@ -11372,6 +11403,7 @@ paths:
                         modifiedAt: '2022-06-30T10:29:16.078Z'
                         name: Alpina Panoma Classic2
                         price: 49.95
+                        alternativePrice: 44.95
                         s3Original: https://img-ecom.mailinblue.com/path-to-original/img.jpg
                         s3ThumbAnalytics: https://img-ecom.mailinblue.com/path-to-analytics/img.jpg
                         s3ThumbEditor: https://img-ecom.mailinblue.com/path-to-editor/img.jpg
@@ -11462,6 +11494,10 @@ paths:
                   type: string
                 price:
                   description: Price of the product
+                  format: float
+                  type: number
+                alternativePrice:
+                  description: Alternative price of the product
                   format: float
                   type: number
                 sku:
@@ -11577,6 +11613,10 @@ paths:
                         type: string
                       price:
                         description: Price of the product
+                        format: float
+                        type: number
+                      alternativePrice:
+                        description: Alternative price of the product
                         format: float
                         type: number
                       sku:
@@ -26422,6 +26462,10 @@ components:
           type: string
         price:
           description: Price of the product
+          format: float
+          type: number
+        alternativePrice:
+          description: Alternative price of the product
           format: float
           type: number
         s3Original:

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/calendar/adapter/GoogleCalendarClient.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/calendar/adapter/GoogleCalendarClient.kt
@@ -68,6 +68,12 @@ class GoogleCalendarClient {
             return
         }
 
+        // Any init failure below — invalid JSON, bad key material,
+        // TLS trust issues — must degrade calendar sync to a no-op
+        // rather than crashloop the whole api. Operator sees the
+        // warning, other features keep working. `requireService()`
+        // throws with a clear message if something actually tries to
+        // invoke a calendar operation in this state.
         try {
             val httpTransport = GoogleNetHttpTransport.newTrustedTransport()
 
@@ -84,11 +90,13 @@ class GoogleCalendarClient {
 
             log.info("Initialized Google Calendar client for calendarId={}", calendarId)
         } catch (e: GeneralSecurityException) {
-            log.error("Failed to initialize GoogleCalendarService", e)
-            throw IllegalStateException("GoogleCalendarService initialization failed", e)
+            log.warn("Google Calendar client init failed (security); calendar sync disabled: {}", e.message)
         } catch (e: IOException) {
-            log.error("Failed to initialize GoogleCalendarService", e)
-            throw IllegalStateException("GoogleCalendarService initialization failed", e)
+            // MalformedJsonException extends IOException — a
+            // placeholder or half-seeded SA JSON lands here.
+            log.warn("Google Calendar client init failed (invalid JSON / I/O); calendar sync disabled: {}", e.message)
+        } catch (e: RuntimeException) {
+            log.warn("Google Calendar client init failed; calendar sync disabled: {}", e.message)
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #151. That PR made \`GoogleCalendarClient\` skip init when \`serviceAccountJson\` was **blank**, but the try/catch around \`GoogleCredentials.fromStream\` still re-threw any parse failure as \`IllegalStateException\`. Result on prod today — with a placeholder/half-seeded JSON value already in Vault — api still crashlooping:

\`\`\`
Caused by: com.google.gson.stream.MalformedJsonException: Use JsonReader.setStrictness(...)
  at line 1 column 1 path \$
Caused by: java.lang.IllegalStateException: GoogleCalendarService initialization failed
\`\`\`

## Change

Log-and-skip on every init failure instead of rethrowing. Widened the catch to cover:

- \`GeneralSecurityException\` — bad/missing key material
- \`IOException\` — includes Gson's \`MalformedJsonException\` (the live case)
- \`RuntimeException\` — future-proof against SDK evolution surfacing different error types

On failure, \`service\` stays null; \`requireService()\` (added in #151) still throws with a clear message if a calendar operation is actually invoked. This preserves observability of broken calendar sync without taking the rest of the api down at boot.

## Test plan

- [x] \`./gradlew :services:api:compileKotlin\` green (verified locally)
- [ ] After this PR merges, the currently-malformed Vault value no longer blocks boot; api pod reaches 1/1 Ready
- [ ] Logs contain \"Google Calendar client init failed (invalid JSON / I/O); calendar sync disabled: …\"
- [ ] \`Blueshell OIDC Discovery\` probe on https://status.esa-blueshell.nl/ turns green
- [ ] After seeding a real JSON + rolling the pod, logs show the success path: \`Initialized Google Calendar client for calendarId=…\`