### PR TITLE
platform: repair-bundle for clean v2 install (6 bugs)

### DIFF
--- a/platform/cluster/flux/apps/core/cloudflare-vss.yaml
+++ b/platform/cluster/flux/apps/core/cloudflare-vss.yaml
@@ -1,6 +1,19 @@
 # cert-manager reads cloudflare-api-token.api-token to satisfy DNS-01
 # challenges for *.v2.esa-blueshell.nl. external-dns reads the same secret
-# shape to manage A/AAAA records. VSO syncs both from the same Vault path.
+# shape to manage A/AAAA records. VSO syncs both from the same Vault path
+# (`secret/platform/edge:cloudflare.dns_api_token`).
+#
+# The CRs live in apps-core (alongside the cert-manager + external-dns
+# HelmReleases that consume them) rather than in apps-vso-secrets,
+# because the cert-manager / external-dns Deployments wedge in
+# CreateContainerConfigError until this Secret exists, which would
+# block apps-core Ready and (transitively) every downstream
+# Kustomization. Same self-bootstrapping pattern PR #161 applied to
+# the MariaDB / listmonk-db credentials. apps-core's VSO HelmRelease
+# disables wait, so the Deployment is Ready before VSO starts
+# materialising — VSO retries on its own backoff once Vault is
+# unsealed and the bootstrap Job has wired up the kubernetes auth
+# role for VSO.
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/platform/cluster/flux/apps/core/kustomization.yaml
+++ b/platform/cluster/flux/apps/core/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - external-dns
   - traefik
   - vso
+  - cloudflare-vss.yaml

--- a/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
+++ b/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
@@ -53,6 +53,29 @@ path "secret/data/api/*" {
   capabilities = ["read"]
 }
 
+# Spring Cloud Vault's KV backend probes secret/<spring.application.name>
+# (= "BlueshellAPI"), secret/<...>/<active-profile>, secret/application,
+# and secret/application/<active-profile> on every startup. None of those
+# paths are seeded — but a 403 on the lookup is fatal to the boot
+# sequence (the Vault property source aborts), while a 404 is a benign
+# INFO log. Granting read here turns the deny-by-default into a 404.
+# These four paths are intentionally never written.
+path "secret/data/application" {
+  capabilities = ["read"]
+}
+
+path "secret/data/application/*" {
+  capabilities = ["read"]
+}
+
+path "secret/data/BlueshellAPI" {
+  capabilities = ["read"]
+}
+
+path "secret/data/BlueshellAPI/*" {
+  capabilities = ["read"]
+}
+
 path "database/creds/api" {
   capabilities = ["read"]
 }

--- a/platform/cluster/flux/apps/stateless/api/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/api/deployment.yaml
@@ -41,29 +41,42 @@ spec:
         vault.hashicorp.com/agent-pre-populate-only: 'true'
         vault.hashicorp.com/role: api
         vault.hashicorp.com/agent-inject-secret-api.env: secret/data/api
+        # Every value is single-quoted and `| default ""` so a missing
+        # KV field renders as `KEY=''` instead of the literal
+        # `<no value>` consul-template default — `<` / `>` are shell
+        # redirection and would crash `. /vault/secrets/api.env` with
+        # `syntax error: unexpected newline`. Single quotes also tame
+        # any `=`, `{`, `}`, `"`, `\n` etc. that legit values carry
+        # (Brevo keys, Google service-account JSON). Google-generated
+        # JSON doesn't contain raw single quotes; if a future rotation
+        # does, base64-encode that one field in Vault and decode in
+        # the start script.
+        #
+        # MYSQL_USER / MYSQL_PASSWORD live in `secret/api` as
+        # `mysql-user` / `mysql-password` (mirrored by
+        # scripts/seed-vault-from-env.sh from the same MYSQL_USER /
+        # MYSQL_PASSWORD env vars that feed `secret/platform/mariadb`).
+        # Future work: re-enable Spring Cloud Vault dynamic creds
+        # (`spring.cloud.vault.database.enabled=true`) once that
+        # integration is fixed and drop these two fields again.
         vault.hashicorp.com/agent-inject-template-api.env: |
           {{- with secret "secret/data/api" -}}
-          JWT_SECRET={{ index .Data.data "jwt-secret" }}
-          BREVO_API_KEY={{ index .Data.data "brevo-api-key" }}
-          BREVO_FOLDER_CONTRIBUTION_PERIODS_ID={{ index .Data.data "brevo-folder-contribution-periods-id" }}
-          MOLLIE_API_KEY={{ index .Data.data "mollie-api-key" }}
-          GOOGLE_CALENDAR_ID={{ index .Data.data "google-calendar-id" }}
-          # application.yaml binds ${GOOGLE_CALENDAR_SA_JSON} directly
-          # into google.calendar.serviceAccountJson. Single-quote the
-          # value so the shell tolerates the braces, double quotes and
-          # backslash-n escapes that appear in a Google service-account
-          # JSON. Google-generated JSON doesn't contain single quotes;
-          # if a future rotation does, base64-encode it in Vault and
-          # decode in the start script.
-          GOOGLE_CALENDAR_SA_JSON='{{ index .Data.data "google-calendar-sa-json" }}'
-          FACEBOOK_PAGE_ID={{ index .Data.data "facebook-page-id" }}
-          FACEBOOK_ACCESS_TOKEN={{ index .Data.data "facebook-access-token" }}
-          X_API_KEY={{ index .Data.data "x-api-key" }}
-          X_API_SECRET={{ index .Data.data "x-api-secret" }}
-          X_ACCESS_TOKEN={{ index .Data.data "x-access-token" }}
-          X_ACCESS_SECRET={{ index .Data.data "x-access-secret" }}
-          DISCORD_BOT_TOKEN={{ index .Data.data "discord-bot-token" }}
-          DISCORD_GUILD_ID={{ index .Data.data "discord-guild-id" }}
+          JWT_SECRET='{{ index .Data.data "jwt-secret" | default "" }}'
+          BREVO_API_KEY='{{ index .Data.data "brevo-api-key" | default "" }}'
+          BREVO_FOLDER_CONTRIBUTION_PERIODS_ID='{{ index .Data.data "brevo-folder-contribution-periods-id" | default "" }}'
+          MOLLIE_API_KEY='{{ index .Data.data "mollie-api-key" | default "" }}'
+          GOOGLE_CALENDAR_ID='{{ index .Data.data "google-calendar-id" | default "" }}'
+          GOOGLE_CALENDAR_SA_JSON='{{ index .Data.data "google-calendar-sa-json" | default "" }}'
+          FACEBOOK_PAGE_ID='{{ index .Data.data "facebook-page-id" | default "" }}'
+          FACEBOOK_ACCESS_TOKEN='{{ index .Data.data "facebook-access-token" | default "" }}'
+          X_API_KEY='{{ index .Data.data "x-api-key" | default "" }}'
+          X_API_SECRET='{{ index .Data.data "x-api-secret" | default "" }}'
+          X_ACCESS_TOKEN='{{ index .Data.data "x-access-token" | default "" }}'
+          X_ACCESS_SECRET='{{ index .Data.data "x-access-secret" | default "" }}'
+          DISCORD_BOT_TOKEN='{{ index .Data.data "discord-bot-token" | default "" }}'
+          DISCORD_GUILD_ID='{{ index .Data.data "discord-guild-id" | default "" }}'
+          MYSQL_USER='{{ index .Data.data "mysql-user" | default "" }}'
+          MYSQL_PASSWORD='{{ index .Data.data "mysql-password" | default "" }}'
           {{- end }}
     spec:
       serviceAccountName: api
@@ -96,8 +109,18 @@ spec:
               value: vault://
             - name: VAULT_ENABLED
               value: 'true'
-            - name: VAULT_DB_ENABLED
-              value: 'true'
+            # VAULT_DB_ENABLED intentionally omitted (defaults to false
+            # via application.yaml). Spring Cloud Vault dynamic MariaDB
+            # creds (`database/creds/api`) are wired up by
+            # bootstrap-auth.sh and the Vault role works end-to-end,
+            # but `spring.cloud.vault.database.enabled=true` does not
+            # actually rebind `spring.datasource.{username,password}`
+            # in the version we ship — the api falls back to the
+            # `${MYSQL_USER:root}` placeholder default and connects
+            # with no password. Static creds via the Vault Agent
+            # template (MYSQL_USER / MYSQL_PASSWORD fields above) are
+            # the path used today; flip this back on once the dynamic-
+            # creds integration is debugged.
             - name: MYSQL_HOST
               value: mariadb.data-system.svc.cluster.local
             - name: MYSQL_PORT

--- a/platform/cluster/flux/apps/stateless/listmonk/setup-job.yaml
+++ b/platform/cluster/flux/apps/stateless/listmonk/setup-job.yaml
@@ -14,10 +14,22 @@ rules:
   # the target lets RBAC block anything outside the script's happy path
   # — a future bug or rogue edit can't pivot to deleting arbitrary pods
   # or reading unrelated Secrets.
+  #
+  # `create` and `resourceNames` are not compatible: Kubernetes RBAC
+  # only sees the resource name on requests that put it in the URL
+  # (get / update / patch / delete). On `create`, the name is in the
+  # request body — the RBAC check happens before the body is parsed,
+  # so `resourceNames` matches nothing and the rule denies. Split into
+  # an unscoped `create` rule (Secrets in this namespace only — the
+  # script only ever creates `listmonk-api-token`) plus the narrow
+  # name-scoped `get` / `patch` rule.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
   - apiGroups: [""]
     resources: ["secrets"]
     resourceNames: ["listmonk-api-token"]
-    verbs: ["get", "create", "patch"]
+    verbs: ["get", "patch"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
     resourceNames: ["api"]

--- a/platform/cluster/flux/apps/vso-secrets/kustomization.yaml
+++ b/platform/cluster/flux/apps/vso-secrets/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - cloudflare.yaml
   - api-secrets.yaml
   - listmonk-secrets.yaml
   - stalwart-secrets.yaml

--- a/platform/docs/vault-bootstrap.md
+++ b/platform/docs/vault-bootstrap.md
@@ -307,3 +307,65 @@ You can regenerate a new root token at any time from the unseal key:
 ```bash
 vault operator generate-root -init
 ```
+
+## 7. Rotating credentials
+
+Every Vault path consumed by an app is rendered into the running pod
+either by VSO (k8s Secret) or the Vault Agent injector
+(`/vault/secrets/*.env`). Both modes are pre-populate-only — neither
+auto-rolls a pod when the source changes — so the rotation pattern is
+always: *update Vault, then restart the consumer.*
+
+### MariaDB password (api + Bitnami chart)
+
+The api reads `MYSQL_USER` / `MYSQL_PASSWORD` from `secret/api`
+(rendered into `/vault/secrets/api.env` by the Vault Agent template in
+`apps/stateless/api/deployment.yaml`). The Bitnami MariaDB chart reads
+the same value from `secret/platform/mariadb` via VSO. Keep the two
+fields in lockstep:
+
+```bash
+NEW=<new-password>
+vault kv patch secret/api               mysql-password="$NEW"
+vault kv patch secret/platform/mariadb  password="$NEW"
+
+ROOT=$(vault kv get -field=root-password secret/platform/mariadb)
+kubectl -n data-system exec mariadb-0 -- \
+  mysql -uroot -p"$ROOT" -e \
+  "ALTER USER 'blueshell'@'%' IDENTIFIED BY '$NEW'; FLUSH PRIVILEGES;"
+
+kubectl -n default rollout restart deployment/api
+```
+
+The `mariadb-credentials` k8s Secret picks up the new value on VSO's
+next refresh (within 1 h, or trigger immediately with the
+`vso.secrets.hashicorp.com/force-refresh` annotation).
+
+### Other Vault paths
+
+Same shape, narrower blast radius:
+
+| Path | Consumers | Restart |
+|---|---|---|
+| `secret/api` | api Deployment | `kubectl -n default rollout restart deployment/api` |
+| `secret/listmonk` | listmonk Deployment, listmonk-db chart | `kubectl -n default rollout restart deployment/listmonk` (+ `data-system listmonk-db-postgresql-0` after VSO refresh) |
+| `secret/platform/mail` | stalwart Deployment | `kubectl -n mail-system rollout restart deployment/stalwart` |
+| `secret/platform/edge` | cert-manager + external-dns | restarts not usually needed; VSO refreshes the Secret in place |
+| `secret/platform/ghcr` | api + frontend `imagePullSecrets` | next image pull picks up the new auth |
+
+For the api's third-party tokens (Brevo, Mollie, etc.),
+`scripts/seed-vault-from-env.sh --apply --sync-api` does the
+`vault kv patch` + VSO force-refresh + api pod delete in one step.
+
+### Future: Spring Cloud Vault dynamic MariaDB creds
+
+`bootstrap-auth.sh` already configures the MariaDB dynamic-secrets
+engine (`database/config/mariadb`) and role
+(`database/roles/api`, 72h default / 168h max). Once
+`spring.cloud.vault.database.enabled=true` correctly rebinds
+`spring.datasource.{username,password}` (currently broken in our
+Spring Cloud Vault version), drop `mysql-user` / `mysql-password`
+from the Vault Agent template and re-set
+`VAULT_DB_ENABLED=true` on the api Deployment. Vault then mints a
+short-lived MariaDB user per pod and rotates it without operator
+involvement.

--- a/scripts/seed-vault-from-env.sh
+++ b/scripts/seed-vault-from-env.sh
@@ -362,6 +362,14 @@ append_field secret/api vault-oidc-client-secret "$(first_value VAULT_OIDC_CLIEN
 mariadb_root_password="$(first_value MYSQL_ROOT_PASSWORD MARIADB_ROOT_PASSWORD 2>/dev/null || true)"
 mariadb_user="$(first_value MYSQL_USER MARIADB_USER 2>/dev/null || true)"
 mariadb_password="$(first_value MYSQL_PASSWORD MARIADB_PASSWORD 2>/dev/null || true)"
+
+# Mirror the app DB user + password into secret/api so the Vault Agent
+# template in apps/stateless/api/deployment.yaml can render them
+# alongside the rest of the api config (no separate Vault path, no
+# policy expansion). Drop these once Spring Cloud Vault dynamic
+# creds (`spring.cloud.vault.database.enabled=true`) are working.
+append_field secret/api mysql-user     "$mariadb_user"
+append_field secret/api mysql-password "$mariadb_password"
 mariadb_admin_user="$(first_value MARIADB_ADMIN_USER MYSQL_ADMIN_USER 2>/dev/null || true)"
 mariadb_admin_password="$(first_value MARIADB_ADMIN_PASSWORD MYSQL_ADMIN_PASSWORD 2>/dev/null || true)"
 


### PR DESCRIPTION
## Summary

Six bugs surfaced during the live v2 bring-up that each blocked the install and each required a hand-applied runtime workaround. Fixing all of them on `main` so the next clean install runs end-to-end with no `kubectl create secret`, no `kubectl set env`, no hand-applied RBAC patches, no Job edits.

| # | Bug | Fix |
|---|---|---|
| 1 | apps-core deadlock — cert-manager + external-dns wait for `cloudflare-api-token`, materialised by VSS in apps-vso-secrets which transitively waits for apps-core | Move `cloudflare.yaml` into apps-core (same pattern PR #161 used for MariaDB / Listmonk-Postgres) |
| 2 | api crashloops with shell `syntax error: unexpected newline` because `{{ index .Data.data "missing-field" }}` renders the literal `<no value>` and `<` / `>` are shell redirection | Wrap every Vault Agent template field in `'{{ ... | default "" }}'` |
| 3 | Spring Cloud Vault `database.enabled=true` doesn't actually rebind `spring.datasource.{username,password}` — api falls back to `root` / no-password and `Access denied` | Inject MYSQL_USER / MYSQL_PASSWORD via the same Vault Agent template; mirror them into `secret/api` from `seed-vault-from-env.sh`; drop `VAULT_DB_ENABLED=true` (defaults to false) |
| 4 | `listmonk-setup` Role denies its own `create secrets` because Kubernetes RBAC ignores `resourceNames` on `create` — Job dies 403, `listmonk-api-token` never created, api can't auth to Listmonk | Split the rule into an unscoped `create` + the narrow `resourceNames`-scoped `get/patch` |
| 5 | api Vault policy denies Spring Cloud Vault's KV auto-discovery probes (`secret/application*`, `secret/BlueshellAPI*`); the 403s abort startup | Grant read on those four paths so Vault returns 404 instead — Spring tolerates 404 as a benign INFO log |
| 6 | Rotation pattern not documented anywhere | Add §7 "Rotating credentials" to `vault-bootstrap.md` with a Vault-path → consumer table + the `kv patch` + `rollout restart` recipe |

## Where each shared secret lives

Per the user's "judgement on Vault for shared secrets" ask: every secret that's shared between namespaces or rotates lives in Vault. The two intentional exceptions are `default/listmonk-api-token` (runtime-generated by the setup Job; would race with VSO overwrite) and the Vault root token + unseal key (operator's offline storage only). Full mapping in the plan file (`~/.claude/plans/when-we-left-off-wondrous-forest.md`).

## Test plan

- [x] `kubectl kustomize` clean for every overlay (`clusters/production`, `apps/{core,edge,utility-system,data,vso-secrets,stateless,mail}`)
- [x] `nix flake check ./platform --no-build` — all checks passed
- [x] `bash -n` clean for `seed-vault-from-env.sh` and `bootstrap-auth.sh`
- [x] Rendered Vault Agent template manually inspected — all fields `'{{ ... | default "" }}'` with no leftover bare references
- [ ] CI green
- [ ] After merge: `nixos-anywhere` re-wipe + clean install end-to-end with no manual workarounds
- [ ] Rotation smoke test: `vault kv patch secret/api mysql-password=<new>` + `vault kv patch secret/platform/mariadb password=<new>` + `ALTER USER` + `kubectl rollout restart deployment/api` — api comes back Ready with the new password

## Out of scope (tracked for future PRs)

- **Spring Cloud Vault dynamic MariaDB creds.** The engine + role already exist (`bootstrap-auth.sh`); only the Spring-side rebinding is broken. Once fixed, drop the MYSQL_USER / MYSQL_PASSWORD lines from the api Vault Agent template and flip `VAULT_DB_ENABLED=true` again.
- **Multi-line PEM in legacy `.env` files.** The seed script's per-line parser can't handle multi-line quoted values; bash-sourcing into the current shell remains the documented workaround (PR #165 made the no-files path bash-3.2-safe).