### PR TITLE
scripts/ci: bash-3.2-friendly seed script + scope openapi-sync to Blueshell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,13 +505,23 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           yarn-version: ${{ env.YARN_VERSION }}
 
-      - name: Generate OpenAPI spec and frontend clients
+      - name: Generate Blueshell OpenAPI spec and frontend client
         run: |
           chmod +x ./scripts/generate-openapi-local.sh
-          ./scripts/generate-openapi-local.sh
+          # External specs (Discord, Brevo) drift too frequently upstream
+          # to gate every PR on. The scheduled workflow
+          # `openapi-external-specs.yml` validates them on a weekly
+          # cadence on main and surfaces drift for a human-driven
+          # update PR.
+          ./scripts/generate-openapi-local.sh --blueshell-only
 
-      - name: Assert OpenAPI spec and client are in sync
-        run: git diff --exit-code -- services/api/openapi.json libs/openapi-specs services/frontend/src/services/api
+      - name: Assert Blueshell spec and client are in sync
+        run: |
+          git diff --exit-code -- \
+            services/api/openapi.json \
+            services/frontend/src/services/api/blueshell \
+            services/frontend/src/services/api/blueshell.runtime.ts \
+            services/frontend/src/services/api/index.ts
 
       - name: Upload OpenAPI generation logs
         if: failure()

--- a/.github/workflows/openapi-external-specs.yml
+++ b/.github/workflows/openapi-external-specs.yml
@@ -1,0 +1,184 @@
+name: OpenAPI external specs check
+
+# CI's openapi-sync job only validates the Blueshell spec — Discord and
+# Brevo drift too frequently upstream to gate every PR on. This workflow
+# runs the full regen on main weekly (and on demand), flags any external
+# spec drift by opening a tracking issue, and otherwise stays silent.
+# Refresh the specs locally with `./scripts/generate-openapi-local.sh`
+# (no flag) and open a PR.
+
+on:
+  schedule:
+    # Mondays at 06:00 UTC. Adjust if you want a different cadence.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+  JAVA_VERSION: '21'
+  NODE_VERSION: '22'
+  YARN_VERSION: '4.10.3'
+
+  MYSQL_ROOT_PASSWORD: blueshell
+  MYSQL_DATABASE: blueshell-test
+  MYSQL_PORT: '3306'
+  MYSQL_USER: blueshell
+  MYSQL_PASSWORD: ci-blueshell
+  MYSQL_HOST: 127.0.0.1
+
+  APP_URL: http://127.0.0.1:8080
+  FRONTEND_URL: http://127.0.0.1:3000
+
+  JWT_SECRET: YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh
+  STORAGE_LOCATION: ./storage
+  BREVO_API_KEY: something
+  BREVO_FOLDER_CONTRIBUTION_PERIODS_ID: '1234'
+
+  GRADLE_OPTS: -Xmx2048m -XX:MaxMetaspaceSize=512m
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  external-spec-drift:
+    name: Detect Discord/Brevo spec drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      db:
+        image: mariadb:10.11.10
+        ports: [ "3306:3306" ]
+        env:
+          MYSQL_ROOT_PASSWORD: ${{ env.MYSQL_ROOT_PASSWORD }}
+          MYSQL_DATABASE: ${{ env.MYSQL_DATABASE }}
+          MYSQL_PORT: ${{ env.MYSQL_PORT }}
+          MYSQL_USER: ${{ env.MYSQL_USER }}
+          MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+          --health-start-period=30s
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Wait for database service
+        run: |
+          sudo apt-get update && sudo apt-get install -y default-mysql-client
+          for i in {1..30}; do
+            if mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -uroot -p"$MYSQL_ROOT_PASSWORD" -e "SELECT 1;" >/dev/null 2>&1; then
+              echo "Database is ready!"
+              exit 0
+            fi
+            echo "Waiting for database... ($i/30)"
+            sleep 2
+          done
+          echo "Database did not become ready in time."
+          exit 1
+
+      - name: Prepare test database schema
+        run: |
+          mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -uroot -p"$MYSQL_ROOT_PASSWORD" < services/api/0_init.sql
+
+      - name: Set up Java Development Kit
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Set up Node.js and Yarn
+        uses: ./.github/actions/setup-node-yarn
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          yarn-version: ${{ env.YARN_VERSION }}
+
+      - name: Run full OpenAPI regen (Blueshell + Discord + Brevo + Listmonk)
+        run: |
+          chmod +x ./scripts/generate-openapi-local.sh
+          ./scripts/generate-openapi-local.sh
+
+      - name: Detect external-spec drift
+        id: drift
+        run: |
+          # Only flag drift in files we don't own — the Blueshell paths
+          # are validated on every PR by `openapi-sync` in ci.yml.
+          if git diff --quiet -- \
+              libs/openapi-specs \
+              services/frontend/src/services/api/discord \
+              services/frontend/src/services/api/discord.runtime.ts; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+            echo "No external spec drift detected."
+          else
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+            {
+              echo 'External OpenAPI specs drifted from upstream. Diff (paths only):'
+              echo
+              git diff --stat -- \
+                libs/openapi-specs \
+                services/frontend/src/services/api/discord \
+                services/frontend/src/services/api/discord.runtime.ts
+            } | tee drift-summary.txt
+          fi
+
+      - name: Open tracking issue on drift
+        if: steps.drift.outputs.drift == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          summary="$(cat drift-summary.txt)"
+          # Only one open tracking issue at a time — re-use the existing
+          # one if any (avoid spamming on every weekly run).
+          # Idempotently ensure the marker label exists.
+          gh label create openapi-external-spec-drift \
+            --color FBCA04 \
+            --description "Upstream OpenAPI spec drift detected by scheduled workflow" \
+            2>/dev/null || true
+
+          existing="$(gh issue list \
+            --label openapi-external-spec-drift \
+            --state open \
+            --limit 1 \
+            --json number \
+            --jq '.[0].number // empty')"
+
+          body=$(cat <<EOF
+          The scheduled \`openapi-external-specs\` workflow detected drift in upstream Discord/Brevo OpenAPI specs.
+
+          **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          \`\`\`
+          ${summary}
+          \`\`\`
+
+          **To resolve:** run \`./scripts/generate-openapi-local.sh\` locally (no flag), commit the regenerated files (\`libs/openapi-specs\`, \`services/frontend/src/services/api/discord\`, generated Java clients), and open a PR.
+          EOF
+          )
+
+          if [ -n "$existing" ]; then
+            echo "Updating existing tracking issue #$existing"
+            gh issue comment "$existing" --body "$body"
+          else
+            echo "Opening new tracking issue"
+            gh issue create \
+              --title "OpenAPI external spec drift detected" \
+              --label openapi-external-spec-drift \
+              --label dependencies \
+              --assignee ExtraToast \
+              --body "$body"
+          fi
+
+      - name: Upload generation log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi-external-specs-log
+          path: openapi-api.log
+          if-no-files-found: ignore

--- a/scripts/generate-openapi-local.sh
+++ b/scripts/generate-openapi-local.sh
@@ -2,6 +2,13 @@
 # Generates the OpenAPI spec by starting the API locally via Gradle bootRun,
 # downloads external specs, regenerates the Brevo client,
 # and generates frontend TypeScript clients.
+#
+# Pass --blueshell-only (or set BLUESHELL_ONLY=true) to skip everything
+# external: no Discord/Brevo download, no Java client regen for those,
+# only the Blueshell spec + frontend Blueshell client. CI uses this mode
+# because upstream Discord/Brevo specs change too often to gate every PR
+# on; a separate scheduled workflow validates the external regen on
+# main and surfaces drift for a human-driven update PR.
 
 set -euo pipefail
 
@@ -10,6 +17,14 @@ cd "$ROOT_DIR"
 
 # shellcheck source=scripts/openapi-common.sh
 source "$ROOT_DIR/scripts/openapi-common.sh"
+
+BLUESHELL_ONLY="${BLUESHELL_ONLY:-false}"
+for arg in "$@"; do
+  case "$arg" in
+    --blueshell-only) BLUESHELL_ONLY=true ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
 
 # ---- Configuration ----
 
@@ -76,18 +91,28 @@ fi
 
 # ---- Shared steps ----
 
-download_external_specs
-regen_brevo_client
-regen_listmonk_client
-normalize_specs
+if [ "$BLUESHELL_ONLY" = "true" ]; then
+  normalize_api_spec
+else
+  download_external_specs
+  regen_brevo_client
+  regen_listmonk_client
+  normalize_specs
+fi
 
 # ---- Generate frontend TypeScript clients ----
 
 echo "Installing frontend dependencies..."
 yarn --cwd services/frontend install
 
-echo "Generating frontend TypeScript clients..."
-yarn --cwd services/frontend gen:all
-yarn --cwd services/frontend lint:gen || true
+if [ "$BLUESHELL_ONLY" = "true" ]; then
+  echo "Generating frontend TypeScript Blueshell client (skipping external specs)..."
+  yarn --cwd services/frontend gen:blueshell
+  yarn --cwd services/frontend lint:gen || true
+else
+  echo "Generating frontend TypeScript clients..."
+  yarn --cwd services/frontend gen:all
+  yarn --cwd services/frontend lint:gen || true
+fi
 
 echo "OpenAPI spec and frontend clients generated successfully."

--- a/scripts/openapi-common.sh
+++ b/scripts/openapi-common.sh
@@ -45,10 +45,10 @@ regen_listmonk_client() {
   ./gradlew --no-daemon --build-cache :services:api:clients:listmonk:generate
 }
 
-# Normalizes the API spec and discord.raw.json in-place.
-# Expects the caller to have written the API spec (or raw JSON) and discord.raw.json before calling.
-normalize_specs() {
-  echo "Normalizing OpenAPI spec files..."
+# Normalizes the Blueshell API spec in-place. Caller must have written
+# either the normalized spec or its `.raw.json` upstream.
+normalize_api_spec() {
+  echo "Normalizing Blueshell OpenAPI spec..."
   local tmp
   tmp="$(mktemp)"
 
@@ -62,7 +62,21 @@ normalize_specs() {
     rm -f "$tmp"
     exit 1
   fi
+}
+
+# Normalizes the Discord spec in-place. Caller must have downloaded
+# discord.raw.json upstream (download_external_specs).
+normalize_discord_spec() {
+  echo "Normalizing Discord OpenAPI spec..."
+  local tmp
+  tmp="$(mktemp)"
 
   jq -S -c . "$SHARED_OPENAPI_DIR/discord.raw.json" > "$tmp" && mv "$tmp" "$SHARED_OPENAPI_DIR/discord.json"
   rm -f "$SHARED_OPENAPI_DIR/discord.raw.json"
+}
+
+# Convenience: normalize both Blueshell + Discord specs.
+normalize_specs() {
+  normalize_api_spec
+  normalize_discord_spec
 }

--- a/scripts/seed-vault-from-env.sh
+++ b/scripts/seed-vault-from-env.sh
@@ -318,10 +318,12 @@ if [[ "$SYNC_API" -eq 1 ]]; then
   done
 fi
 
-for file in "${FILES[@]}"; do
-  [[ -f "$file" ]] || { echo "env file not found: $file" >&2; exit 1; }
-  load_env_file "$file"
-done
+if (( ${#FILES[@]} > 0 )); then
+  for file in "${FILES[@]}"; do
+    [[ -f "$file" ]] || { echo "env file not found: $file" >&2; exit 1; }
+    load_env_file "$file"
+  done
+fi
 
 API_ARGS=()
 API_FIELDS=()


### PR DESCRIPTION
## Summary
- **`scripts/seed-vault-from-env.sh`**: guard the file-iteration loop so an empty `FILES` array doesn't trip `set -u` on bash 3.2 (macOS default `/bin/bash`). Hit during the v2 bring-up when bash-sourcing the legacy `.api.env` (multi-line PEM the per-line parser can't handle) and falling back to the documented "use current shell env" path. Bash 4+ users are unaffected.
- **`scripts/generate-openapi-local.sh`**: add `--blueshell-only` mode (also `BLUESHELL_ONLY=true`). Skips Discord/Brevo download + Java client regen and only runs `yarn gen:blueshell`. Default behaviour unchanged.
- **`scripts/openapi-common.sh`**: split `normalize_specs()` into `normalize_api_spec` + `normalize_discord_spec`; `normalize_specs` still works as a convenience that calls both.
- **`.github/workflows/ci.yml`**: `openapi-sync` now runs with `--blueshell-only` and the diff assertion is scoped to `services/api/openapi.json` + the frontend Blueshell client. PRs no longer fail because Discord or Brevo upstream rev'd a comment overnight.
- **`.github/workflows/openapi-external-specs.yml`** (new): scheduled weekly (Mondays 06:00 UTC) + `workflow_dispatch`. Runs the full regen, detects drift in `libs/openapi-specs` + the frontend Discord client, opens (or comments on) a tracking issue with the diffstat. Resolution: run `./scripts/generate-openapi-local.sh` locally (no flag), commit, open a PR.

## Why
External Discord/Brevo OpenAPI specs change too often to gate every PR on; it produced false-positive failures unrelated to the work in the PR. CI still validates the only spec we own (Blueshell). The scheduled workflow surfaces external drift on its own cadence so we can refresh those clients deliberately.

## Test plan
- [x] `bash --version` 3.2.x: `./scripts/seed-vault-from-env.sh` (no args, env vars exported) runs and prints the dry-run preview without `unbound variable`
- [x] `./scripts/generate-openapi-local.sh --blueshell-only` skips Discord/Brevo download (verified locally)
- [ ] CI green on this PR (validates the new Blueshell-only path end-to-end)
- [ ] Trigger `openapi-external-specs.yml` via `workflow_dispatch` after merge to confirm full path works and (if drift) opens an issue