### PR TITLE
docs: add Day-0 secrets checklist to vault-bootstrap.md

### DIFF
--- a/platform/docs/bringup-v2.md
+++ b/platform/docs/bringup-v2.md
@@ -139,7 +139,13 @@ step 6 in parallel) → `apps-edge` / `apps-vso-secrets` /
 
 ## 6. Unseal Vault and seed secrets
 
-Port-forward and point the CLI at it:
+Before unsealing, gather every external token and dotenv file the seed
+flow needs — see the **Day-0 checklist** at the top of
+[`vault-bootstrap.md` §4](vault-bootstrap.md#4-seed-static-secrets).
+Doing this on the workstation first is much faster than discovering a
+missing `cloudflare.dns_api_token` mid-bootstrap.
+
+Port-forward and point the CLI at Vault:
 
 ```bash
 kubectl -n data-system port-forward svc/vault 8200:8200 &

--- a/platform/docs/vault-bootstrap.md
+++ b/platform/docs/vault-bootstrap.md
@@ -59,6 +59,47 @@ The Job is idempotent — you can re-run it safely after editing
 
 ## 4. Seed static secrets
 
+### Day-0 checklist (have these in hand before unsealing Vault)
+
+Each item below maps to one or more keys in §4.x — gather them once, in
+one local working directory, before starting the seed flow. Missing any
+of them blocks at least one downstream Secret.
+
+- **Old-VPS `.env` files** (operator-controlled, never committed). The
+  repo's `scripts/seed-vault-from-env.sh` reads dotenv-style files;
+  typical inventory:
+  - `services/api/.api.env` — `JWT_SECRET` (Base64, ≥64 bytes), Brevo,
+    Mollie, Google Calendar SA, Facebook, X, Discord tokens.
+  - `services/api/.db.env` — `MYSQL_ROOT_PASSWORD`, `MYSQL_USER`,
+    `MYSQL_PASSWORD`.
+  - `services/listmonk/.listmonk.env` — `LISTMONK_DB_PASSWORD`,
+    `LISTMONK_ADMIN_*`, optional `LISTMONK_SMTP_*` and bounce IMAP.
+- **Cloudflare DNS API token** with `Zone:DNS:Edit` scope on
+  `esa-blueshell.nl` (cert-manager DNS-01 + external-dns).
+- **GHCR pull credential**: GitHub username + a fine-grained PAT scoped
+  to `read:packages` on `ESA-Blueshell` (private api/frontend images).
+- **Stalwart admin user/password** + base64-encoded RSA-2048 DKIM
+  private key + bounce mailbox `bounce@v2.esa-blueshell.nl` credentials.
+- **One-shot generated values** (only if missing from the legacy env):
+  - `JWT_SECRET` — `openssl rand -base64 64`.
+  - `vault-oidc-client-secret` — `openssl rand -hex 32`.
+
+Sanity-check the env files locally with a dry run *before* unsealing:
+
+```bash
+scripts/seed-vault-from-env.sh \
+  /path/to/old/.api.env \
+  /path/to/old/.db.env \
+  /path/to/old/.listmonk.env \
+  /path/to/extra-tokens.env
+```
+
+The dry run prints every Vault path/field it would write. If a path
+shows up empty or with fewer fields than §4.x lists below, top up the
+env files and re-run the dry run.
+
+### Seed Vault
+
 These paths must exist in Vault before the corresponding VSO
 `VaultStaticSecret` CRs can sync. The VSO CRs loop on a 1h refresh and
 will eventually succeed once the paths are present; there is no need to


### PR DESCRIPTION
## Summary
- New **Day-0 checklist** at the top of `vault-bootstrap.md` §4 listing every external token, dotenv file, and one-shot generated value the operator needs before unsealing Vault.
- Includes a `seed-vault-from-env.sh` dry-run command to confirm the .env inventory covers every Vault path before going live.
- `bringup-v2.md` §6 now links to the checklist so the install flow surfaces missing tokens on the workstation, not mid-bootstrap.

Pure docs — no behaviour change. Fills a gap that bit the previous bring-up attempt (missing Cloudflare token discovered after Vault was already unsealed).

## Test plan
- [ ] CI green
- [ ] Walk through the checklist before the next clean install