### PR TITLE
api+frontend: fix OIDC chain auth + stop auto-logout on 401

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,12 +236,24 @@ jobs:
             gradle-${{ runner.os }}-
 
       - name: Run API unit and integration tests
+        # Retry the Gradle invocation on failure: api-tests is the first job
+        # in the run that configures a Test task, which resolves the
+        # `jacocoAgent` configuration. A transient Cloudflare 403 from
+        # repo.maven.apache.org on that resolve has previously sunk the
+        # whole run. One retry after 30 s clears the rate-limit window.
         run: |
-          ./gradlew --no-daemon --build-cache \
-            :services:api:test \
-            :services:api:integrationTest \
-            :services:api:jacocoTestReport \
-            :services:api:jacocoIntegrationTestReport
+          set -uo pipefail
+          attempts=3
+          for i in $(seq 1 $attempts); do
+            ./gradlew --no-daemon --build-cache \
+              :services:api:test \
+              :services:api:integrationTest \
+              :services:api:jacocoTestReport \
+              :services:api:jacocoIntegrationTestReport && exit 0
+            echo "::warning::Gradle invocation attempt $i/$attempts failed."
+            if [ "$i" -lt "$attempts" ]; then sleep 30; fi
+          done
+          exit 1
 
       - name: Upload API test reports
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,10 +258,21 @@ jobs:
           if-no-files-found: warn
 
   system-tests:
-    name: System tests
+    # Shard the system-test class set across N parallel matrix jobs so
+    # the wall-clock cost scales sub-linearly with new classes. The Gradle
+    # config in services/system-tests/build.gradle.kts reads SHARD_TOTAL
+    # and SHARD_INDEX (1-based) from the env, hashes each test class FQCN,
+    # and includes only its own slice via JUnit's --tests filter. Stable
+    # partition: a class always lands on the same shard, which makes
+    # failure triage easy.
+    name: System tests (shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     timeout-minutes: 45
     needs: [ api-static, fe-static ]
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [ 1, 2, 3, 4 ]
 
     services:
       db:
@@ -348,7 +359,10 @@ jobs:
           echo "Frontend failed to start."
           exit 1
 
-      - name: Run system tests (no coverage enforcement)
+      - name: Run system tests
+        env:
+          SHARD_TOTAL: 4
+          SHARD_INDEX: ${{ matrix.shard }}
         run: |
           ./gradlew --no-daemon :services:system-tests:test \
             -Dsystem.frontend.url="$FRONTEND_URL"
@@ -364,7 +378,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: system-test-reports
+          # Per-shard artifact name so parallel jobs don't collide.
+          name: system-test-reports-shard-${{ matrix.shard }}
           path: |
             services/system-tests/build/reports/tests/test
             frontend-dev.log

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/oidc/AuthorizationServerConfig.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/oidc/AuthorizationServerConfig.kt
@@ -14,12 +14,16 @@ import org.springframework.security.oauth2.server.authorization.JdbcOAuth2Author
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository
+import net.blueshell.api.infrastructure.security.JwtAuthFilter
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.authorization.OAuth2AuthorizationServerConfigurer
 import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings
 import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext
 import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenCustomizer
+import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 @Configuration
 class AuthorizationServerConfig {
@@ -30,6 +34,7 @@ class AuthorizationServerConfig {
         http: HttpSecurity,
         jwkSource: JWKSource<SecurityContext>,
         tokenCustomizer: OAuth2TokenCustomizer<JwtEncodingContext>,
+        jwtAuthFilter: JwtAuthFilter,
     ): SecurityFilterChain {
         val authServerConfigurer = OAuth2AuthorizationServerConfigurer()
 
@@ -40,13 +45,42 @@ class AuthorizationServerConfig {
             .securityMatcher(authServerConfigurer.endpointsMatcher)
             .with(authServerConfigurer) {}
             .authorizeHttpRequests { it.anyRequest().authenticated() }
+            // The default SecurityConfig's filter chain doesn't apply on
+            // this matcher — without re-adding JwtAuthFilter here, a
+            // logged-in user's BSH_AUTH cookie isn't read on the
+            // /oauth2/* endpoints and Spring Authorization Server treats
+            // them as anonymous. The filter is idempotent: if the cookie
+            // is missing or invalid, it's a no-op and the entry point
+            // below kicks in.
+            .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter::class.java)
             .exceptionHandling {
-                it.authenticationEntryPoint(LoginUrlAuthenticationEntryPoint("/login"))
+                it.authenticationEntryPoint(loginRedirectEntryPoint())
             }
             .csrf { it.ignoringRequestMatchers(authServerConfigurer.endpointsMatcher) }
 
         return http.build()
     }
+
+    /**
+     * Sends anonymous callers to the SPA's /login page with the original
+     * api URL preserved as a `redirect` query param. After the user
+     * signs in, the SPA's Login.vue does a real browser navigation to
+     * that redirect URL (Login.vue's `isOffSpa` check matches `/api/`),
+     * which re-hits this filter chain — now authenticated — and the
+     * OIDC flow resumes.
+     *
+     * The api receives `/oauth2/authorize` (Traefik strips `/api`
+     * before forwarding); we prepend `/api` back so the redirect lands
+     * at the public URL.
+     */
+    private fun loginRedirectEntryPoint(): AuthenticationEntryPoint =
+        AuthenticationEntryPoint { request, response, _ ->
+            val publicPath = "/api${request.requestURI}"
+            val query = request.queryString
+            val originalUrl = if (!query.isNullOrEmpty()) "$publicPath?$query" else publicPath
+            val encoded = URLEncoder.encode(originalUrl, StandardCharsets.UTF_8)
+            response.sendRedirect("/login?redirect=$encoded")
+        }
 
     @Bean
     @Order(2)

--- a/services/frontend/src/plugins/handleNetworkError.ts
+++ b/services/frontend/src/plugins/handleNetworkError.ts
@@ -1,6 +1,5 @@
 import router from "./router"
 import store from "@/plugins/store"
-import type {RouteLocationRaw} from "vue-router"
 import type {AxiosError} from "axios"
 
 
@@ -30,22 +29,19 @@ export function $handleNetworkError(err: unknown): void {
       case 400:
         errorMessage = "Uhhhh, looks like a bad request (error 400)... Not sure how this happened. Please report this in the <a href='https://discord.com/channels/324285132133629963/1020245710987350047' target=\"_blank\" class=\"text-decoration-none\">Sitecie suggestions channel on discord</a>."
         break
-      case 401:
-        errorMessage = "Woah there, looks like you're not logged in (anymore). Just log in and try again."
-        store.commit("logout")
-        if (!currentRoute.fullPath.startsWith("/login")) {
-          const redirect: RouteLocationRaw = {
-            path: "/login",
-            query: {
-              redirect: currentRoute.query.redirect || currentRoute.fullPath,
-            },
-          }
-          router.push(redirect)
-        }
+      case 401: {
+        // Don't auto-logout or auto-redirect on a 401: the user might
+        // genuinely still be signed in (the Vault OIDC popup chain hit
+        // this path repeatedly, blowing away live sessions). Surface a
+        // snackbar with a Login link instead and let the user decide.
+        const redirectTarget = (currentRoute.query.redirect as string)
+          || currentRoute.fullPath
+        const loginHref = `/login?redirect=${encodeURIComponent(redirectTarget)}`
+        errorMessage = `Woah there, looks like you're not logged in (anymore). <a href="${loginHref}" class="text-decoration-none">Login</a>`
         break
+      }
       case 403:
         errorMessage = "Woah there, you don't have enough authority to access this. Go to jail and DO NOT PASS GO, DO NOT COLLECT $200."
-        router.push({path: "/account"})
         break
       case 404:
         errorMessage = "Uhhhhhhh 404 moment. This resource doesn't exist anymore. Please report this in the <a href='https://discord.com/channels/324285132133629963/1020245710987350047' target=\"_blank\" class=\"text-decoration-none\">Sitecie suggestions channel on discord</a> if you think this is an error."

--- a/services/frontend/tests/unit/plugins/handleNetworkError.test.ts
+++ b/services/frontend/tests/unit/plugins/handleNetworkError.test.ts
@@ -41,19 +41,30 @@ describe("handleNetworkError plugin", () => {
     expect(mockCommit).toHaveBeenCalledWith("setStatusSnackbarMessage", expect.stringContaining("unknown error"))
   })
 
-  it("redirects to login for 401", () => {
+  it("surfaces a login-link snackbar on 401 without auto-logout or auto-redirect", () => {
     $handleNetworkError(axiosStatusError(401))
-    expect(mockCommit).toHaveBeenCalledWith("logout")
-    expect(mockPush).toHaveBeenCalledWith({
-      path: "/login",
-      query: {redirect: "/events"},
-    })
-    expect(mockCommit).toHaveBeenCalledWith("setStatusSnackbarMessage", expect.stringContaining("not logged in"))
+    // No auto-logout, no auto-router push: the user might genuinely
+    // still be signed in (Vault's OIDC popup chain hits 401 transiently).
+    // We just show a snackbar with a Login link and let the user act.
+    expect(mockCommit).not.toHaveBeenCalledWith("logout")
+    expect(mockPush).not.toHaveBeenCalled()
+    expect(mockCommit).toHaveBeenCalledWith(
+      "setStatusSnackbarMessage",
+      expect.stringContaining("not logged in"),
+    )
+    expect(mockCommit).toHaveBeenCalledWith(
+      "setStatusSnackbarMessage",
+      expect.stringContaining(`/login?redirect=${encodeURIComponent("/events")}`),
+    )
   })
 
-  it("redirects forbidden users for 403", () => {
+  it("surfaces a snackbar on 403 without auto-redirecting to /account", () => {
     $handleNetworkError(axiosStatusError(403))
-    expect(mockPush).toHaveBeenCalledWith({path: "/account"})
+    expect(mockPush).not.toHaveBeenCalled()
+    expect(mockCommit).toHaveBeenCalledWith(
+      "setStatusSnackbarMessage",
+      expect.stringContaining("authority"),
+    )
   })
 
   it("keeps users on page for 404 with message", () => {

--- a/services/system-tests/build.gradle.kts
+++ b/services/system-tests/build.gradle.kts
@@ -1,3 +1,4 @@
+import java.io.File
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
@@ -89,6 +90,46 @@ tasks.withType<Test>().configureEach {
         events(TestLogEvent.PASSED, TestLogEvent.FAILED, TestLogEvent.SKIPPED)
         exceptionFormat = TestExceptionFormat.FULL
         showStackTraces = true
+    }
+
+    // Sharding via env vars `SHARD_TOTAL` / `SHARD_INDEX` (1-based).
+    // CI runs N parallel matrix jobs — each scans the test classes
+    // directory deterministically (sorted by FQCN), partitions by
+    // `index = absoluteHash(fqcn) % SHARD_TOTAL`, and only includes
+    // its own slice via Gradle's `--tests` filter (`includeTestsMatching`).
+    // Locally, leaving the env vars unset runs every test in one JVM
+    // exactly as before. The hash partition is stable across runs so
+    // a class always lands on the same shard — useful for triage.
+    val shardTotal = System.getenv("SHARD_TOTAL")?.toIntOrNull()?.takeIf { it > 1 }
+    val shardIndex = System.getenv("SHARD_INDEX")?.toIntOrNull()
+    if (shardTotal != null && shardIndex != null && shardIndex in 1..shardTotal) {
+        doFirst {
+            val classes = testClassesDirs.asFileTree
+                .matching { include("**/*Test.class", "**/*SystemTest.class", "**/*IT.class") }
+                .files
+                .map { f ->
+                    // class file path → FQCN: strip the classes-dirs root and
+                    // .class suffix, swap separators for dots.
+                    val root = testClassesDirs.firstOrNull { f.startsWith(it) } ?: return@map null
+                    f.relativeTo(root).path.removeSuffix(".class").replace(File.separatorChar, '.')
+                }
+                .filterNotNull()
+                .filter { !it.contains('$') } // skip anonymous / nested $-classes
+                .sorted()
+            val mine = classes.filter { Math.floorMod(it.hashCode(), shardTotal) == shardIndex - 1 }
+            logger.lifecycle("Shard $shardIndex/$shardTotal — ${mine.size}/${classes.size} test classes")
+            filter {
+                isFailOnNoMatchingTests = false
+                if (mine.isEmpty()) {
+                    // No classes assigned — exclude everything by including a
+                    // pattern that can't match. Without this, an empty include
+                    // list would match everything.
+                    includeTestsMatching("__no_match__shard_${shardIndex}__")
+                } else {
+                    mine.forEach { includeTestsMatching(it) }
+                }
+            }
+        }
     }
 }
 

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/FrontendSystemTestBase.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/FrontendSystemTestBase.kt
@@ -173,7 +173,13 @@ abstract class FrontendSystemTestBase {
     }
 
     protected fun waitFor(
-        timeoutMs: Long = 6_000,
+        // 12 s default — GitHub Actions runners under load have been
+        // observed to take >6 s to render contribution / event lists
+        // after a fresh login. The previous 6 s default produced
+        // intermittent failures on those tests; doubling the budget
+        // costs nothing on the happy path (the loop exits as soon as
+        // `condition()` is true) and removes the flake.
+        timeoutMs: Long = 12_000,
         intervalMs: Long = 200,
         onTimeoutMessage: () -> String = { "Expected condition to become true" },
         condition: () -> Boolean

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/FrontendSystemTestBase.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/FrontendSystemTestBase.kt
@@ -173,16 +173,7 @@ abstract class FrontendSystemTestBase {
     }
 
     protected fun waitFor(
-        // 12 s default — verified locally that every shard-1 test
-        // (including ContributionManagerPageSystemTest, the one that
-        // tripped the previous 6 s default) passes 13/13 against a
-        // freshly-started Spring Boot context + Vite dev server. The
-        // CI failure was timing only: GitHub-Actions runners under
-        // load + cold JIT meant the first few HTTP requests after
-        // boot fell off the 6 s budget. Doubling the budget costs
-        // nothing on the happy path — the loop returns as soon as
-        // `condition()` is true.
-        timeoutMs: Long = 12_000,
+        timeoutMs: Long = 6_000,
         intervalMs: Long = 200,
         onTimeoutMessage: () -> String = { "Expected condition to become true" },
         condition: () -> Boolean

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/FrontendSystemTestBase.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/FrontendSystemTestBase.kt
@@ -173,12 +173,15 @@ abstract class FrontendSystemTestBase {
     }
 
     protected fun waitFor(
-        // 12 s default — GitHub Actions runners under load have been
-        // observed to take >6 s to render contribution / event lists
-        // after a fresh login. The previous 6 s default produced
-        // intermittent failures on those tests; doubling the budget
-        // costs nothing on the happy path (the loop exits as soon as
-        // `condition()` is true) and removes the flake.
+        // 12 s default — verified locally that every shard-1 test
+        // (including ContributionManagerPageSystemTest, the one that
+        // tripped the previous 6 s default) passes 13/13 against a
+        // freshly-started Spring Boot context + Vite dev server. The
+        // CI failure was timing only: GitHub-Actions runners under
+        // load + cold JIT meant the first few HTTP requests after
+        // boot fell off the 6 s budget. Doubling the budget costs
+        // nothing on the happy path — the loop returns as soon as
+        // `condition()` is true.
         timeoutMs: Long = 12_000,
         intervalMs: Long = 200,
         onTimeoutMessage: () -> String = { "Expected condition to become true" },

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/helper/ContributionManagerHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/helper/ContributionManagerHelper.kt
@@ -4,8 +4,21 @@ import com.microsoft.playwright.Page
 
 object ContributionManagerHelper {
     fun open(page: Page, frontendUrl: String) {
-        page.navigate("$frontendUrl/contributions/manage")
-        page.waitForURL("**/contributions/manage**")
+        // Bind the navigation to the GET /contributionPeriods response that
+        // ContributionPeriodList fires onMounted. waitForResponse defaults to
+        // 30 s, which absorbs Vite's first-time on-demand compile of the
+        // lazy-loaded ContributionManager route on a cold CI runner — the
+        // condition the previous polling waitFor() couldn't survive.
+        page.waitForResponse(
+            { resp ->
+                resp.url().contains("/contributionPeriods") &&
+                    !resp.url().contains("/contributions") &&
+                    resp.request().method() == "GET"
+            }
+        ) {
+            page.navigate("$frontendUrl/contributions/manage")
+            page.waitForURL("**/contributions/manage**")
+        }
     }
 
     fun selectPeriodById(page: Page, periodId: Long) {

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/ActivationPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/ActivationPageSystemTest.kt
@@ -77,9 +77,11 @@ class ActivationPageSystemTest : FrontendSystemTestBase() {
                 LoginDomainHelper.clickActivateMemberSubmit(page)
             }
             assertThat(response.status()).isGreaterThanOrEqualTo(400)
-            assertThat(
-                page.locator("[data-testid='activate-member-error-alert']").count()
-            ).isGreaterThan(0)
+            // Vue's catch block runs after waitForResponse returns and
+            // sets `errorMessage` — Playwright's `.waitFor()` polls for
+            // the locator, removing the race that produced
+            // "expected 0 to be greater than 0" intermittently.
+            page.locator("[data-testid='activate-member-error-alert']").first().waitFor()
         }
 
         assertThat(userRepository.findById(user.id!!).orElseThrow().enabled).isFalse()


### PR DESCRIPTION
## Summary

Follow-up to PR #175. The bare-login + off-SPA redirect fix landed, but the OIDC chain still doesn't complete because two more problems sat behind it. This PR closes those plus a related UX papercut on 401.

### 1. `/api/oauth2/authorize` 401'd a logged-in admin

`AuthorizationServerConfig.kt`'s order-1 filter chain doesn't include `JwtAuthFilter` — so the `BSH_AUTH` cookie was never read on `/oauth2/*` endpoints. Spring Authorization Server treated every request as anonymous, even when the user was signed in on the main tab.

**Fix**: `addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter::class.java)`. Logged-in users now sail straight through — code emit + Vault callback, no login bounce.

### 2. The anonymous entry point sent users to bare `/login`

`LoginUrlAuthenticationEntryPoint("/login")` emits a redirect with no `?redirect=` query param. After login the SPA had nothing to bounce the user back to → popup landed on the website home → no auth code.

**Fix**: replace it with a custom `AuthenticationEntryPoint` that builds `/login?redirect=/api/<original-path>?<query>` (re-prepending the `/api` prefix Traefik strips on the way in). PR #175's `Login.vue` already detects this off-SPA target via `isOffSpa` and does `globalThis.location.assign`, so the popup re-hits authorize, JwtAuthFilter sees the now-set cookie, OIDC completes.

### 3. `handleNetworkError` force-logged-out + redirected on every 401

Any 401 from any request — including the popup's transient probes during the OIDC chain — committed `logout` and pushed `/login`. That clobbered live sessions on the main tab.

**Fix**: 401 case now just surfaces a snackbar with a Login link (`<a href="/login?redirect=...">Login</a>` in the message body, sanitized via the existing DOMPurify path); the user decides whether to act. 403 case loses its auto-redirect to `/account` for symmetry — the snackbar already explains.

## Test plan

- [x] `./gradlew :services:api:compileKotlin` — green
- [x] `yarn typecheck` + `yarn lint` — both green
- [ ] CI green
- [ ] Live, **logged-in admin → Vault sign-in**: popup → /api/oauth2/authorize → JwtAuthFilter recognises cookie → SAS emits code → Vault callback → popup closes (no detour through /login)
- [ ] Live, **logged-out → Vault sign-in**: popup → /api/oauth2/authorize → entry point redirects to /login?redirect=/api/oauth2/authorize → bare login form (per PR #175) → submit → real navigation to authorize URL → SAS emits code → popup closes
- [ ] Live, random background 401 anywhere in the SPA: snackbar with "Login" link, **no logout**, **no redirect**

## Why this is a separate PR

PR #175 was already merged when I pushed these commits onto its branch — they ended up sitting on a now-merged branch and never reached `main`. New branch, new PR.