### PR TITLE
platform: api probes use tcpSocket; revert APP_SECURITY_REQUIRE_HTTPS

### DIFF
--- a/platform/cluster/flux/apps/stateless/api/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/api/deployment.yaml
@@ -116,21 +116,6 @@ spec:
               value: vault://
             - name: VAULT_ENABLED
               value: 'true'
-            # SecurityConfig.kt adds Spring's HttpsRedirectFilter when
-            # `app.security.require-https` is true (the default). The
-            # filter throws 500 on the management port (8081, actuator)
-            # and on any HTTP request whose port has no corresponding
-            # HTTPS mapping — including the kubelet's in-cluster
-            # readiness probe on the api Service port. The pod never
-            # reports Ready, the Service has no endpoints, traffic
-            # never reaches the api.
-            #
-            # Edge HTTPS enforcement lives on Traefik (IngressRoute
-            # `http -> https` redirect) plus HSTS at the IngressRoute
-            # level, so the api itself doesn't need to enforce HTTPS
-            # again on every internal request.
-            - name: APP_SECURITY_REQUIRE_HTTPS
-              value: 'false'
             # VAULT_DB_ENABLED intentionally omitted (defaults to false
             # via application.yaml). Spring Cloud Vault dynamic MariaDB
             # creds (`database/creds/api`) are wired up by
@@ -218,20 +203,28 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+          # All probes are tcpSocket rather than httpGet because
+          # SecurityConfig.kt registers Spring's HttpsRedirectFilter in
+          # production (`app.security.require-https=true`, enforced by
+          # ProductionSecurityHardeningGuard which fails startup if you
+          # set it to false outside dev/test). The filter throws HTTP
+          # 500 on any in-cluster HTTP request whose port has no
+          # corresponding HTTPS port mapping — the kubelet probe is
+          # exactly that. tcpSocket avoids the filter entirely; the
+          # probe just checks Tomcat is bound to 8080. Edge HTTP
+          # behaviour is unaffected (Traefik terminates TLS and
+          # forwards X-Forwarded-Proto).
           startupProbe:
-            httpGet:
-              path: /health
+            tcpSocket:
               port: http
             periodSeconds: 5
             failureThreshold: 60
           readinessProbe:
-            httpGet:
-              path: /health
+            tcpSocket:
               port: http
             timeoutSeconds: 5
           livenessProbe:
-            httpGet:
-              path: /health
+            tcpSocket:
               port: http
             timeoutSeconds: 5
           resources:


### PR DESCRIPTION
## Summary

PR #171 set `APP_SECURITY_REQUIRE_HTTPS=false` to disarm Spring's HttpsRedirectFilter for in-cluster probe traffic. **That env override is DOA**: `ProductionSecurityHardeningGuard.validate` (`net.blueshell.api.platform.config.ProductionSecurityHardeningGuard`) explicitly throws on startup if the flag is anything other than true outside dev/test profiles:

```
java.lang.IllegalArgumentException: app.security.require-https must be true outside dev/test profiles
  at ProductionSecurityHardeningGuard.validate(ProductionSecurityHardeningGuard.kt:22)
```

Live install pods crashloop on `BeanCreationException` immediately after #171's env arrived.

This PR:
1. Reverts the env addition.
2. Switches the api's three probes (startup / readiness / liveness) from `httpGet /health` to `tcpSocket :8080`.

The probe now checks Tomcat is bound, bypasses the SecurityFilterChain, and the pod becomes Ready as soon as the listener is up. Real app-level health is already observed externally by Gatus hitting the public URL through Traefik, so app-level liveness on the api itself doesn't add much.

Edge HTTPS enforcement is unchanged: Traefik IngressRoute does the http→https redirect, HSTS still ships, `ProductionSecurityHardeningGuard` still gates the boot. The api just doesn't have to 500 on every probe to get there.

## Test plan
- [x] `kubectl kustomize` clean
- [ ] CI green
- [ ] Live: pod becomes Ready within startup window, Service has the pod as endpoint, `curl https://v2.esa-blueshell.nl/api/health` works through Traefik

## Follow-up tracked separately

Real fix is to make `HttpsRedirectFilter` not 500 on requests with no HTTPS port counterpart — either by skipping `/health` and `/actuator/**` in the filter chain, or by registering a `PortMapper` so the filter sends 302 (which kubelet would treat as success). Both are api-side code changes outside the scope of getting this install over the line.