### PR TITLE
flux: switch GitRepository auth from HTTPS PAT to SSH deploy key

### DIFF
--- a/platform/cluster/flux/clusters/production/flux-system/gotk-sync.yaml
+++ b/platform/cluster/flux/clusters/production/flux-system/gotk-sync.yaml
@@ -3,6 +3,15 @@
 # back to main; reconciliation only pulls from here. If the repo moves
 # or the branch changes, update the url/branch fields and
 # `kubectl apply -k platform/cluster/flux/clusters/production/flux-system/`.
+#
+# Auth: SSH deploy key (read-only). The flux-system Secret holds three
+# keys consumed by source-controller:
+#   - identity      (PEM private key)
+#   - identity.pub  (matching public key registered as a deploy key on
+#                    https://github.com/ESA-Blueshell/website/settings/keys)
+#   - known_hosts   (`ssh-keyscan github.com`)
+# Switched away from an HTTPS PAT so the cluster credential is scoped
+# to this single repo, read-only, and not tied to an operator account.
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
@@ -14,7 +23,7 @@ spec:
     branch: main
   secretRef:
     name: flux-system
-  url: https://github.com/ESA-Blueshell/website
+  url: ssh://git@github.com/ESA-Blueshell/website
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization


### PR DESCRIPTION
## Summary
- `gotk-sync.yaml` GitRepository URL: `https://github.com/ESA-Blueshell/website` → `ssh://git@github.com/ESA-Blueshell/website`.
- Doc comment in the manifest now describes the three keys the cluster Secret carries: `identity`, `identity.pub`, `known_hosts`.

## Why
The cluster credential was a personal `gh auth token` with `repo`/`workflow`/`gist` scope tied to the operator account. Replace with a per-repo, read-only ed25519 deploy key. Smaller blast radius if the cluster Secret leaks; no rotation churn when an operator's account changes.

Deploy key already added to https://github.com/ESA-Blueshell/website/settings/keys (read-only). The matching cluster Secret is created out-of-band by the operator after merge.

## Test plan
- [ ] CI green
- [ ] After merge: re-apply `platform/cluster/flux/clusters/production/flux-system/`, recreate the `flux-system` Secret with `identity` / `identity.pub` / `known_hosts`, watch source-controller pull over SSH (`flux get sources git -A`)