### PR TITLE
platform: tolerate api OIDC discovery URL not yet reachable on fresh cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ services/**/*.env
 # negate the broad patterns above that would otherwise eat it.
 !platform/
 !platform/**
+# GHCR pull-PAT used during v2 bring-up
+.ghcr_token

--- a/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
+++ b/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
@@ -214,17 +214,28 @@ if vault kv get -field=vault-oidc-client-secret secret/api >/dev/null 2>&1; then
 
   OIDC_CLIENT_SECRET=$(vault kv get -field=vault-oidc-client-secret secret/api)
 
-  vault write auth/oidc/config \
-    oidc_discovery_url="https://v2.esa-blueshell.nl/api" \
-    oidc_client_id="vault" \
-    oidc_client_secret="${OIDC_CLIENT_SECRET}" \
-    default_role="admin"
-
-  vault write auth/oidc/role/admin \
-    bound_audiences="vault" \
-    allowed_redirect_uris="https://vault.esa-blueshell.nl/ui/vault/auth/oidc/oidc/callback" \
-    user_claim="sub" \
-    policies="default"
+  # Vault validates `oidc_discovery_url` at write time by fetching the
+  # issuer's discovery document. On a fresh cluster the api Deployment
+  # only comes up *after* apps-data is Ready (apps-stateless depends on
+  # apps-data), so the URL is unreachable during the very first run of
+  # this Job. Tolerate that failure so the Job exits 0; the next
+  # reconcile (after apps-stateless lands) re-runs this script
+  # idempotently and the write succeeds.
+  if vault write auth/oidc/config \
+      oidc_discovery_url="https://v2.esa-blueshell.nl/api" \
+      oidc_client_id="vault" \
+      oidc_client_secret="${OIDC_CLIENT_SECRET}" \
+      default_role="admin"; then
+    vault write auth/oidc/role/admin \
+      bound_audiences="vault" \
+      allowed_redirect_uris="https://vault.esa-blueshell.nl/ui/vault/auth/oidc/oidc/callback" \
+      user_claim="sub" \
+      policies="default"
+  else
+    echo "auth/oidc/config write failed (api OIDC discovery URL likely not"
+    echo "reachable yet — fresh cluster, apps-stateless not Ready). Skipping"
+    echo "OIDC role write; the next reconcile re-runs this Job idempotently."
+  fi
 
   unset OIDC_CLIENT_SECRET
 else


### PR DESCRIPTION
## Summary
- `bootstrap-auth.sh` OIDC block: wrap `vault write auth/oidc/config` in an `if` so a 400 from Vault's discovery-URL fetch is caught instead of aborting the script (`set -e`).
- Gitignore `.ghcr_token` (operator-local file used to feed the GHCR PAT into `seed-vault-from-env.sh` during bring-up).

## Why
PR #163 folded the OIDC auth-method config into the bootstrap Job, but a fresh cluster hits a hard ordering bug:
1. Vault's `vault write auth/oidc/config` validates `oidc_discovery_url` at write time by fetching the issuer's `/.well-known/openid-configuration`.
2. The api only comes up after apps-data is Ready (apps-stateless depends on apps-data), so the URL is unreachable when the bootstrap Job first runs.
3. Vault returns `400: error checking oidc discovery URL`, the script exits non-zero, the Job is Failed, apps-data never reaches Ready, apps-stateless never starts → permanent stall.

Caught this on the live v2 bring-up. With this fix the Job exits 0 with an explicit "skipping OIDC role write" log; the next reconcile of apps-data (after apps-stateless lands) re-runs the script idempotently and the OIDC config write succeeds with the api now reachable. Same lazy-config pattern as the MariaDB engine block above it.

## Test plan
- [x] Live cluster: Job runs to Complete (1/1) with the patched script; logs show "skipping OIDC role write" before api is up
- [ ] CI green
- [ ] After apps-stateless Ready: `vault read auth/oidc/config` returns the configured issuer