### PR TITLE
platform: fold Vault OIDC auth method into bootstrap Job

### DIFF
--- a/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
+++ b/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
@@ -194,3 +194,40 @@ else
   echo "secret/platform/mariadb not seeded yet — skipping database/config/mariadb."
   echo "Seed with: vault kv put secret/platform/mariadb root-password=<secret> user=<app-user> password=<app-secret> admin-user=<db-admin> admin-password=<db-admin-secret>"
 fi
+
+# --- OIDC auth method (vault login -method=oidc) ------------------------
+#
+# `vault login -method=oidc` redirects the operator through the website
+# api as the IdP. The api's RegisteredClients registers the `vault`
+# client with the redirect URI below; the shared secret lives at
+# secret/api:vault-oidc-client-secret (seeded by
+# scripts/seed-vault-from-env.sh — see vault-bootstrap.md §4). The block
+# short-circuits when the field is missing so a fresh Vault install does
+# not block the Job on an unsatisfiable precondition; re-running the
+# Kustomization after seeding (or letting Flux reconcile on its 2 min
+# loop) picks it up on the next pass.
+
+if vault kv get -field=vault-oidc-client-secret secret/api >/dev/null 2>&1; then
+  if ! vault auth list -format=json | grep -q '"oidc/"'; then
+    vault auth enable oidc
+  fi
+
+  OIDC_CLIENT_SECRET=$(vault kv get -field=vault-oidc-client-secret secret/api)
+
+  vault write auth/oidc/config \
+    oidc_discovery_url="https://v2.esa-blueshell.nl/api" \
+    oidc_client_id="vault" \
+    oidc_client_secret="${OIDC_CLIENT_SECRET}" \
+    default_role="admin"
+
+  vault write auth/oidc/role/admin \
+    bound_audiences="vault" \
+    allowed_redirect_uris="https://vault.esa-blueshell.nl/ui/vault/auth/oidc/oidc/callback" \
+    user_claim="sub" \
+    policies="default"
+
+  unset OIDC_CLIENT_SECRET
+else
+  echo "secret/api:vault-oidc-client-secret not seeded yet — skipping OIDC auth method."
+  echo "Seed with: scripts/seed-vault-from-env.sh --apply <env-files...> (then re-run this Job via flux reconcile kustomization apps-data)."
+fi

--- a/platform/docs/bringup-v2.md
+++ b/platform/docs/bringup-v2.md
@@ -156,9 +156,10 @@ export VAULT_ADDR=http://127.0.0.1:8200
 
 Follow [`vault-bootstrap.md`](vault-bootstrap.md) end-to-end from §1
 (init + unseal, 5-of-3 Shamir) through §6 (revoke root token). That
-runbook is the canonical source for every `vault kv put` command and
-for the Transit signing key the OIDC issuer needs — keeping the detail
-in one place prevents the two docs from drifting.
+runbook is the canonical source for every `vault kv put` command;
+the bootstrap Job handles the Transit signing key, kubernetes auth
+roles, MariaDB dynamic-secrets engine, and OIDC auth method on its own
+once `secret/api` and `secret/platform/mariadb` are seeded.
 
 Once the bootstrap sequence has completed, confirm VSO materialised
 every VaultStaticSecret as a Kubernetes Secret:

--- a/platform/docs/vault-bootstrap.md
+++ b/platform/docs/vault-bootstrap.md
@@ -226,40 +226,33 @@ Notes:
   still has split `GOOGLE_CALENDAR_*` fields, the seeding script
   reconstructs the JSON for you; there is no separate Google-only script.
 
-### Transit signing key (OIDC issuer)
+### Transit signing key + Vault OIDC auth method (handled by the bootstrap Job)
 
-The api's OIDC issuer signs JWTs with a Vault-managed RSA key. The
-bootstrap Job grants the `api` policy `sign` on this key but does not
-create it (idempotency is cheaper than a pre-check).
+The bootstrap Job (`apps-data/vault/bootstrap-auth.sh`) already creates
+`transit/keys/api-jwt` (RSA-2048, used by the api's OIDC issuer to sign
+JWTs) and configures the `oidc` auth method that backs
+`vault login -method=oidc` — the operator does not run any `vault write`
+commands for either.
 
-```bash
-vault write -f transit/keys/api-jwt type=rsa-2048
-vault write transit/keys/api-jwt/config deletion_allowed=false
-```
-
-### Vault OIDC auth method (logging into Vault via the api)
-
-`vault login -method=oidc` redirects the operator through the
-website api as the IdP. Configure the auth method to point at the
-same-origin issuer:
+The OIDC step short-circuits when `secret/api:vault-oidc-client-secret`
+is missing, so on a fresh cluster the Job runs once before the seed
+script and again after it. After running `seed-vault-from-env.sh
+--apply`, trigger the Job to re-run:
 
 ```bash
-vault auth enable oidc 2>/dev/null || true
-vault write auth/oidc/config \
-  oidc_discovery_url="https://v2.esa-blueshell.nl/api" \
-  oidc_client_id="vault" \
-  oidc_client_secret="$(vault kv get -field=vault-oidc-client-secret secret/api)" \
-  default_role="admin"
-vault write auth/oidc/role/admin \
-  bound_audiences="vault" \
-  allowed_redirect_uris="https://vault.esa-blueshell.nl/ui/vault/auth/oidc/oidc/callback" \
-  user_claim="sub" \
-  policies="default"
+flux reconcile kustomization apps-data
 ```
 
-The redirect URI must match the one registered in
-`RegisteredClients.kt:47`. The client secret was seeded above with
-`openssl rand -hex 32` under `vault-oidc-client-secret`.
+If you ever need to inspect or override the OIDC config manually:
+
+```bash
+vault read auth/oidc/config
+vault read auth/oidc/role/admin
+```
+
+The redirect URI baked into the role is
+`https://vault.esa-blueshell.nl/ui/vault/auth/oidc/oidc/callback`; it
+must match the `vault` client registered in `RegisteredClients.kt`.
 
 ### GHCR pull credential (api + frontend Deployments)
 


### PR DESCRIPTION
## Summary
- Adds the OIDC auth method config (`vault auth enable oidc`, `auth/oidc/config`, `auth/oidc/role/admin`) to `bootstrap-auth.sh` with the same lazy-config idempotency pattern as the MariaDB dynamic-secrets block: short-circuits if `secret/api:vault-oidc-client-secret` is missing, configures everything once it exists.
- Removes the matching manual `vault write` block from `vault-bootstrap.md` §4. Operator no longer touches the OIDC auth method by hand.
- Drops the now-redundant "Transit signing key" subsection — the bootstrap Job has been creating `transit/keys/api-jwt` since the original PR; the doc was stale.
- Updates `bringup-v2.md` §6 to reflect the smaller manual surface.

## Why
After this lands, a clean install needs exactly: unseal Vault → seed Vault (`scripts/seed-vault-from-env.sh --apply <env-files...>`) → `flux reconcile kustomization apps-data`. No `vault write auth/oidc/*` commands, no manual transit key creation. The Job picks up its own re-run via the kustomize content-hash annotation.

## Test plan
- [x] `sh -n bootstrap-auth.sh` clean
- [x] `kubectl kustomize platform/cluster/flux/apps/data` builds; ConfigMap hash changes (force re-run on next reconcile)
- [ ] CI green
- [ ] Validate end-to-end on the next clean v2 bring-up: seed Vault, `flux reconcile kustomization apps-data`, then `vault read auth/oidc/config` shows the configured issuer