### PR TITLE
api+platform: fix OIDC sign-in to Vault by moving admin gate off the token endpoint

### DIFF
--- a/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
+++ b/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
@@ -121,6 +121,32 @@ EOF
 # platform/mail (stalwart admin, bounce mailbox, DKIM),
 # platform/ghcr (GitHub PAT for pulling private ghcr.io images).
 # See platform/docs/vault-bootstrap.md §4 for the full key list.
+cat <<'EOF' >/tmp/admin.hcl
+# Broad operator policy attached to OIDC-issued tokens for users with
+# ROLE_ADMIN. Mirrors the access an interactive Vault administrator
+# needs through the UI: read/write on every KV-v2 secret, manage auth
+# methods + policies + transit keys, list mounts, lookup own token,
+# inspect dynamic-secret roles. Excludes raw-storage and sys/seal so
+# accidental destruction stays gated on the unseal flow.
+path "secret/*"        { capabilities = ["create", "read", "update", "delete", "list"] }
+path "secret/data/*"   { capabilities = ["create", "read", "update", "delete", "list"] }
+path "secret/metadata/*" { capabilities = ["create", "read", "update", "delete", "list"] }
+path "transit/*"       { capabilities = ["create", "read", "update", "delete", "list"] }
+path "database/*"      { capabilities = ["create", "read", "update", "delete", "list"] }
+path "auth/*"          { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
+path "sys/auth"        { capabilities = ["read", "list"] }
+path "sys/auth/*"      { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
+path "sys/policies/acl"   { capabilities = ["list"] }
+path "sys/policies/acl/*" { capabilities = ["create", "read", "update", "delete", "list"] }
+path "sys/mounts"      { capabilities = ["read", "list"] }
+path "sys/mounts/*"    { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
+path "sys/health"      { capabilities = ["read"] }
+path "sys/capabilities-self" { capabilities = ["update"] }
+path "auth/token/lookup-self"  { capabilities = ["read"] }
+path "auth/token/renew-self"   { capabilities = ["update"] }
+path "auth/token/revoke-self"  { capabilities = ["update"] }
+EOF
+
 cat <<'EOF' >/tmp/vso.hcl
 path "secret/data/platform/edge" {
   capabilities = ["read"]
@@ -151,6 +177,7 @@ vault policy write api /tmp/api.hcl
 vault policy write listmonk /tmp/listmonk.hcl
 vault policy write stalwart /tmp/stalwart.hcl
 vault policy write vso /tmp/vso.hcl
+vault policy write admin /tmp/admin.hcl
 
 # --- Kubernetes auth roles ---------------------------------------------
 
@@ -249,11 +276,24 @@ if vault kv get -field=vault-oidc-client-secret secret/api >/dev/null 2>&1; then
       oidc_client_id="vault" \
       oidc_client_secret="${OIDC_CLIENT_SECRET}" \
       default_role="admin"; then
+    # `groups_claim` + `oidc_scopes` + `bound_claims` mirror the working
+    # `personal-stack-2` setup. The api's OidcTokenCustomizer emits a
+    # `groups` claim under the `groups` scope and a `roles` claim
+    # populated from Role.name (e.g. "ADMIN"). `bound_claims` here is
+    # belt-and-braces — the api already 403s non-admins at
+    # /oauth2/authorize via downstreamClientAuthorizationFilter — but
+    # also stops a regression on that filter from leaking access. We
+    # bind on Role.reprString rather than "ROLE_ADMIN" because that is
+    # what UserPrincipal.getAuthorities surfaces and what the customizer
+    # emits into the `roles` claim.
     vault write auth/oidc/role/admin \
       bound_audiences="vault" \
       allowed_redirect_uris="https://vault.esa-blueshell.nl/ui/vault/auth/oidc/oidc/callback" \
       user_claim="sub" \
-      policies="default"
+      groups_claim="groups" \
+      oidc_scopes="openid,profile,email,groups" \
+      bound_claims='{"roles":["ADMIN"]}' \
+      token_policies="admin"
   else
     echo "auth/oidc/config write failed (api OIDC discovery URL likely not"
     echo "reachable yet — fresh cluster, apps-stateless not Ready). Skipping"

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/oidc/AuthorizationServerConfig.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/oidc/AuthorizationServerConfig.kt
@@ -2,26 +2,35 @@ package net.blueshell.api.platform.oidc
 
 import com.nimbusds.jose.jwk.source.JWKSource
 import com.nimbusds.jose.proc.SecurityContext
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import net.blueshell.api.infrastructure.security.JwtAuthFilter
+import net.blueshell.api.shared.enums.Role
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.annotation.Order
+import org.springframework.security.authentication.AnonymousAuthenticationToken
 import org.springframework.security.config.Customizer
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configurers.oauth2.server.authorization.OAuth2AuthorizationServerConfigurer
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.oauth2.server.authorization.InMemoryOAuth2AuthorizationConsentService
 import org.springframework.security.oauth2.server.authorization.InMemoryOAuth2AuthorizationService
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService
-import net.blueshell.api.infrastructure.security.JwtAuthFilter
-import org.springframework.security.config.annotation.web.configurers.oauth2.server.authorization.OAuth2AuthorizationServerConfigurer
 import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings
 import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext
 import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenCustomizer
 import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.web.filter.OncePerRequestFilter
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+
+private val ADMIN_ONLY_CLIENTS = setOf("headlamp", "vault")
 
 @Configuration
 class AuthorizationServerConfig {
@@ -51,6 +60,14 @@ class AuthorizationServerConfig {
             // is missing or invalid, it's a no-op and the entry point
             // below kicks in.
             .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter::class.java)
+            // Gate non-admin users out of admin-only clients (vault,
+            // headlamp) at /oauth2/authorize. Doing this here rather
+            // than from the OAuth2TokenCustomizer means Spring SAS sees
+            // a clean 403 *before* an authorization code is issued —
+            // throwing from the customizer at /oauth2/token bubbles up
+            // as `invalid_grant`, which Vault's UI surfaces as
+            // "callback did not supply all of the required parameters".
+            .addFilterAfter(downstreamClientAuthorizationFilter(), JwtAuthFilter::class.java)
             .exceptionHandling {
                 it.authenticationEntryPoint(loginRedirectEntryPoint())
             }
@@ -58,6 +75,39 @@ class AuthorizationServerConfig {
 
         return http.build()
     }
+
+    private fun downstreamClientAuthorizationFilter(): OncePerRequestFilter =
+        object : OncePerRequestFilter() {
+            override fun shouldNotFilter(request: HttpServletRequest): Boolean =
+                request.requestURI != "/oauth2/authorize"
+
+            override fun doFilterInternal(
+                request: HttpServletRequest,
+                response: HttpServletResponse,
+                filterChain: FilterChain,
+            ) {
+                val clientId = request.getParameter("client_id")
+                if (clientId == null || clientId !in ADMIN_ONLY_CLIENTS) {
+                    filterChain.doFilter(request, response)
+                    return
+                }
+                val auth = SecurityContextHolder.getContext().authentication
+                if (auth == null || auth is AnonymousAuthenticationToken || !auth.isAuthenticated) {
+                    // Unauthenticated — let the entry point redirect to /login.
+                    filterChain.doFilter(request, response)
+                    return
+                }
+                val isAdmin = auth.authorities.any { it.authority == Role.ADMIN.reprString }
+                if (!isAdmin) {
+                    response.sendError(
+                        HttpServletResponse.SC_FORBIDDEN,
+                        "Admin access required for $clientId",
+                    )
+                    return
+                }
+                filterChain.doFilter(request, response)
+            }
+        }
 
     /**
      * Sends anonymous callers to the SPA's /login page with the original

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/oidc/OidcTokenCustomizer.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/oidc/OidcTokenCustomizer.kt
@@ -4,13 +4,11 @@ import net.blueshell.api.shared.enums.Role
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.core.Authentication
-import org.springframework.security.oauth2.core.OAuth2Error
-import org.springframework.security.oauth2.core.OAuth2ErrorCodes
-import org.springframework.security.oauth2.server.authorization.authentication.OAuth2AuthorizationCodeRequestAuthenticationException
+import org.springframework.security.oauth2.core.oidc.OidcScopes
+import org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenType
 import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext
 import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenCustomizer
-
-private val ADMIN_ONLY_CLIENTS = setOf("headlamp", "vault")
 
 @Configuration
 class OidcTokenCustomizer(private val userLoader: OidcUserLoader) {
@@ -21,20 +19,37 @@ class OidcTokenCustomizer(private val userLoader: OidcUserLoader) {
             val principal = context.getPrincipal<Authentication>().name ?: return@OAuth2TokenCustomizer
             val user = userLoader.load(principal) ?: return@OAuth2TokenCustomizer
 
+            val roles = user.roles.map { it.name }
+            val subject = user.userId.toString()
             val clientId = context.registeredClient.clientId
-            if (clientId in ADMIN_ONLY_CLIENTS && !user.roles.any { it.matchesRole(Role.ADMIN) }) {
-                throw OAuth2AuthorizationCodeRequestAuthenticationException(
-                    OAuth2Error(OAuth2ErrorCodes.ACCESS_DENIED, "Admin access required for $clientId", null),
-                    null,
-                )
-            }
 
-            context.claims.apply {
-                claim("preferred_username", user.username)
-                claim("email", user.email)
-                claim("name", "${user.firstName} ${user.lastName}".trim())
-                claim("roles", user.roles.map { it.name })
-                claim("groups", user.roles.toGroups())
+            when {
+                context.tokenType == OAuth2TokenType.ACCESS_TOKEN -> {
+                    context.claims.subject(subject)
+                    context.claims.claim("aud", listOf(clientId))
+                    context.claims.claim("roles", roles)
+                    context.claims.claim("username", user.username)
+                    context.claims.claim("preferred_username", user.username)
+                    context.claims.claim("email", user.email)
+                }
+
+                context.tokenType.value == OidcParameterNames.ID_TOKEN -> {
+                    context.claims.subject(subject)
+                    context.claims.claim("roles", roles)
+
+                    if (OidcScopes.PROFILE in context.authorizedScopes) {
+                        context.claims.claim("preferred_username", user.username)
+                        context.claims.claim("name", "${user.firstName} ${user.lastName}".trim())
+                    }
+
+                    if (OidcScopes.EMAIL in context.authorizedScopes) {
+                        context.claims.claim("email", user.email)
+                    }
+
+                    if ("groups" in context.authorizedScopes) {
+                        context.claims.claim("groups", user.roles.toGroups())
+                    }
+                }
             }
         }
     }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/oidc/OidcUserLoader.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/oidc/OidcUserLoader.kt
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
 data class OidcUserData(
+    val userId: Long,
     val username: String,
     val email: String,
     val firstName: String,
@@ -24,8 +25,10 @@ class OidcUserLoader(private val userService: UserService) {
         } catch (_: UserNotFoundException) {
             return null
         }
+        val id = user.id ?: return null
         val roles = user.roles.toSet()
         return OidcUserData(
+            userId = id,
             username = user.username,
             email = user.email,
             firstName = user.firstName,

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/oidc/RegisteredClients.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/oidc/RegisteredClients.kt
@@ -44,6 +44,7 @@ class RegisteredClients {
             .clientSecret("{noop}$vaultClientSecret")
             .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
             .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
             .redirectUri("https://vault.esa-blueshell.nl/ui/vault/auth/oidc/oidc/callback")
             .scope(OidcScopes.OPENID)
             .scope(OidcScopes.PROFILE)


### PR DESCRIPTION
## Summary

- Vault sign-in via OIDC failed with `Authentication failed: The callback from the provider did not supply all of the required parameters` — that string is Vault's UI surface for an `invalid_grant` returned by `/oauth2/token` (already documented in `AuthorizationServerConfig.kt:102-114`). The redirect was fine; the back-channel token exchange was failing.
- Root cause: `OidcTokenCustomizer` threw `OAuth2AuthorizationCodeRequestAuthenticationException` at JWT-encoding time whenever the principal lacked `ROLE_ADMIN`. That exception type is meant for the authorization endpoint, not token issuance — Spring SAS treated it as a generic code-to-token failure and emitted `invalid_grant`.
- Move the admin gate to a `OncePerRequestFilter` on `/oauth2/authorize` (`downstreamClientAuthorizationFilter`), 403ing non-admins before any authorization code is ever issued. Mirrors the working pattern from `personal-stack-2`.
- Restructure `OidcTokenCustomizer` to branch on `OAuth2TokenType.ACCESS_TOKEN` vs `OidcParameterNames.ID_TOKEN`, set `aud=[clientId]` and a stable `subject` on access tokens, and scope-gate ID-token claims (`profile`, `email`, `groups`). Anchor `sub` on the persisted user id by adding `userId` to `OidcUserData`.
- Add `AuthorizationGrantType.REFRESH_TOKEN` to the `vault` registered client so Vault's session-extension calls don't hit `unauthorized_client`.
- Tighten `auth/oidc/role/admin` in `bootstrap-auth.sh`: add `groups_claim="groups"`, `oidc_scopes="openid,profile,email,groups"`, `bound_claims='{"roles":["ADMIN"]}'` (defence-in-depth alongside the api-side filter), and switch `token_policies` from `default` to a new `admin` policy that grants the operator capabilities a Vault administrator needs through the UI (excludes raw-storage and seal).

## Test plan

- [x] `./gradlew :services:api:compileKotlin :services:api:compileTestKotlin :services:api:compileIntegrationTestKotlin` — green.
- [x] `sh -n platform/cluster/flux/apps/data/vault/bootstrap-auth.sh` — green.
- [ ] Post-merge: `kubectl rollout restart deploy/api -n default`, then `flux reconcile kustomization apps-data --timeout=5m`. Tail `kubectl logs -n data-system -l app.kubernetes.io/name=vault-bootstrap-auth -f` and confirm the new role write succeeds (no error on the `groups_claim`/`oidc_scopes`/`bound_claims` fields).
- [ ] Sign in to `https://vault.esa-blueshell.nl/ui/vault/auth/oidc/oidc` as an admin user → expect a successful round-trip (no callback-error), and the resulting Vault token carries the `admin` policy.
- [ ] Negative-path: sign in as a non-admin → expect a 403 from the api at the authorize step (`Admin access required for vault`), not the misleading callback error from Vault.
- [ ] Optional: capture the issued ID token from a successful flow and decode it; confirm `aud=vault`, `sub=<numeric user id>`, `roles` array contains `ADMIN`, `groups` array contains `k8s-admin`.