### PR TITLE
fix(platform): unstick traefik helmrelease + flatten ingressroute match

### DIFF
--- a/platform/cluster/flux/apps/core/traefik/release.yaml
+++ b/platform/cluster/flux/apps/core/traefik/release.yaml
@@ -24,8 +24,10 @@ spec:
     # Gatus probes it internally to confirm Traefik is alive without
     # going through the dashboard IngressRoute (which sits behind
     # forward-auth and would only ever 302 an anonymous prober).
-    ping:
-      enabled: true
+    # Chart 39.x removed the top-level `ping:` key — enable via the
+    # static-config CLI flag instead.
+    additionalArguments:
+      - "--ping=true"
     providers:
       kubernetesCRD:
         allowCrossNamespace: true

--- a/platform/cluster/flux/apps/edge/ingressroutes/api.yaml
+++ b/platform/cluster/flux/apps/edge/ingressroutes/api.yaml
@@ -35,13 +35,10 @@ spec:
   routes:
     - kind: Rule
       priority: 100
-      match: >-
-        Host(`v2.esa-blueshell.nl`) && (
-          PathPrefix(`/api/oauth2`) ||
-          PathPrefix(`/api/userinfo`) ||
-          Path(`/api/.well-known/openid-configuration`) ||
-          Path(`/api/.well-known/oauth-authorization-server`)
-        )
+      # Single line on purpose: Traefik's rule parser rejects embedded
+      # newlines, and YAML folded scalars (>-) preserve them when
+      # subsequent lines are more-indented than the first.
+      match: Host(`v2.esa-blueshell.nl`) && (PathPrefix(`/api/oauth2`) || PathPrefix(`/api/userinfo`) || Path(`/api/.well-known/openid-configuration`) || Path(`/api/.well-known/oauth-authorization-server`))
       middlewares:
         - name: strip-api-prefix
           namespace: edge-system

--- a/platform/cluster/flux/apps/edge/ingressroutes/traefik-dashboard.yaml
+++ b/platform/cluster/flux/apps/edge/ingressroutes/traefik-dashboard.yaml
@@ -14,12 +14,9 @@ spec:
   routes:
     # /api here is Traefik's own admin API, not ours — it lives on a
     # different host so there's no collision with v2.../api.
+    # Single line: Traefik's rule parser rejects embedded newlines.
     - kind: Rule
-      match: >-
-        Host(`traefik.esa-blueshell.nl`) && (
-          PathPrefix(`/dashboard`) ||
-          PathPrefix(`/api`)
-        )
+      match: Host(`traefik.esa-blueshell.nl`) && (PathPrefix(`/dashboard`) || PathPrefix(`/api`))
       services:
         - name: api@internal
           kind: TraefikService


### PR DESCRIPTION
## Summary

Two bugs from PR #156 that left Flux stuck on `apps-core` HealthCheckFailed for 15 min, blocking every downstream Kustomization (including the apps-edge IngressRoute updates from #156 itself):

1. **Traefik chart 39.0.8 rejected the top-level `ping:` key** — \`additional properties 'ping' not allowed\`. The chart removed it; the static-config CLI flag is the supported path. Switched to:
   ```yaml
   additionalArguments:
     - "--ping=true"
   ```

2. **IngressRoute `match:` had embedded newlines Traefik couldn't parse.** The YAML folded scalar (\`>-\`) only folds when subsequent lines are indented to the *same* column as the first; both `api.yaml` and `traefik-dashboard.yaml` had more-indented inner lines, so YAML preserved the `\n`. Traefik logs (continuous):
   ```
   error while parsing rule Host(\`v2.esa-blueshell.nl\`) && (\n\n  PathPrefix(\`/api\`) || ...
       7:50: expected ')', found newline
   ```
   Result: the `api` router never registered, `/api/*` fell through to the frontend SPA catch-all, OIDC discovery + JWKS + every REST call returned the SPA HTML 200. Flattened both match strings to single lines and added a comment explaining why.

This bug actually pre-existed in the OLD `api.yaml` too — same indentation pattern, same Traefik parse error in the logs going back days. PR #156 carried it forward; this PR fixes it for both routes.

## Test plan

- [ ] `apps-core` Kustomization goes Ready within ≤2 min of merge.
- [ ] `kubectl -n ingress-system get helmrelease traefik` → READY=True.
- [ ] `kubectl -n edge-system get ingressroute api,traefik-dashboard` both present, no parse errors in Traefik logs.
- [ ] `curl https://v2.esa-blueshell.nl/api/.well-known/openid-configuration | jq .issuer` → `https://v2.esa-blueshell.nl/api` (proves OIDC route now matches and StripPrefix works).
- [ ] `curl https://v2.esa-blueshell.nl/api/oauth2/jwks` → JSON, not SPA HTML.
- [ ] `curl https://v2.esa-blueshell.nl/api/health` → 200 plain-text (not SPA HTML).
- [ ] `dig +short auth.esa-blueshell.nl` → empty after external-dns reconcile.
- [ ] Gatus "Blueshell OIDC Discovery" green within one probe interval (assumes the api pod's pre-existing vault-agent template bug is also fixed — separate issue).

## Notes

- The api pod's `vault-agent-init` is still failing on the `required` template function (consul-template doesn't have it; that's Sprig). That's a separate bug, not addressed here. Until that's fixed, the OIDC discovery probe will still fail because the api pod has no endpoints — but at least Traefik will route correctly to the api Service so it'll work the moment api comes up.