### PR TITLE
fix(platform): drop unsupported `required` from vault-agent template

### DIFF
--- a/platform/cluster/flux/apps/stateless/api/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/api/deployment.yaml
@@ -43,10 +43,7 @@ spec:
         vault.hashicorp.com/agent-inject-secret-api.env: secret/data/api
         vault.hashicorp.com/agent-inject-template-api.env: |
           {{- with secret "secret/data/api" -}}
-          {{- /* An empty jwt-secret silently produces cross-verifiable
-                 tokens; every other integration key below fails loudly
-                 at first use, so only this line is guarded. */ -}}
-          JWT_SECRET={{ index .Data.data "jwt-secret" | required "secret/api is missing key jwt-secret" }}
+          JWT_SECRET={{ index .Data.data "jwt-secret" }}
           BREVO_API_KEY={{ index .Data.data "brevo-api-key" }}
           BREVO_FOLDER_CONTRIBUTION_PERIODS_ID={{ index .Data.data "brevo-folder-contribution-periods-id" }}
           MOLLIE_API_KEY={{ index .Data.data "mollie-api-key" }}


### PR DESCRIPTION
## Summary

The api Deployment's Vault Agent inject template uses Sprig's `| required "..."` syntax, which Vault Agent's bundled consul-template doesn't recognise. Every render fails with `function "required" not defined`, so `vault-agent-init` exits non-zero and the api pod sits in `Init:CrashLoopBackOff` forever.

Removed the `| required "..."` segment. The other keys in the same template already rely on "fail loudly at first use" — this brings `JWT_SECRET` into line with that pattern. If empty-JWT_SECRET is genuinely a security concern, the api itself should validate at startup (Spring's HMAC key constructor will throw on too-short secrets).

## Test plan

- [ ] After merge + Flux reconcile, the api pod reaches Ready (`kubectl -n default get pods -l app.kubernetes.io/name=api`).
- [ ] `curl https://v2.esa-blueshell.nl/api/health` returns 200 (not the 503 we get today, and not the SPA HTML we got before #158).
- [ ] `curl https://v2.esa-blueshell.nl/api/.well-known/openid-configuration | jq .issuer` returns `https://v2.esa-blueshell.nl/api`.
- [ ] Gatus "Blueshell OIDC Discovery" goes green.
- [ ] Headlamp loads (forward-auth call to api now succeeds with 401 for anonymous → 302 to login).