### PR TITLE
feat(platform): persist api uploads on a hostPath PV at /srv/blueshell/storage

### DIFF
--- a/platform/cluster/flux/apps/stateless/api/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/api/deployment.yaml
@@ -108,7 +108,7 @@ spec:
             - name: FRONTEND_URL
               value: https://v2.esa-blueshell.nl
             - name: STORAGE_LOCATION
-              value: /home/storage
+              value: /srv/storage
             - name: LISTMONK_API_BASE_URL
               value: http://listmonk.default.svc.cluster.local:9000/api
             - name: LISTMONK_FROM_ADDRESS
@@ -189,10 +189,28 @@ spec:
               memory: 2Gi
           volumeMounts:
             - name: storage
-              mountPath: /home/storage
+              mountPath: /srv/storage
+      # The api image runs as an Alpine `-S` system user with a
+      # dynamic uid, so we can't fsGroup our way onto the hostPath
+      # mount. Loosen the mount root to 0777 at pod start instead;
+      # traversal from outside is still gated by /srv/blueshell
+      # (0755 root:root, owned by systemd-tmpfiles on the node).
+      initContainers:
+        - name: storage-perms
+          image: busybox:1.37-musl
+          command:
+            - sh
+            - -c
+            - chmod 0777 /srv/storage
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: storage
+              mountPath: /srv/storage
       volumes:
         - name: storage
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: api-storage
 ---
 apiVersion: v1
 kind: Service

--- a/platform/cluster/flux/apps/stateless/api/kustomization.yaml
+++ b/platform/cluster/flux/apps/stateless/api/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - pvc.yaml
   - deployment.yaml

--- a/platform/cluster/flux/apps/stateless/api/pvc.yaml
+++ b/platform/cluster/flux/apps/stateless/api/pvc.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: api-storage
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  # Static binding: empty storageClassName bypasses the default
+  # local-path provisioner so this PV is only claimed by the PVC
+  # below (which also sets storageClassName: "" and volumeName:
+  # api-storage). Keeps uploads at a predictable host path instead
+  # of /var/lib/rancher/k3s/storage/pvc-<uid>_default_api-storage.
+  storageClassName: ""
+  hostPath:
+    path: /srv/blueshell/storage
+    type: DirectoryOrCreate
+  # Pin the api pod to the node that owns the data. A hostPath PV
+  # is node-local by nature; without nodeAffinity a future multi-node
+  # topology could schedule the api away from its own uploads.
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - frankfurt-contabo-1
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: api-storage
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: ""
+  volumeName: api-storage

--- a/platform/docs/runbook.md
+++ b/platform/docs/runbook.md
@@ -21,3 +21,24 @@ The v2 stack runs side-by-side with the old Swarm on apex. No big-bang
 cutover — when v2 has carried real traffic for long enough, the apex
 moves in its own PR. The full PR-9 bring-up runbook lives at
 `platform/docs/bringup-v2.md`.
+
+## User uploads — migrating /home/storage from the old Swarm VPS
+
+The api now persists uploads to `/srv/blueshell/storage` on the
+new node, backed by a static hostPath PV
+(`platform/cluster/flux/apps/stateless/api/pvc.yaml`). The old Swarm
+VPS kept the same data under `/home/storage`. Once the new api pod
+is Ready on the PV, rsync the files across:
+
+```bash
+rsync -av --progress \
+  root@<old-vps>:/home/storage/ \
+  root@frankfurt-contabo-1:/srv/blueshell/storage/
+```
+
+Run this **after** the api rollout on the new PV (so subdirectory
+structure and perms already exist) and **before** DNS cutover in
+PR 10. After rsync, verify a known upload loads via the frontend:
+the subdirectory layout (`profile-pictures/`, `event-banners/`,
+`board-documents/`, …) is owned by `FileType.directory` in code,
+so filenames should round-trip unchanged.

--- a/platform/nix/modules/base/default.nix
+++ b/platform/nix/modules/base/default.nix
@@ -61,6 +61,19 @@ in
     vim
   ];
 
+  # Durable home for api user uploads. The api Deployment mounts
+  # /srv/blueshell/storage via a static hostPath PV (see
+  # platform/cluster/flux/apps/stateless/api/pvc.yaml); kubelet would
+  # auto-create the path with DirectoryOrCreate, but seeding it here
+  # keeps ownership + perms in NixOS's hands across reboots. An
+  # initContainer in the api pod loosens the inner mount to 0777 at
+  # pod start so the pod's dynamic Alpine uid can write.
+  systemd.tmpfiles.rules = [
+    "d /srv                   0755 root root -"
+    "d /srv/blueshell         0755 root root -"
+    "d /srv/blueshell/storage 0755 root root -"
+  ];
+
   # A missing deploy.pub is caught loudly at install/deploy time by the
   # bash guards in platform/scripts. Surface it here as a warning too,
   # but do not fail the build — otherwise `nix flake check` blows up on


### PR DESCRIPTION
## Summary

The api Deployment backs `/home/storage` with `emptyDir: {}`, so every pod roll wipes uploads (profile pictures, event banners, board documents). After today's ~15 rolls between the JWT-secret fix, the Brevo/Google tolerance PRs, and version bumps, assume current prod uploads are gone. We also need somewhere durable to rsync the old Swarm VPS's `/home/storage` into before the PR 10 apex cutover.

This PR wires the api onto a static hostPath PersistentVolume at `/srv/blueshell/storage`, pinned via `nodeAffinity` to `frankfurt-contabo-1` and owned declaratively by NixOS.

- **`platform/cluster/flux/apps/stateless/api/pvc.yaml`** — 20Gi hostPath PV + PVC, `persistentVolumeReclaimPolicy: Retain`, `storageClassName: ""` on both ends so binding is static (bypasses the default `local-path` provisioner). `type: DirectoryOrCreate` so kubelet doesn't refuse to mount if NixOS hasn't run tmpfiles yet.
- **`platform/cluster/flux/apps/stateless/api/deployment.yaml`** — `volumes.storage` swapped from emptyDir to `persistentVolumeClaim.claimName: api-storage`; mount moved `/home/storage` → `/srv/storage` (FHS-correct for site-specific service data) and `STORAGE_LOCATION` updated to match. A busybox initContainer `chmod 0777`s the mount at pod start so the api's Alpine `-S` (dynamic uid) user can write — we can't fsGroup a hostPath mount, and the outer `/srv/blueshell` stays `0755 root:root`.
- **`platform/nix/modules/base/default.nix`** — `systemd.tmpfiles.rules` idempotently owns `/srv`, `/srv/blueshell`, `/srv/blueshell/storage` on every boot, so the path survives `nixos-rebuild switch` and node wipes.
- **`platform/docs/runbook.md`** — rsync one-liner for migrating `/home/storage` from the old Swarm VPS into the new PV (operator-driven, to run after api rollout and before PR 10 cutover).

Why static hostPath and not the default k3s `local-path` provisioner? The dynamic provisioner binds under `/var/lib/rancher/k3s/storage/pvc-<uid>_<ns>_<name>/` — path is opaque from the host, and backups have to `kubectl get pv` to find the subdirectory. With one PVC to manage, a static hostPath at a predictable `/srv/blueshell/storage` is smaller and better ergonomics for `rsync` backups.

## Rollout

NixOS must land on the node **before** Flux binds the PV, so tmpfiles owns the perms on the seed path.

1. Merge the PR.
2. `nixos-rebuild switch --flake './platform#frankfurt-contabo-1' --target-host deploy@157.173.115.164` — verify `ls -ld /srv/blueshell/storage` shows `0755 root root`.
3. `flux reconcile kustomization apps-stateless` (or wait ≤ 2 min) — verify `kubectl -n default get pvc api-storage` → Bound.
4. Api pod rolls automatically. First boot runs `storage-perms` initContainer, then the api.
5. Operator: rsync from old VPS per runbook — separate one-shot, not part of this PR.

## Test plan

- [ ] `kubectl -n default get pv api-storage -o wide` → `STATUS=Bound`, `CLAIM=default/api-storage`, `RECLAIM POLICY=Retain`.
- [ ] `kubectl -n default get pvc api-storage` → `STATUS=Bound`, `CAPACITY=20Gi`.
- [ ] `kubectl -n default describe pod <api-pod>` → `Init Containers: storage-perms  Completed`, main container Ready.
- [ ] `kubectl -n default exec <api-pod> -c api -- ls -la /srv/storage` → dir exists, mode `drwxrwxrwx`.
- [ ] Upload smoke test: POST a file via the event-banner endpoint, confirm it appears at `/srv/blueshell/storage/<FileType.directory>/<filename>` on the node (`ssh deploy@frankfurt-contabo-1 ls /srv/blueshell/storage/`).
- [ ] Persistence test: `kubectl -n default delete pod -l app.kubernetes.io/name=api`, wait for Ready, repeat the `ls` — file still there.
- [ ] Backup dry-run: `rsync -av --dry-run root@frankfurt-contabo-1:/srv/blueshell/storage/ /tmp/` — lists files, no errors.