### PR TITLE
platform: api APP_SECURITY_REQUIRE_HTTPS=false (edge handles HTTPS, kubelet probe was 500ing)

### DIFF
--- a/platform/cluster/flux/apps/stateless/api/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/api/deployment.yaml
@@ -116,6 +116,21 @@ spec:
               value: vault://
             - name: VAULT_ENABLED
               value: 'true'
+            # SecurityConfig.kt adds Spring's HttpsRedirectFilter when
+            # `app.security.require-https` is true (the default). The
+            # filter throws 500 on the management port (8081, actuator)
+            # and on any HTTP request whose port has no corresponding
+            # HTTPS mapping — including the kubelet's in-cluster
+            # readiness probe on the api Service port. The pod never
+            # reports Ready, the Service has no endpoints, traffic
+            # never reaches the api.
+            #
+            # Edge HTTPS enforcement lives on Traefik (IngressRoute
+            # `http -> https` redirect) plus HSTS at the IngressRoute
+            # level, so the api itself doesn't need to enforce HTTPS
+            # again on every internal request.
+            - name: APP_SECURITY_REQUIRE_HTTPS
+              value: 'false'
             # VAULT_DB_ENABLED intentionally omitted (defaults to false
             # via application.yaml). Spring Cloud Vault dynamic MariaDB
             # creds (`database/creds/api`) are wired up by


### PR DESCRIPTION
## Summary

`SecurityConfig.kt` adds Spring's `HttpsRedirectFilter` when `app.security.require-https=true` (default). The filter throws HTTP 500 on any request whose port has no corresponding HTTPS port mapping — which is every in-cluster request, because Traefik terminates TLS at the edge and the api binds only HTTP on 8080 + 8081.

Concrete failure on the live install: kubelet's readiness probe (`GET /health` on port 8080) trips the filter, gets a 500, the pod never reports Ready, the Service stays empty of endpoints, traffic never reaches the api.

Set `APP_SECURITY_REQUIRE_HTTPS=false` on the api Deployment. Edge HTTPS enforcement is already on Traefik (IngressRoute redirects `http→https`) plus HSTS at the IngressRoute level — disabling api-side enforcement doesn't weaken the public surface.

## Test plan
- [x] `kubectl kustomize` clean
- [ ] CI green
- [ ] Live: api pod reaches Ready (kubelet probe returns 200), Service gets the pod as an endpoint, `curl https://v2.esa-blueshell.nl/api/health` works through Traefik