### PR TITLE
platform: fix apps-core CRD-ordering by reverting cloudflare VSS move + disableWait on external-dns

### DIFF
--- a/platform/cluster/flux/apps/core/external-dns/release.yaml
+++ b/platform/cluster/flux/apps/core/external-dns/release.yaml
@@ -20,10 +20,19 @@ spec:
   # becomes Ready and Flux's default single-retry stalls the
   # HelmRelease permanently. Infinite retries let it self-heal once
   # the Secret lands, no manual `flux reconcile --force` needed.
+  #
+  # disableWait so this HelmRelease reports Ready as soon as Helm
+  # finishes the chart install — without it, Helm's own
+  # `--wait` blocks for the full timeout while the pod is in
+  # CreateContainerConfigError, which keeps apps-core stuck Pending
+  # and (transitively) every downstream Kustomization. The pod
+  # crashloops on its own; once VSO syncs the Secret it recovers.
   install:
+    disableWait: true
     remediation:
       retries: -1
   upgrade:
+    disableWait: true
     remediation:
       retries: -1
   values:

--- a/platform/cluster/flux/apps/core/kustomization.yaml
+++ b/platform/cluster/flux/apps/core/kustomization.yaml
@@ -9,4 +9,3 @@ resources:
   - external-dns
   - traefik
   - vso
-  - cloudflare-vss.yaml

--- a/platform/cluster/flux/apps/vso-secrets/cloudflare.yaml
+++ b/platform/cluster/flux/apps/vso-secrets/cloudflare.yaml
@@ -3,17 +3,17 @@
 # shape to manage A/AAAA records. VSO syncs both from the same Vault path
 # (`secret/platform/edge:cloudflare.dns_api_token`).
 #
-# The CRs live in apps-core (alongside the cert-manager + external-dns
-# HelmReleases that consume them) rather than in apps-vso-secrets,
-# because the cert-manager / external-dns Deployments wedge in
-# CreateContainerConfigError until this Secret exists, which would
-# block apps-core Ready and (transitively) every downstream
-# Kustomization. Same self-bootstrapping pattern PR #161 applied to
-# the MariaDB / listmonk-db credentials. apps-core's VSO HelmRelease
-# disables wait, so the Deployment is Ready before VSO starts
-# materialising — VSO retries on its own backoff once Vault is
-# unsealed and the bootstrap Job has wired up the kubernetes auth
-# role for VSO.
+# These VSS lived briefly in apps-core (PR #167) so cert-manager /
+# external-dns could find their Secret without a manual operator
+# pre-seed. That created a hard ordering bug: kustomize-controller
+# atomically dry-runs every resource in a Kustomization, and the
+# VaultStaticSecret CRD is installed by the VSO HelmRelease in the
+# same Kustomization — so the dry-run on this VSS aborts the entire
+# apps-core apply before VSO ever installs its CRDs. Keep the VSS in
+# apps-vso-secrets (CRDs already established by the time apps-core is
+# Ready) and rely on disableWait + retries on the consumers
+# (apps/core/external-dns/release.yaml) so apps-core itself doesn't
+# block waiting for the cloudflare Secret.
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/platform/cluster/flux/apps/vso-secrets/kustomization.yaml
+++ b/platform/cluster/flux/apps/vso-secrets/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - cloudflare.yaml
   - api-secrets.yaml
   - listmonk-secrets.yaml
   - stalwart-secrets.yaml


### PR DESCRIPTION
## Summary

PR #167's fix #1 moved the `cloudflare-api-token` VSS into apps-core so cert-manager / external-dns could find their Secret without a pre-seed. **That introduces a worse bug**: kustomize-controller atomically dry-runs every resource in a Kustomization, and the `VaultStaticSecret` CRD is installed by the VSO HelmRelease in the same Kustomization. Dry-run fails (`no matches for kind VaultStaticSecret`), Flux aborts the entire apply, VSO is never installed, apps-core never converges. Caught on the very next clean install (right after #167 merged).

This PR:

1. Moves `cloudflare.yaml` back to `apps-vso-secrets` (CRDs already established by the time apps-vso-secrets applies — depends on apps-core).
2. Adds `install.disableWait: true` and `upgrade.disableWait: true` to the external-dns HelmRelease — so apps-core reports Ready as soon as Helm finishes, even while the external-dns pod is in `CreateContainerConfigError` waiting for VSO to materialise the Secret. The pod crashloops on its own; once the operator unseals + seeds Vault, VSO syncs, and the pod recovers without further ceremony.

cert-manager doesn't need disableWait: its controller pods don't reference the cloudflare Secret directly (only the ClusterIssuer in apps-edge does), so they go Ready independently.

## Why this works (sequence diagram)

```
apps-core applied
  ├── cert-manager HelmRelease   → Ready (no Secret dependency at pod level)
  ├── external-dns HelmRelease   → Ready (disableWait — Helm doesn't wait for pod)
  ├── traefik HelmRelease        → Ready
  └── vso HelmRelease            → Ready (disableWait already)
                                    ↳ VaultStaticSecret CRD established

apps-vso-secrets + apps-data unblock in parallel
  apps-vso-secrets:
    └── cloudflare-api-token VSS → CR created, VSO retries (Vault sealed)
  apps-data:
    └── Vault HelmRelease        → Vault pod Running, sealed

operator: unseal Vault, create vault-bootstrap-token Secret, seed Vault

bootstrap Job runs → kubernetes auth + vso role → VSO can authenticate

VSO syncs every VSS:
  → cloudflare-api-token (cert-manager + external-dns)
  → mariadb-credentials  (data-system, in apps-data)
  → listmonk-db-credentials
  → api-secrets, listmonk-secrets, stalwart-secrets, ghcr-pull-secret

external-dns pod CreateContainerConfigError → recovers as soon as Secret appears
mariadb / listmonk-db Helm install upgrades unblock
apps-data Ready → apps-stateless Ready → apps-edge Ready → site up
```

## Test plan
- [x] `kubectl kustomize` clean for every overlay
- [ ] CI green
- [ ] Live: re-run `nixos-anywhere`, watch apps-core converge without manual `kubectl create secret cloudflare-api-token` and without the kustomization dry-run failing on the missing CRD