### PR TITLE
docs(platform): align vault bootstrap with actual secret consumption

### DIFF
--- a/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
+++ b/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
@@ -92,9 +92,12 @@ EOF
 
 # VSO reads here to mint k8s Secrets in the namespaces of apps that need
 # them — platform/edge (Cloudflare DNS-01 token for cert-manager and
-# external-dns), platform/api (api secrets), platform/listmonk (listmonk
-# admin + SMTP), platform/mail (stalwart admin + DKIM),
+# external-dns), api (third-party integration keys — Brevo, Mollie,
+# Google Calendar, Facebook, X, Discord, plus jwt-secret and the Vault
+# OIDC client secret), listmonk (postgres + admin + SMTP passwords),
+# platform/mail (stalwart admin, bounce mailbox, DKIM),
 # platform/ghcr (GitHub PAT for pulling private ghcr.io images).
+# See platform/docs/vault-bootstrap.md §4 for the full key list.
 cat <<'EOF' >/tmp/vso.hcl
 path "secret/data/platform/edge" {
   capabilities = ["read"]

--- a/platform/cluster/flux/apps/stateless/api/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/api/deployment.yaml
@@ -43,7 +43,10 @@ spec:
         vault.hashicorp.com/agent-inject-secret-api.env: secret/data/api
         vault.hashicorp.com/agent-inject-template-api.env: |
           {{- with secret "secret/data/api" -}}
-          JWT_SECRET={{ index .Data.data "jwt-secret" }}
+          {{- /* An empty jwt-secret silently produces cross-verifiable
+                 tokens; every other integration key below fails loudly
+                 at first use, so only this line is guarded. */ -}}
+          JWT_SECRET={{ index .Data.data "jwt-secret" | required "secret/api is missing key jwt-secret" }}
           BREVO_API_KEY={{ index .Data.data "brevo-api-key" }}
           BREVO_FOLDER_CONTRIBUTION_PERIODS_ID={{ index .Data.data "brevo-folder-contribution-periods-id" }}
           MOLLIE_API_KEY={{ index .Data.data "mollie-api-key" }}

--- a/platform/cluster/flux/apps/vso-secrets/stalwart-secrets.yaml
+++ b/platform/cluster/flux/apps/vso-secrets/stalwart-secrets.yaml
@@ -1,7 +1,19 @@
-# stalwart-secrets: admin credentials and DKIM private key for the mail
-# server. Stalwart reads these via Vault Agent injection (see PR7 manifests)
-# rather than a k8s Secret, but VSO is used to create the Secret that
-# Stalwart's initContainer uses on first boot.
+# stalwart-secrets: k8s Secret mirrored from secret/platform/mail into the
+# mail-system namespace. Stalwart itself reads admin-user/admin-password
+# via Vault Agent injection (see deployment.yaml template), so from
+# Stalwart's perspective this Secret is not strictly required — but the
+# VaultStaticSecret exists so operators can `kubectl get secret` in
+# mail-system during debugging without port-forwarding Vault.
+#
+# Follow-ups before mail cutover:
+# - dkim-private-key is seeded in Vault KV but not yet rendered into the
+#   Stalwart config-template; wiring it is pending.
+# - bounce-mailbox-user/password are consumed by the api (default ns) and
+#   listmonk setup job (default ns) via secretKeyRef, which is namespace-
+#   scoped — those refs currently target a Secret named stalwart-secrets
+#   in the default namespace, which this VaultStaticSecret does not create.
+#   A second VSO sync into default, or a cross-namespace copy, is still
+#   needed before bounce polling works in production.
 #
 # VSO needs the `vault-secrets-operator` ServiceAccount in the same
 # namespace as this VaultStaticSecret; apps-mail doesn't create this SA

--- a/platform/docs/bringup-v2.md
+++ b/platform/docs/bringup-v2.md
@@ -148,66 +148,14 @@ kubectl -n data-system port-forward svc/vault 8200:8200 &
 export VAULT_ADDR=http://127.0.0.1:8200
 ```
 
-First time only — init Vault and **save the 5 unseal keys + root
-token OFFLINE** somewhere safe:
+Follow [`vault-bootstrap.md`](vault-bootstrap.md) end-to-end from §1
+(init + unseal, 5-of-3 Shamir) through §6 (revoke root token). That
+runbook is the canonical source for every `vault kv put` command and
+for the Transit signing key the OIDC issuer needs — keeping the detail
+in one place prevents the two docs from drifting.
 
-```bash
-vault operator init -key-shares=5 -key-threshold=3
-```
-
-Unseal (need 3 of 5; replace `<keyN>` with the actual key strings from
-the init output):
-
-```bash
-vault operator unseal <key1>
-```
-```bash
-vault operator unseal <key2>
-```
-```bash
-vault operator unseal <key3>
-```
-```bash
-vault login <root-token>
-```
-
-Watch the bootstrap Job enable auth / transit / database engines and
-seed policies:
-
-```bash
-kubectl -n data-system logs -l app.kubernetes.io/name=vault-bootstrap-auth -f
-```
-
-Seed static secrets (one `vault kv put` per path; replace the
-angle-bracketed placeholders):
-
-```bash
-vault kv put secret/platform/edge cloudflare.dns_api_token=<token>
-```
-```bash
-vault kv put secret/platform/mariadb root-password=<pass> user=blueshell password=<user-pass>
-```
-```bash
-vault kv put secret/platform/mail admin-user=admin admin-password=<pass> dkim-private-key=<base64-pem> bounce-mailbox-user=bounce@v2.esa-blueshell.nl bounce-mailbox-password=<pass>
-```
-```bash
-vault kv put secret/listmonk db-admin-password=<pass> db-password=<pass> admin-user=listmonk-admin admin-password=<pass> smtp-password=<pass>
-```
-```bash
-vault kv put secret/api brevo-api-key=<key> mollie-api-key=<key> google-calendar-sa-json=<base64> facebook-app-secret=<secret> x-api-secret=<secret> vault-oidc-client-secret=$(openssl rand -hex 32)
-```
-
-Create the Transit signing key the OIDC issuer uses (PR 8):
-
-```bash
-vault write -f transit/keys/api-jwt type=rsa-2048
-```
-```bash
-vault write transit/keys/api-jwt/config deletion_allowed=false
-```
-
-Confirm VSO materialised every VaultStaticSecret as a Kubernetes
-Secret:
+Once the bootstrap sequence has completed, confirm VSO materialised
+every VaultStaticSecret as a Kubernetes Secret:
 
 ```bash
 kubectl get vaultstaticsecret -A

--- a/platform/docs/vault-bootstrap.md
+++ b/platform/docs/vault-bootstrap.md
@@ -8,20 +8,24 @@ secrets remain unsynced until you complete the sequence.
 
 ```bash
 kubectl exec -n data-system vault-0 -- vault operator init \
-  -key-shares=1 -key-threshold=1 \
+  -key-shares=5 -key-threshold=3 \
   -format=json > /tmp/vault-init.json
 
-# Store both values somewhere safe (password manager).
-UNSEAL_KEY=$(jq -r '.unseal_keys_b64[0]' /tmp/vault-init.json)
-ROOT_TOKEN=$(jq -r '.root_token'          /tmp/vault-init.json)
+# Store ALL values OFFLINE (password manager, split across operators).
+# Never commit /tmp/vault-init.json; shred it after the keys are saved.
+ROOT_TOKEN=$(jq -r '.root_token' /tmp/vault-init.json)
 
-kubectl exec -n data-system vault-0 -- vault operator unseal "$UNSEAL_KEY"
+for i in 0 1 2; do
+  kubectl exec -n data-system vault-0 -- vault operator unseal \
+    "$(jq -r ".unseal_keys_b64[$i]" /tmp/vault-init.json)"
+done
 ```
 
-Single-replica Raft, so one unseal is enough. You must unseal again after
-every Vault pod restart (e.g. node reboot). Automate with
+Single-replica Raft, so the three unseal operations complete on the one
+pod. You must unseal again after every Vault pod restart (e.g. node
+reboot) — three of the five shares are required each time. Automate with
 [vault-unseal](https://github.com/lrstanley/vault-unseal) or store the
-unseal key in a cloud KMS later.
+unseal keys in a cloud KMS later.
 
 ## 2. Seed the bootstrap token
 
@@ -105,18 +109,51 @@ vault kv put secret/platform/mail \
 
 ### API third-party secrets
 
+The api Vault Agent template renders these into `/vault/secrets/api.env`
+at pod start (`platform/cluster/flux/apps/stateless/api/deployment.yaml`).
+Every key must exist; the template silently substitutes empty strings
+when a KV key is missing, which boots the pod with a broken integration.
+
 ```bash
 vault kv put secret/api \
-  brevo-api-key=<key> \
-  mollie-api-key=<key> \
-  google-calendar-sa-json=<base64-json> \
-  facebook-app-secret=<secret> \
-  x-api-secret=<secret> \
-  vault-oidc-client-secret=<random-secret>
+  jwt-secret=$(openssl rand -hex 32) \
+  brevo-api-key=<brevo-api-key> \
+  brevo-folder-contribution-periods-id=<brevo-folder-id> \
+  mollie-api-key=<mollie-api-key> \
+  google-calendar-id=<calendar-id> \
+  google-calendar-sa-json=<base64-encoded-sa-json> \
+  facebook-page-id=<facebook-page-id> \
+  facebook-access-token=<long-lived-page-token> \
+  x-api-key=<x-consumer-key> \
+  x-api-secret=<x-consumer-secret> \
+  x-access-token=<x-access-token> \
+  x-access-secret=<x-access-token-secret> \
+  discord-bot-token=<discord-bot-token> \
+  discord-guild-id=<discord-guild-id> \
+  vault-oidc-client-secret=$(openssl rand -hex 32)
 ```
 
-`vault-oidc-client-secret` is the shared secret the Vault OIDC auth method uses
-when calling back to the api. Generate with `openssl rand -hex 32`.
+Notes:
+
+- `jwt-secret` is the HMAC key the api uses to sign its own JWTs. Must be
+  at least 256 bits of entropy; `openssl rand -hex 32` is the baseline.
+- `vault-oidc-client-secret` is the shared secret the Vault OIDC auth
+  method uses when calling back to the api. It reaches the api via VSO
+  (`api-secrets` Kubernetes Secret) rather than the Vault Agent template,
+  so it must be seeded here even though it is not in the agent template.
+- `google-calendar-sa-json` is the full JSON contents of a Google service
+  account key, base64-encoded, without wrapping newlines.
+
+### Transit signing key (OIDC issuer)
+
+The api's OIDC issuer signs JWTs with a Vault-managed RSA key. The
+bootstrap Job grants the `api` policy `sign` on this key but does not
+create it (idempotency is cheaper than a pre-check).
+
+```bash
+vault write -f transit/keys/api-jwt type=rsa-2048
+vault write transit/keys/api-jwt/config deletion_allowed=false
+```
 
 ### GHCR pull credential (api + frontend Deployments)
 


### PR DESCRIPTION
## Summary

On `main`, the api's Vault Agent template renders **15 keys** from `secret/api`, but `platform/docs/vault-bootstrap.md` only seeded **6** — and one of those (`facebook-app-secret`) was dead. Following the doc end-to-end on a fresh cluster booted the api with empty env vars for JWT signing, Discord, X, Facebook Page, Google Calendar ID and the Brevo folder lookup, failing silently at first integration use. This PR aligns the runbook with reality before the old-VPS data migration.

### Secrets added to `vault-bootstrap.md` §API

`jwt-secret`, `brevo-folder-contribution-periods-id`, `google-calendar-id`, `facebook-page-id`, `facebook-access-token`, `x-api-key`, `x-access-token`, `x-access-secret`, `discord-bot-token`, `discord-guild-id` — all consumed by the agent template today, none previously seeded.

### Secrets removed

`facebook-app-secret` — never referenced by any template, code path or VSO sync.

### Other fixes in the same pass

- **Transit signing key step** lifted out of `bringup-v2.md` into `vault-bootstrap.md` so the canonical doc covers OIDC issuer setup end-to-end.
- **Unseal Shamir mismatch** reconciled: `vault-bootstrap.md` used `-key-shares=1 -key-threshold=1` while `bringup-v2.md` used `5/3`. Canonical doc now standardises on `5/3` and `bringup-v2.md` links to it instead of duplicating the block.
- **`jwt-secret` guarded with Consul-Template `required`** in the api agent-inject template. An empty HMAC silently produces cross-verifiable JWTs; every other integration key in the template fails loudly at first use, so only this line needs defensive rendering.
- **Comment hygiene** in `bootstrap-auth.sh` (path list wrong: `platform/api` → `api`, `platform/listmonk` → `listmonk`) and `stalwart-secrets.yaml` (described a Stalwart initContainer that doesn't exist; now accurately describes the secret's purpose).

### Known follow-ups (flagged in the updated `stalwart-secrets.yaml` comment, not fixed here)

- `dkim-private-key` is seeded in Vault KV but not rendered into the Stalwart config-template. Needs wiring before mail cutover.
- `bounce-mailbox-user`/`password` are referenced by the api (default ns) and listmonk setup job (default ns) via `secretKeyRef`, which is namespace-scoped. The `stalwart-secrets` k8s Secret only exists in `mail-system` today, so both references silently resolve to empty (they are marked `optional: true`). A second VSO sync into `default`, or a cross-namespace copy, is needed before bounce polling works in production.

## Test plan

- [ ] Diff `grep -rnh 'index .Data.data' platform/cluster/flux/apps/` against the new `vault kv put` commands — every rendered key must appear in a seed command.
- [ ] Diff `grep -rn 'secretKeyRef' platform/cluster/flux/apps/` against the seed commands — every referenced key must appear in the corresponding `secret/<path>` seed.
- [ ] On a throwaway cluster, init Vault, run the updated runbook verbatim, and confirm `kubectl get secret -n default api-secrets -o json | jq -r '.data | keys | length'` reports 15.
- [ ] On the same cluster, set `jwt-secret=""` in Vault and restart the api pod; confirm the Vault Agent init container fails with a `required` rendering error instead of the pod becoming Ready.