### PR TITLE
frontend: bare layout on auth routes + real-browser redirect off-SPA

### DIFF
--- a/services/frontend/src/App.vue
+++ b/services/frontend/src/App.vue
@@ -1,6 +1,14 @@
 <template>
   <v-app>
-    <v-app-bar theme="dark">
+    <!-- `route.meta.bare` (set on /login, /unauthorized, etc. — see
+         router.ts) drops the full site chrome. Useful when this SPA
+         is loaded into a small popup window — Vault's OIDC flow being
+         the canonical case — where the top bar / drawer / footer are
+         purely visual noise around the login form. -->
+    <v-app-bar
+      v-if="!route.meta.bare"
+      theme="dark"
+    >
       <v-btn
         v-if="display.mdAndDown.value"
         class="ml-2"
@@ -260,6 +268,7 @@
     </v-app-bar>
 
     <v-navigation-drawer
+      v-if="!route.meta.bare"
       v-model="drawer"
       temporary
     >
@@ -415,7 +424,7 @@
 
     <router-view />
 
-    <footer-banner />
+    <footer-banner v-if="!route.meta.bare" />
 
 
     <v-snackbar

--- a/services/frontend/src/pages/login/Login.vue
+++ b/services/frontend/src/pages/login/Login.vue
@@ -131,8 +131,25 @@ const login = async () => {
       const loginData = response.data as LoginResponse
       store.commit("setLogin", loginData)
 
-      // Go to redirect page or home page
-      await router.push(route.query.redirect?.toString() || "/")
+      // Go to redirect page or home page. If the redirect target lives
+      // outside the SPA (the api at /api/*, Spring Authorization Server
+      // at /oauth2/* or /.well-known/*, or any absolute http(s) URL),
+      // do a full browser navigation — Vue Router's `push` only handles
+      // SPA routes and would silently land on `/` for everything else.
+      // This is the path Vault's OIDC flow takes: the popup arrives here
+      // with `?redirect=/api/oauth2/authorize?…`, after login we have
+      // to bounce the browser back to that authorize URL so Spring can
+      // emit the code and Vault's callback fires.
+      const redirect = route.query.redirect?.toString() || "/"
+      const isOffSpa = /^https?:\/\//i.test(redirect)
+        || redirect.startsWith("/api/")
+        || redirect.startsWith("/oauth2/")
+        || redirect.startsWith("/.well-known/")
+      if (isOffSpa) {
+        globalThis.location.assign(redirect)
+      } else {
+        await router.push(redirect)
+      }
     } else if (response?.status === 401) {
       store.commit("setStatusSnackbarMessage", "Incorrect login credentials. Please double check your username and password.")
     } else {

--- a/services/frontend/src/plugins/router.ts
+++ b/services/frontend/src/plugins/router.ts
@@ -98,14 +98,23 @@ const routes: RouteRecordRaw[] = [
     component: () => import("@/pages/partners/MarketingMaatwerk.vue"),
   },
   {
+    // `meta.bare = true` (here and on /unauthorized below) tells App.vue
+    // to drop the v-app-bar / v-navigation-drawer / footer-banner so the
+    // login form is the only thing on screen. Mainly so Vault's OIDC
+    // popup at https://v2.esa-blueshell.nl/api/oauth2/authorize?... ->
+    // /login?redirect=... isn't visually wrapped in the full website
+    // chrome; same goes for forgot-password / account-create which are
+    // linked from the login form.
     path: "/login",
     name: "login",
     component: () => import("@/pages/login/Login.vue"),
+    meta: {bare: true},
   },
   {
     path: "/login/forgor",
     name: "forgotPassword",
     component: () => import("@/pages/login/ForgotPassword.vue"),
+    meta: {bare: true},
   },
   {
     path: "/account",
@@ -117,6 +126,7 @@ const routes: RouteRecordRaw[] = [
     path: "/account/create",
     name: "accountCreation",
     component: () => import("@/pages/login/CreateAccount.vue"),
+    meta: {bare: true},
   },
   {
     path: "/account/reset-password",
@@ -264,9 +274,12 @@ const routes: RouteRecordRaw[] = [
     // because their role isn't high enough for the requested admin host
     // (vault, headlamp, listmonk, stalwart, traefik). The api redirects
     // here with `?service=<host>` so the page can name what was blocked.
+    // `meta.bare` because this page is reached from a popup / new tab
+    // that has no business showing the full site chrome.
     path: "/unauthorized",
     name: "unauthorized",
     component: () => import("@/pages/Unauthorized.vue"),
+    meta: {bare: true},
   },
   {
     path: "/:pathMatch(.*)*",


### PR DESCRIPTION
## Summary

Two intertwined fixes for the Vault OIDC popup login.

### 1. Off-SPA redirect bug (functional)

`Login.vue` did `router.push(route.query.redirect)` on success. Vue Router only handles SPA routes — when the redirect target was off-SPA (Vault's OIDC chain redirects with `?redirect=/api/oauth2/authorize?…`), the router silently fell through to `/`. The popup ended up on the website home, the user was logged in but the OIDC flow never resumed.

Now `Login.vue` detects off-SPA targets (absolute `http(s)://`, or paths under `/api/`, `/oauth2/`, `/.well-known/`) and uses `globalThis.location.assign(...)` for them — a real browser navigation. SPA-internal redirects (`/account`, `/myapps`, …) keep using `router.push`, so existing flows are unchanged.

### 2. Bare layout on auth routes (UX)

`App.vue` always wrapped `<router-view>` with the full top bar, navigation drawer, and footer banner. For a popup whose only purpose is "capture credentials and bounce back", that's pure visual noise.

Add `meta: {bare: true}` to:
- `/login`, `/login/forgor`, `/account/create` (the login flow)
- `/unauthorized` (the forwardAuth wrong-role landing page — also frequently reached from a popup / new tab)

`App.vue` then hides `v-app-bar`, `v-navigation-drawer`, and `footer-banner` when `route.meta.bare === true`. Same Vite build, same Vuetify theme — no commons / new build target / Traefik route plumbing.

## Combined effect

Vault's OIDC popup chain end-to-end:

1. Vault `…/oidc/login` → popup opens at `https://v2.esa-blueshell.nl/api/oauth2/authorize?…`
2. Spring sees no session → redirects popup to `/login?redirect=<authorize-url>`
3. Login form renders **alone** (no chrome)
4. User submits → `globalThis.location.assign('<authorize-url>')`
5. Spring (now seeing the cookie) emits an auth code, redirects to the Vault callback
6. Vault callback closes the popup; main Vault tab is signed in as the OIDC `admin` role

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` clean
- [ ] CI green
- [ ] Manual SPA login (`/login?redirect=/account`) — still works via `router.push`
- [ ] Manual off-SPA redirect (`/login?redirect=/api/csrf`) — full browser navigation, lands on the api response
- [ ] `/login` and `/unauthorized` — no top bar, no drawer, no footer; just the form / page content
- [ ] **Live OIDC** after merge: open Vault `…/oidc/login` in a logged-out browser → popup → login form alone → submit → popup closes → main Vault tab signed in

## Out of scope

- Separate Vite SPA / theme commons workspace (Approach C from the prior analysis). Defer until OIDC traffic justifies a dedicated build target.
- Spring Authorization Server's built-in form-login (Approach D). Would duplicate the existing snackbar/forgot-password/create-account links in Thymeleaf.