### PR TITLE
ci: warm Gradle cache in api-static so api-tests skips Maven Central

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,14 +154,23 @@ jobs:
           restore-keys: |
             gradle-${{ runner.os }}-
 
-      - name: Compile API main, test and integration-test sources
+      - name: Compile sources and warm Gradle cache for downstream jobs
+        # `resolveAllDependencies` (defined in kotlin-conventions) eagerly
+        # resolves every resolvable configuration on the listed projects so
+        # the Gradle cache this job persists contains the `jacocoAgent` /
+        # `jacocoAnt` artifacts that downstream Test tasks would otherwise
+        # be the first to fetch. Keeps `api-tests` and the system-test
+        # shards off `repo.maven.apache.org` entirely, side-stepping the
+        # Cloudflare-rate-limit 403 that has flaked the run before.
         run: |
           ./gradlew --no-daemon --build-cache \
             :services:api:compileKotlin \
             :services:api:compileTestFixturesKotlin \
             :services:api:compileTestKotlin \
             :services:api:compileIntegrationTestKotlin \
-            :services:system-tests:compileTestKotlin
+            :services:system-tests:compileTestKotlin \
+            :services:api:resolveAllDependencies \
+            :services:system-tests:resolveAllDependencies
 
       - name: Save Gradle cache
         if: always()
@@ -236,24 +245,12 @@ jobs:
             gradle-${{ runner.os }}-
 
       - name: Run API unit and integration tests
-        # Retry the Gradle invocation on failure: api-tests is the first job
-        # in the run that configures a Test task, which resolves the
-        # `jacocoAgent` configuration. A transient Cloudflare 403 from
-        # repo.maven.apache.org on that resolve has previously sunk the
-        # whole run. One retry after 30 s clears the rate-limit window.
         run: |
-          set -uo pipefail
-          attempts=3
-          for i in $(seq 1 $attempts); do
-            ./gradlew --no-daemon --build-cache \
-              :services:api:test \
-              :services:api:integrationTest \
-              :services:api:jacocoTestReport \
-              :services:api:jacocoIntegrationTestReport && exit 0
-            echo "::warning::Gradle invocation attempt $i/$attempts failed."
-            if [ "$i" -lt "$attempts" ]; then sleep 30; fi
-          done
-          exit 1
+          ./gradlew --no-daemon --build-cache \
+            :services:api:test \
+            :services:api:integrationTest \
+            :services:api:jacocoTestReport \
+            :services:api:jacocoIntegrationTestReport
 
       - name: Upload API test reports
         if: always()

--- a/build-logic/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -23,3 +23,23 @@ kotlin {
 tasks.withType<Test> {
     useJUnitPlatform()
 }
+
+// Cache-warming hook for CI. The `api-static` job runs this on every
+// Kotlin subproject so the Gradle cache it persists is a superset of
+// what every downstream Test/IntegrationTest job needs — including
+// `jacocoAgent` / `jacocoAnt`, which are otherwise resolved lazily
+// the first time a Test task is configured. Without this, the api-tests
+// job is the canary that eats every transient repo.maven.apache.org 403.
+tasks.register("resolveAllDependencies") {
+    description = "Resolves every resolvable configuration to warm the Gradle cache."
+    group = "build setup"
+    notCompatibleWithConfigurationCache("Resolves configurations at execution time.")
+    doLast {
+        configurations
+            .matching { it.isCanBeResolved }
+            .forEach { cfg ->
+                runCatching { cfg.resolve() }
+                    .onFailure { logger.warn("Skipping ${cfg.name}: ${it.message}") }
+            }
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the 3× retry-loop band-aid in `api-tests` with a real fix:
  pre-resolve every resolvable configuration in `api-static` so the
  Gradle cache it saves is complete. Downstream jobs (`api-tests` and
  the four system-test shards) restore that cache and never touch
  `repo.maven.apache.org` — side-stepping the Cloudflare 403 rate-limit
  that has been killing runs.
- Adds a `resolveAllDependencies` task to `kotlin-conventions` so any
  Kotlin subproject gets the warm-up hook for free.

## Root cause

`api-static`'s compile tasks only resolve compile-time configurations.
`jacocoAgent` / `jacocoAnt` are resolved lazily the first time a `Test`
task is configured — i.e. in `api-tests`. That made `api-tests` the
canary that ate every transient Maven Central flake. With this PR the
cache is fully populated before any Test task runs, so the lazy resolve
is a cache hit.

## Test plan

- [ ] CI green on this branch — in particular `api-tests` finishes without
      "Could not GET … repo.maven.apache.org" and without any "Gradle
      invocation attempt N/3 failed" warnings (the retry loop is gone).
- [ ] Local sanity: `./gradlew :services:api:resolveAllDependencies
      :services:system-tests:resolveAllDependencies` succeeds and
      `org.jacoco.agent-0.8.14.jar` is present under
      `~/.gradle/caches/modules-2/files-2.1/org.jacoco/`.
- [ ] Local offline test: with the cache warmed,
      `./gradlew --offline :services:api:test` passes without network.