### PR TITLE
api: switch OAuth2Authorization{,Consent}Service to InMemory

### DIFF
--- a/services/api/src/main/kotlin/net/blueshell/api/platform/oidc/AuthorizationServerConfig.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/oidc/AuthorizationServerConfig.kt
@@ -6,14 +6,12 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.annotation.Order
-import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.security.config.Customizer
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
-import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationConsentService
-import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationService
+import org.springframework.security.oauth2.server.authorization.InMemoryOAuth2AuthorizationConsentService
+import org.springframework.security.oauth2.server.authorization.InMemoryOAuth2AuthorizationService
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService
-import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository
 import net.blueshell.api.infrastructure.security.JwtAuthFilter
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.authorization.OAuth2AuthorizationServerConfigurer
 import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings
@@ -101,19 +99,26 @@ class AuthorizationServerConfig {
             .build()
     }
 
+    // In-memory rather than JDBC: JdbcOAuth2AuthorizationService roundtrips
+    // OAuth2Authorization (incl. the principal Authentication) through Jackson
+    // to/from `oauth2_authorization.attributes` LONGTEXT. Our `UserPrincipal`
+    // (a Kotlin data class implementing UserDetails) isn't registered in
+    // SecurityJackson2Modules' allowlist, so the row written at /oauth2/authorize
+    // can't be deserialised back at /oauth2/token — Spring SAS treats the auth
+    // code as not-found and emits `invalid_grant` (which Vault's UI surfaces
+    // as "callback did not supply all required parameters", and Headlamp as
+    // "oauth2: invalid_grant"). The api Deployment is replicas=1 and auth
+    // codes are short-lived (~5 min), so an in-process store has no
+    // operational downside today; if we ever scale out, the right fix is to
+    // configure JdbcOAuth2AuthorizationService with a custom ObjectMapper that
+    // knows how to serialise UserPrincipal.
     @Bean
-    fun authorizationService(
-        jdbcTemplate: JdbcTemplate,
-        registeredClientRepository: RegisteredClientRepository,
-    ): OAuth2AuthorizationService {
-        return JdbcOAuth2AuthorizationService(jdbcTemplate, registeredClientRepository)
+    fun authorizationService(): OAuth2AuthorizationService {
+        return InMemoryOAuth2AuthorizationService()
     }
 
     @Bean
-    fun authorizationConsentService(
-        jdbcTemplate: JdbcTemplate,
-        registeredClientRepository: RegisteredClientRepository,
-    ): OAuth2AuthorizationConsentService {
-        return JdbcOAuth2AuthorizationConsentService(jdbcTemplate, registeredClientRepository)
+    fun authorizationConsentService(): OAuth2AuthorizationConsentService {
+        return InMemoryOAuth2AuthorizationConsentService()
     }
 }


### PR DESCRIPTION
## Summary

- After PR #176 made `JwtAuthFilter` actually authenticate users on `/oauth2/*`, the JDBC-backed `OAuth2AuthorizationService` started round-tripping our `UserPrincipal` Kotlin data class through Jackson — and our principal isn't in `SecurityJackson2Modules`' allowlist, so the auth-code row written at `/oauth2/authorize` can't be deserialised back at `/oauth2/token`. Spring SAS treats the code as not-found and emits `invalid_grant`.
- Headlamp shows that verbatim ("Failed to exchange token: oauth2: invalid_grant"). Vault's UI mistranslates the upstream token-exchange error as "callback did not supply all of the required parameters" — code and state DO arrive on `vault.../oidc/callback`; it's the subsequent token POST that fails.
- Replace `JdbcOAuth2AuthorizationService` / `JdbcOAuth2AuthorizationConsentService` with the in-memory variants. The api Deployment runs at `replicas=1` and auth codes live ~5 min, so persistence buys nothing today and the in-memory store keeps the `Authentication` object alive without touching JSON.
- If we ever scale out the api, the correct follow-up is to configure `JdbcOAuth2AuthorizationService` with a custom `ObjectMapper` that registers a `UserPrincipalMixin`. That's flagged in the inline comment so it doesn't get lost.

## Test plan

- [ ] CI green.
- [ ] Live: log in to the SPA as an admin, click the Vault tile in `/myapps`, sign-in popup completes and the main Vault tab shows the `admin` OIDC role.
- [ ] Live: same flow for Headlamp — popup at `https://headlamp.esa-blueshell.nl/oidc-callback?code=...` exchanges the code and Headlamp lands on the cluster overview, no `invalid_grant`.
- [ ] Live (optional): tail `kubectl logs -n core-system deploy/api -f` while logging in — no `Cannot deserialize` / `OAuth2Authorization` lookup-miss errors.

## Out of scope

- Dropping the now-unused `oauth2_authorization` / `oauth2_authorization_consent` / `oauth2_registered_client` tables (V54). Separate PR — keeping the schema around in case we re-enable JDBC with a proper mixin.
- Replacing the `OAuth2AuthorizationCodeRequestAuthenticationException` thrown from `OidcTokenCustomizer` with a plain `OAuth2AuthenticationException` (the former is meant for the authorize step, not token issuance). Not actively breaking anything for admin users; cleanup later.