### PR TITLE
chore: remove residual RabbitMQ references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,6 @@ env:
   MYSQL_PASSWORD: ci-blueshell
   MYSQL_HOST: 127.0.0.1
 
-  RABBITMQ_HOST: 127.0.0.1
-  RABBITMQ_PORT: '5672'
-  RABBITMQ_USERNAME: guest
-  RABBITMQ_PASSWORD: guest
-
   APP_URL: http://127.0.0.1:8080
   FRONTEND_URL: http://127.0.0.1:3000
 
@@ -199,18 +194,6 @@ jobs:
           --health-timeout=5s
           --health-retries=10
           --health-start-period=30s
-      rabbitmq:
-        image: rabbitmq:3.13-management
-        ports: [ "5672:5672" ]
-        env:
-          RABBITMQ_DEFAULT_USER: ${{ env.RABBITMQ_USERNAME }}
-          RABBITMQ_DEFAULT_PASS: ${{ env.RABBITMQ_PASSWORD }}
-        options: >-
-          --health-cmd="rabbitmq-diagnostics -q ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=10
-          --health-start-period=30s
 
     steps:
       - name: Checkout repository
@@ -235,20 +218,6 @@ jobs:
           mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -uroot -p"$MYSQL_ROOT_PASSWORD" < services/api/0_init.sql
           mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -uroot -p"$MYSQL_ROOT_PASSWORD" -e "SHOW DATABASES;"
           mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -uroot -p"$MYSQL_ROOT_PASSWORD" -e "USE $MYSQL_DATABASE; SHOW TABLES;"
-
-      - name: Wait for RabbitMQ service
-        run: |
-          set -euo pipefail
-          for i in {1..30}; do
-            if (echo > /dev/tcp/$RABBITMQ_HOST/$RABBITMQ_PORT) >/dev/null 2>&1; then
-              echo "RabbitMQ is ready!"
-              exit 0
-            fi
-            echo "Waiting for RabbitMQ... ($i/30)"
-            sleep 2
-          done
-          echo "RabbitMQ did not become ready in time."
-          exit 1
 
       - name: Set up Java Development Kit
         uses: actions/setup-java@v4
@@ -310,18 +279,6 @@ jobs:
           --health-timeout=5s
           --health-retries=10
           --health-start-period=30s
-      rabbitmq:
-        image: rabbitmq:3.13-management
-        ports: [ "5672:5672" ]
-        env:
-          RABBITMQ_DEFAULT_USER: ${{ env.RABBITMQ_USERNAME }}
-          RABBITMQ_DEFAULT_PASS: ${{ env.RABBITMQ_PASSWORD }}
-        options: >-
-          --health-cmd="rabbitmq-diagnostics -q ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=10
-          --health-start-period=30s
 
     steps:
       - name: Checkout repository
@@ -344,20 +301,6 @@ jobs:
       - name: Prepare test database schema
         run: |
           mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -uroot -p"$MYSQL_ROOT_PASSWORD" < services/api/0_init.sql
-
-      - name: Wait for RabbitMQ service
-        run: |
-          set -euo pipefail
-          for i in {1..30}; do
-            if (echo > /dev/tcp/$RABBITMQ_HOST/$RABBITMQ_PORT) >/dev/null 2>&1; then
-              echo "RabbitMQ is ready!"
-              exit 0
-            fi
-            echo "Waiting for RabbitMQ... ($i/30)"
-            sleep 2
-          done
-          echo "RabbitMQ did not become ready in time."
-          exit 1
 
       - name: Set up Java Development Kit
         uses: actions/setup-java@v4
@@ -516,18 +459,6 @@ jobs:
           --health-timeout=5s
           --health-retries=10
           --health-start-period=30s
-      rabbitmq:
-        image: rabbitmq:3.13-management
-        ports: [ "5672:5672" ]
-        env:
-          RABBITMQ_DEFAULT_USER: ${{ env.RABBITMQ_USERNAME }}
-          RABBITMQ_DEFAULT_PASS: ${{ env.RABBITMQ_PASSWORD }}
-        options: >-
-          --health-cmd="rabbitmq-diagnostics -q ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=10
-          --health-start-period=30s
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -551,20 +482,6 @@ jobs:
           mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -uroot -p"$MYSQL_ROOT_PASSWORD" < services/api/0_init.sql
           mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -uroot -p"$MYSQL_ROOT_PASSWORD" -e "SHOW DATABASES;"
           mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -uroot -p"$MYSQL_ROOT_PASSWORD" -e "USE $MYSQL_DATABASE; SHOW TABLES;"
-
-      - name: Wait for RabbitMQ service
-        run: |
-          set -euo pipefail
-          for i in {1..30}; do
-            if (echo > /dev/tcp/$RABBITMQ_HOST/$RABBITMQ_PORT) >/dev/null 2>&1; then
-              echo "RabbitMQ is ready!"
-              exit 0
-            fi
-            echo "Waiting for RabbitMQ... ($i/30)"
-            sleep 2
-          done
-          echo "RabbitMQ did not become ready in time."
-          exit 1
 
       - name: Set up Java Development Kit
         uses: actions/setup-java@v4

--- a/services/api/src/test/kotlin/net/blueshell/tools/DatabaseSeedTool.kt
+++ b/services/api/src/test/kotlin/net/blueshell/tools/DatabaseSeedTool.kt
@@ -57,9 +57,6 @@ fun main(args: Array<String>) {
         .properties(
             "spring.main.banner-mode=off",
             "spring.main.log-startup-info=false",
-            "spring.rabbitmq.dynamic=false",
-            "spring.rabbitmq.listener.simple.auto-startup=false",
-            "spring.rabbitmq.listener.direct.auto-startup=false",
         )
         .run()
 


### PR DESCRIPTION
## Summary

RabbitMQ was removed from the api in favour of `@Async` + `RetryTemplate` ([ADR-023](docs/adr/api/ADR-023-job-consolidation-and-reliable-execution.md)). An audit across the monorepo confirms no live code, Gradle deps, Spring config, Flux manifests, NixOS modules, or Vault secrets still reference it — only stale CI scaffolding and a defensive test-tool property block remained. This PR deletes both.

- **`.github/workflows/ci.yml`** — drops the env-block `RABBITMQ_*` vars (lines 45-48), the three `rabbitmq:3.13-management` service containers in the `api-tests` / `system-tests` / `openapi-sync` jobs, and the three matching "Wait for RabbitMQ service" readiness steps. Each of those jobs now starts one fewer container, so CI runs a little faster.
- **`services/api/src/test/kotlin/net/blueshell/tools/DatabaseSeedTool.kt`** — drops the three `spring.rabbitmq.*` disable properties. The dependency was never on the classpath, so they were no-ops anyway.

ADR-023 stays as the authoritative record for the migration; the 1.1.0 `CHANGELOG.md` entries stay intact since they accurately describe a past release.

## Test plan

- [ ] `./gradlew :services:api:check` green locally (`compileTestKotlin` already verified).
- [ ] CI green end-to-end on this branch — confirms all three jobs work without their RabbitMQ service container.
- [ ] Post-merge grep: `rg -i 'rabbit|amqp|5672|15672'` returns only ADR-023, the historical `docs/changelogs/*`, and false positives (a phone number in a test fixture).