### PR TITLE
api: stamp kid/alg/use on Transit JWKS so Vault's go-oidc picks the key

### DIFF
--- a/services/api/src/main/kotlin/net/blueshell/api/platform/oidc/VaultTransitJwkSource.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/oidc/VaultTransitJwkSource.kt
@@ -1,7 +1,9 @@
 package net.blueshell.api.platform.oidc
 
+import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.JWKSelector
 import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.KeyUse
 import com.nimbusds.jose.jwk.RSAKey
 import com.nimbusds.jose.jwk.source.JWKSource
 import com.nimbusds.jose.proc.SecurityContext
@@ -47,7 +49,17 @@ class VaultTransitJwkSource(
 
     private fun refresh() {
         val publicKeys = client.readPublicKeys(keyName)
-        val jwks = publicKeys.map { RSAKey.parseFromPEMEncodedObjects(it.publicKeyPem) as RSAKey }
+        // kid/alg/use MUST be set on the published JWK: go-oidc-v3 (Vault's verifier)
+        // skips any JWKS key whose `kid` doesn't match the JWT header's `kid`, and
+        // VaultTransitJwtEncoder writes kid="$keyName:v$version" into the header.
+        val jwks = publicKeys.map { vk ->
+            val parsed = RSAKey.parseFromPEMEncodedObjects(vk.publicKeyPem) as RSAKey
+            RSAKey.Builder(parsed)
+                .keyID("$keyName:v${vk.keyVersion}")
+                .algorithm(JWSAlgorithm.RS256)
+                .keyUse(KeyUse.SIGNATURE)
+                .build()
+        }
         if (jwks.isEmpty()) error("Vault returned no public keys for transit key '$keyName'")
         current.set(JWKSet(jwks))
     }

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/oidc/VaultTransitJwkSourceTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/oidc/VaultTransitJwkSourceTest.kt
@@ -20,7 +20,7 @@ class VaultTransitJwkSourceTest {
     private val selector = JWKSelector(JWKMatcher.Builder().build())
 
     @Test
-    fun `initial refresh succeeds and get returns the cached key`() {
+    fun `initial refresh succeeds and get returns the cached key with kid alg use`() {
         val (pem, modulus) = generateRsaPem()
         val client: VaultTransitClient = mock()
         whenever(client.readPublicKeys(eq(keyName)))
@@ -30,7 +30,13 @@ class VaultTransitJwkSourceTest {
 
         val keys = source.get(selector, null)
         assertThat(keys).hasSize(1)
-        assertThat((keys.single() as RSAKey).modulus.decodeToBigInteger()).isEqualTo(modulus)
+        val rsa = keys.single() as RSAKey
+        assertThat(rsa.modulus.decodeToBigInteger()).isEqualTo(modulus)
+        // Must match the kid VaultTransitJwtEncoder writes into the JWT header;
+        // go-oidc-v3 (Vault) filters JWKS keys by kid and would skip otherwise.
+        assertThat(rsa.keyID).isEqualTo("$keyName:v1")
+        assertThat(rsa.algorithm?.name).isEqualTo("RS256")
+        assertThat(rsa.keyUse?.identifier()).isEqualTo("sig")
     }
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/playwright/VaultTransitJwksPlaywrightTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/playwright/VaultTransitJwksPlaywrightTest.kt
@@ -105,5 +105,13 @@ class VaultTransitJwksPlaywrightTest {
         assertThat(first["kty"]?.asString()).isEqualTo("RSA")
         assertThat(first["n"]?.asString()).isNotBlank()
         assertThat(first["e"]?.asString()).isNotBlank()
+        // kid/alg/use must be present and match what VaultTransitJwtEncoder
+        // stamps into the JWT header — go-oidc-v3 (Vault) filters JWKS keys
+        // by kid and refuses to verify when there's no match.
+        assertThat(first["kid"]?.asString())
+            .withFailMessage("JWKS key must carry kid='api-jwt:v<N>' so Vault's go-oidc verifier picks it up")
+            .startsWith("api-jwt:v")
+        assertThat(first["alg"]?.asString()).isEqualTo("RS256")
+        assertThat(first["use"]?.asString()).isEqualTo("sig")
     }
 }


### PR DESCRIPTION
## Summary

Vault sign-in after #190 + #191 still failed:

```
Provider.VerifyIDToken: invalid id_token: failed to verify signature:
failed to verify id token signature: invalid signature
```

Diagnosed cryptographically against the live cluster: I signed a known payload via `transit/sign/api-jwt`, then verified it directly with both the JWKS-published public key and the Transit-engine PEM. **Both verify cleanly.** Same RSA modulus, RS256 with PKCS1v15+SHA256, signature length 256 — the crypto is correct end-to-end. So the failure was upstream of the actual signature check.

**Root cause.** The published JWK had no `kid`, no `alg`, no `use` — just `{kty, e, n}`. `VaultTransitJwtEncoder` writes `kid="api-jwt:v1"` into the JWT header. Vault's verifier is coreos/go-oidc-v3, which filters JWKS keys by `kid`:

```go
for _, key := range keys {
    if keyID == "" || key.KeyID == keyID {        // header.kid="api-jwt:v1" != JWK.KeyID=""
        if payload, err := jws.Verify(&key); err == nil { return payload, nil }
    }
}
return nil, errors.New("failed to verify id token signature")
```

Every key skipped → error. Nimbus's `RSAKey.parseFromPEMEncodedObjects` leaves kid/alg/use unset, and `VaultTransitJwkSource.refresh()` published the parsed key as-is.

## Fix

Three lines in `VaultTransitJwkSource.refresh()` — rebuild each parsed RSAKey with kid/alg/use stamped to match what the encoder writes:

```kotlin
RSAKey.Builder(parsed)
    .keyID("$keyName:v${vk.keyVersion}")
    .algorithm(JWSAlgorithm.RS256)
    .keyUse(KeyUse.SIGNATURE)
    .build()
```

Unit test now asserts `kid="$keyName:v1"`, `alg="RS256"`, `use="sig"` on the published JWK. System test (`VaultTransitJwksPlaywrightTest`) asserts the same on `/oauth2/jwks` against the live api in the `oidc-e2e` compose stack.

## Verified locally

```
JWKS public key sha256(n)        = 37cfe9d8…
Transit api-jwt v1 sha256(n)     = 37cfe9d8…   ← identical
JWKS[0] verify of vault-signed:  ✓ VERIFIES
Transit v1 verify of vault-signed: ✓ VERIFIES
```

After fix, `/oauth2/jwks` returns:
```json
{"kty":"RSA","e":"AQAB","use":"sig","kid":"api-jwt:v1","alg":"RS256","n":"..."}
```

## Test plan
- [x] `./gradlew :services:api:test --tests VaultTransitJwkSourceTest` (4/4)
- [x] `./gradlew :services:system-tests:vaultOidcLiveTest` against compose stack — green
- [ ] After merge + deploy: `vault login -method=oidc` completes
- [ ] Headlamp OIDC completes