### PR TITLE
api: stop driving Listmonk config from the api (template creation, settings writes)

### DIFF
--- a/services/api/src/main/kotlin/net/blueshell/api/platform/config/ListmonkConfig.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/config/ListmonkConfig.kt
@@ -1,23 +1,33 @@
 package net.blueshell.api.platform.config
 
+import net.blueshell.clients.listmonk.ApiClient
 import net.blueshell.clients.listmonk.api.BouncesApi
 import net.blueshell.clients.listmonk.api.ListsApi
 import net.blueshell.clients.listmonk.api.SubscribersApi
-import net.blueshell.clients.listmonk.api.TemplatesApi
 import net.blueshell.clients.listmonk.api.TransactionalApi
-import net.blueshell.clients.listmonk.ApiClient
-import net.blueshell.clients.listmonk.model.NewTemplate
-import net.blueshell.clients.listmonk.model.NewTemplateType
 import org.slf4j.LoggerFactory
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpHeaders
-import org.springframework.web.client.RestClient
 import java.io.File
 import java.util.Base64
 
+/**
+ * Wires HTTP clients for the api → Listmonk integration.
+ *
+ * Scope is intentionally narrow: this api only *reads from* and *sends to*
+ * Listmonk. It does not configure Listmonk. Templates, SMTP settings, bounce
+ * processing settings, and the API user are managed by
+ * `platform/cluster/flux/apps/stateless/listmonk/setup.py` (the setup Job)
+ * or the Listmonk admin UI.
+ *
+ * Beans exposed:
+ *  - [TransactionalApi]: `POST /api/tx` for sending transactional emails.
+ *  - [BouncesApi]: `GET /api/bounces` for the read-only bounce poller.
+ *  - [SubscribersApi] / [ListsApi]: contact + list sync (subscribers are user data).
+ */
 @Configuration
 @EnableConfigurationProperties(ListmonkProperties::class)
 class ListmonkConfig {
@@ -48,26 +58,6 @@ class ListmonkConfig {
     @Profile("!test")
     fun listmonkBouncesApi(client: ApiClient): BouncesApi = BouncesApi(client)
 
-    /**
-     * Pre-configured [RestClient] for Listmonk admin API calls (e.g. settings).
-     * Uses the API token from the secrets volume when available; falls back to basic auth.
-     */
-    @Bean(ADMIN_REST_CLIENT_BEAN)
-    @Profile("!test")
-    fun listmonkAdminRestClient(props: ListmonkProperties): RestClient {
-        val baseUrl = props.api.baseUrl.removeSuffix("/api")
-        val (username, password) = readApiTokenFile(props) ?: (props.api.username to props.api.password)
-        val encoded = Base64.getEncoder().encodeToString("$username:$password".toByteArray())
-        return RestClient.builder()
-            .baseUrl(baseUrl)
-            .defaultHeader(HttpHeaders.AUTHORIZATION, "Basic $encoded")
-            .build()
-    }
-
-    @Bean
-    @Profile("!test")
-    fun listmonkTemplatesApi(client: ApiClient): TemplatesApi = TemplatesApi(client)
-
     @Bean
     @Profile("!test")
     fun listmonkSubscribersApi(client: ApiClient): SubscribersApi = SubscribersApi(client)
@@ -76,68 +66,8 @@ class ListmonkConfig {
     @Profile("!test")
     fun listmonkListsApi(client: ApiClient): ListsApi = ListsApi(client)
 
-    /**
-     * Resolves the Listmonk transactional template ID to use for sending emails.
-     *
-     * If [ListmonkProperties.templateId] is explicitly configured (> 0), it is used as-is.
-     * Otherwise, the template named [TEMPLATE_NAME] is looked up via the Listmonk API and
-     * created if it does not exist yet. This means no manual setup is needed in the Listmonk UI.
-     *
-     * The template renders the full pre-built HTML passed via `data.body` in each transactional send.
-     */
-    @Bean(TEMPLATE_ID_BEAN)
-    @Profile("!test")
-    fun resolvedListmonkTemplateId(
-        templatesApi: TemplatesApi,
-        props: ListmonkProperties,
-    ): Int {
-        if (props.templateId > 0) {
-            log.info("Using configured Listmonk template id={}", props.templateId)
-            return props.templateId
-        }
-
-        val templates = try {
-            templatesApi.getTemplates(true)?.data ?: emptyList()
-        } catch (e: Exception) {
-            log.warn("Could not list Listmonk templates: {}", e.message)
-            emptyList()
-        }
-
-        val existing = templates.find { it.name == TEMPLATE_NAME && it.type == "tx" }
-        if (existing?.id != null) {
-            log.info("Found Listmonk template '{}' id={}", TEMPLATE_NAME, existing.id)
-            return existing.id!!
-        }
-
-        val created = try {
-            val req = NewTemplate()
-                .name(TEMPLATE_NAME)
-                .type(NewTemplateType.TX)
-                .subject("{{ .Tx.Subject }}")  // forwarded from each transactional send request
-                .body(TEMPLATE_BODY)
-            templatesApi.createTemplate(req)?.data
-        } catch (e: Exception) {
-            throw IllegalStateException("Failed to create Listmonk template '$TEMPLATE_NAME': ${e.message}", e)
-        } ?: throw IllegalStateException("Listmonk returned null when creating template '$TEMPLATE_NAME'")
-
-        log.info("Created Listmonk template '{}' id={}", TEMPLATE_NAME, created.id)
-        return created.id!!
-    }
-
     companion object {
         private val log = LoggerFactory.getLogger(ListmonkConfig::class.java)
-
-        const val TEMPLATE_ID_BEAN = "resolvedListmonkTemplateId"
-        const val ADMIN_REST_CLIENT_BEAN = "listmonkAdminRestClient"
-
-        /** Name used to look up or create the passthrough transactional template. */
-        const val TEMPLATE_NAME = "Blueshell Transactional"
-
-        /**
-         * Minimal passthrough template: renders the full HTML passed in `data.body`.
-         * Listmonk wraps the body in its own MIME envelope, so this is all we need.
-         */
-        const val TEMPLATE_BODY = "{{ .Tx.Data.body }}"
 
         /**
          * Reads the API token written by Listmonk's `--install` step when

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/config/ListmonkProperties.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/config/ListmonkProperties.kt
@@ -7,7 +7,6 @@ data class ListmonkProperties(
     val api: ApiProperties = ApiProperties(),
     val from: FromProperties = FromProperties(),
     val replyTo: String = "sitecie@blueshell.utwente.nl",
-    val templateId: Int = 0,  // 0 = auto-detect/create on startup
     val bounce: BounceProperties = BounceProperties(),
     val contact: ContactProperties = ContactProperties(),
 ) {

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/email/adapter/ListmonkEmailClient.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/email/adapter/ListmonkEmailClient.kt
@@ -1,11 +1,10 @@
 package net.blueshell.api.platform.integration.email.adapter
 
-import net.blueshell.api.platform.config.ListmonkConfig
 import net.blueshell.clients.listmonk.api.TransactionalApi
 import net.blueshell.clients.listmonk.model.TransactionalMessage
 import net.blueshell.clients.listmonk.model.TransactionalMessageSubscriberMode
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 import java.util.UUID
@@ -17,13 +16,18 @@ import java.util.UUID
  * Listmonk returns only `{"data": true}` with no message ID, so a UUID is
  * generated locally and used as the messageId for outbox tracking.
  *
+ * The transactional template referenced by [templateId] is provisioned
+ * out-of-band (Listmonk admin UI or `platform/cluster/flux/apps/stateless/listmonk/setup.py`);
+ * the api never creates or mutates it. The operator sets `LISTMONK_TEMPLATE_ID`
+ * to the id of the existing "Blueshell Transactional" template.
+ *
  * Active in both dev and prod (all non-test profiles).
  */
 @Component
 @Profile("!test")
 class ListmonkEmailClient(
     private val transactionalApi: TransactionalApi,
-    @field:Qualifier(ListmonkConfig.TEMPLATE_ID_BEAN) private val templateId: Int,
+    @param:Value("\${listmonk.template-id}") private val templateId: Int,
 ) : EmailTransportClient {
 
     override fun send(

--- a/services/api/src/main/resources/application.yaml
+++ b/services/api/src/main/resources/application.yaml
@@ -156,20 +156,13 @@ listmonk:
   from:
     address: ${LISTMONK_FROM_ADDRESS:no-reply@mg.v2.esa-blueshell.nl}
   reply-to: ${LISTMONK_REPLY_TO_ADDRESS:sitecie@blueshell.utwente.nl}
-  template-id: ${LISTMONK_TEMPLATE_ID:0}  # 0 = auto-detect/create on startup
+  # ID of the pre-existing "Blueshell Transactional" template in Listmonk.
+  # Provisioned by the listmonk setup Job or manually via the admin UI; the
+  # api does not create or mutate Listmonk templates. The operator must set
+  # LISTMONK_TEMPLATE_ID to the template's id; sends fail at runtime otherwise.
+  template-id: ${LISTMONK_TEMPLATE_ID:0}
   bounce:
     poll-interval-ms: ${LISTMONK_BOUNCE_POLL_INTERVAL_MS:300000}
-    mailbox:
-      enabled: ${LISTMONK_BOUNCE_MAILBOX_ENABLED:false}
-      host: ${LISTMONK_BOUNCE_MAILBOX_HOST:}
-      port: ${LISTMONK_BOUNCE_MAILBOX_PORT:993}
-      username: ${LISTMONK_BOUNCE_MAILBOX_USERNAME:}
-      password: ${LISTMONK_BOUNCE_MAILBOX_PASSWORD:}
-      tls-enabled: ${LISTMONK_BOUNCE_MAILBOX_TLS:true}
-      tls-skip-verify: ${LISTMONK_BOUNCE_MAILBOX_TLS_SKIP_VERIFY:false}
-      folder: ${LISTMONK_BOUNCE_MAILBOX_FOLDER:INBOX}
-      return-path: ${LISTMONK_BOUNCE_MAILBOX_RETURN_PATH:}
-      scan-interval: ${LISTMONK_BOUNCE_MAILBOX_SCAN_INTERVAL:10m}
   contact:
     sync-cron: ${LISTMONK_CONTACT_SYNC_CRON:0 0 2 * * *}
 


### PR DESCRIPTION
## Summary
- The api's `ListmonkConfig.resolvedListmonkTemplateId()` was calling `TemplatesApi.createTemplate("Blueshell Transactional", ...)` at startup, hard-failing api boot whenever Listmonk creds drifted. We hit this on the live v2 install — the api crash-looped because it couldn't authenticate as the listmonk admin user it was trying to mutate state with.
- Listmonk configuration (templates, SMTP/bounce settings, API user) now lives entirely in `platform/cluster/flux/apps/stateless/listmonk/setup.py` (the setup Job) and the Listmonk admin UI. The api stops trying to provision Listmonk state.
- The api keeps only its legitimate runtime paths: `POST /api/tx` (send), `GET /api/bounces` (read-only bounce poller), and subscriber + list sync (user data, not Listmonk config).

## What changed
- `ListmonkConfig`: drop `resolvedListmonkTemplateId` (auto-create + lookup), drop `listmonkAdminRestClient` (no caller after templates leave), drop `listmonkTemplatesApi`. The remaining beans wire `TransactionalApi` / `BouncesApi` / `SubscribersApi` / `ListsApi` only.
- `ListmonkEmailClient`: now reads `listmonk.template-id` straight via `@Value("\${listmonk.template-id}")`. The operator sets `LISTMONK_TEMPLATE_ID` to the id of the pre-existing "Blueshell Transactional" template provisioned by the setup Job or admin UI.
- `ListmonkProperties`: drop the `templateId` field (was the auto-create flag's home).
- `application.yaml`: drop the dead `listmonk.bounce.mailbox.*` block (no Kotlin code consumed it; the listmonk service has its own `configure-bounce.py`).

## Test plan
- [x] `./gradlew :services:api:compileKotlin` clean
- [x] `./gradlew :services:api:test --tests "*Listmonk*"` — 20/20 pass
- [ ] On live v2: set `LISTMONK_TEMPLATE_ID` to the id of the existing transactional template (created via Listmonk admin UI or future setup-Job step), confirm api boots without authenticating as `listmonk` admin and that `POST /api/tx` still sends.
- [ ] Confirm `ListmonkBouncePollingService` still polls `GET /api/bounces` on schedule (read-only path, untouched).