### PR TITLE
api: forward-auth returns 401/403 for XHR, 302 for HTML

### DIFF
--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/web/oidc/ForwardAuthControllerIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/web/oidc/ForwardAuthControllerIT.kt
@@ -15,10 +15,11 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
  * Verifies the per-host role gating that Traefik forwardAuth delegates
  * to. Each test sends a GET to `/oauth2/forward-auth` with the
  * `X-Forwarded-Host` (and `X-Forwarded-Uri`) headers Traefik would set;
- * the controller is expected to return either:
- *  - 200 with X-User-Id / X-User-Groups (authenticated + role OK), or
- *  - 302 to /login (anonymous), or
- *  - 302 to /unauthorized (authenticated but role too low).
+ * the controller branches on the Accept header:
+ *  - text/html (browser navigation) → 302 to /login or /unauthorized
+ *  - anything else (SPA XHR) → 401 or 403 so the cross-origin auto-follow
+ *    doesn't get CORS-blocked
+ *  - authorised → 200 with X-User-Id / X-User-Groups
  */
 @SpringBootTest
 class ForwardAuthControllerIT : UserTestSupport() {
@@ -26,9 +27,10 @@ class ForwardAuthControllerIT : UserTestSupport() {
     @Nested
     inner class Anonymous {
         @Test
-        fun `redirects anonymous caller to login with the original URL preserved as redirect query`() {
+        fun `redirects anonymous HTML navigation to login with the original URL preserved as redirect query`() {
             mvc.perform(
                 get("/oauth2/forward-auth")
+                    .header(HttpHeaders.ACCEPT, "text/html")
                     .header("X-Forwarded-Proto", "https")
                     .header("X-Forwarded-Host", "vault.esa-blueshell.nl")
                     .header("X-Forwarded-Uri", "/ui/dashboard")
@@ -39,9 +41,22 @@ class ForwardAuthControllerIT : UserTestSupport() {
         }
 
         @Test
-        fun `unknown host falls back to ADMIN required and still redirects anonymous to login`() {
+        fun `anonymous XHR receives 401 with WWW-Authenticate instead of cross-origin redirect`() {
             mvc.perform(
                 get("/oauth2/forward-auth")
+                    .header(HttpHeaders.ACCEPT, "application/json")
+                    .header("X-Forwarded-Host", "stalwart.esa-blueshell.nl")
+                    .header("X-Forwarded-Uri", "/api/principal")
+            )
+                .andExpect(status().isUnauthorized)
+                .andExpect(header().string(HttpHeaders.WWW_AUTHENTICATE, org.hamcrest.Matchers.startsWith("Bearer realm=")))
+        }
+
+        @Test
+        fun `unknown host with HTML accept falls back to ADMIN required and still redirects anonymous to login`() {
+            mvc.perform(
+                get("/oauth2/forward-auth")
+                    .header(HttpHeaders.ACCEPT, "text/html")
                     .header("X-Forwarded-Host", "rogue.example.com")
                     .header("X-Forwarded-Uri", "/")
             )
@@ -53,11 +68,12 @@ class ForwardAuthControllerIT : UserTestSupport() {
     @Nested
     inner class WrongRole {
         @Test
-        fun `member hitting vault is redirected to unauthorized with the service in the query`() {
+        fun `member HTML navigation to vault is redirected to unauthorized with the service in the query`() {
             val member = createUserWithRole(Role.MEMBER)
             mvc.perform(
                 get("/oauth2/forward-auth")
                     .with(bearer(member))
+                    .header(HttpHeaders.ACCEPT, "text/html")
                     .header("X-Forwarded-Host", "vault.esa-blueshell.nl")
                     .header("X-Forwarded-Uri", "/")
             )
@@ -66,16 +82,29 @@ class ForwardAuthControllerIT : UserTestSupport() {
         }
 
         @Test
-        fun `board hitting vault is redirected to unauthorized — board does not inherit admin`() {
+        fun `board HTML navigation to vault is redirected to unauthorized — board does not inherit admin`() {
             val board = createUserWithRole(Role.BOARD)
             mvc.perform(
                 get("/oauth2/forward-auth")
                     .with(bearer(board))
+                    .header(HttpHeaders.ACCEPT, "text/html")
                     .header("X-Forwarded-Host", "vault.esa-blueshell.nl")
                     .header("X-Forwarded-Uri", "/")
             )
                 .andExpect(status().isFound)
                 .andExpect(header().string(HttpHeaders.LOCATION, "https://v2.esa-blueshell.nl/unauthorized?service=vault.esa-blueshell.nl"))
+        }
+
+        @Test
+        fun `member XHR on board-gated host receives 403, not redirect`() {
+            val member = createUserWithRole(Role.MEMBER)
+            mvc.perform(
+                get("/oauth2/forward-auth")
+                    .with(bearer(member))
+                    .header(HttpHeaders.ACCEPT, "application/json")
+                    .header("X-Forwarded-Host", "stalwart.esa-blueshell.nl")
+            )
+                .andExpect(status().isForbidden)
         }
     }
 

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/web/oidc/ForwardAuthController.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/web/oidc/ForwardAuthController.kt
@@ -67,11 +67,27 @@ class ForwardAuthController(
             Role.ADMIN
         }
 
+        // SPAs (Stalwart webadmin, Headlamp, …) fetch their own /api/* via XHR.
+        // A 302 to v2.esa-blueshell.nl/login auto-follows cross-origin and the
+        // browser blocks it with CORS, surfacing as a generic network error in
+        // the SPA. 401 lets the SPA show a proper "session expired" state.
+        val wantsHtml = request.getHeader(HttpHeaders.ACCEPT).orEmpty().contains("text/html")
+
         if (principal == null) {
-            return redirect("$frontendBaseUrl/login?redirect=${urlEncode(originalUrl)}")
+            return if (wantsHtml) {
+                redirect("$frontendBaseUrl/login?redirect=${urlEncode(originalUrl)}")
+            } else {
+                ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .header(HttpHeaders.WWW_AUTHENTICATE, """Bearer realm="$frontendBaseUrl/login"""")
+                    .build()
+            }
         }
         if (!principal.hasAuthority(required)) {
-            return redirect("$frontendBaseUrl/unauthorized?service=${urlEncode(forwardedHost)}")
+            return if (wantsHtml) {
+                redirect("$frontendBaseUrl/unauthorized?service=${urlEncode(forwardedHost)}")
+            } else {
+                ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+            }
         }
         return ResponseEntity.ok()
             .header("X-User-Id", principal.id.toString())

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/ForwardAuthChainSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/ForwardAuthChainSystemTest.kt
@@ -126,6 +126,49 @@ class ForwardAuthChainSystemTest : OidcSystemTestBase() {
             .isEqualTo("$FRONTEND_BASE/unauthorized?service=$host")
     }
 
+    @ParameterizedTest(name = "anonymous XHR → 401 (host={0})")
+    @MethodSource("allGatedHosts")
+    fun anonymous_xhr_returns_401_not_302(host: String, @Suppress("UNUSED_PARAMETER") required: Role) {
+        // Stalwart/Headlamp/etc. SPAs fetch /api/* with Accept: application/json
+        // (no text/html). A 302 to v2.esa-blueshell.nl/login auto-follows and
+        // browser CORS-blocks it → SPA shows a generic network error. 401 lets
+        // the SPA recognise an expired session.
+        val response = java.net.http.HttpClient.newHttpClient().send(
+            java.net.http.HttpRequest.newBuilder()
+                .uri(java.net.URI.create("$baseUrl/oauth2/forward-auth"))
+                .GET()
+                .header("Accept", "application/json")
+                .header("X-Forwarded-Host", host)
+                .header("X-Forwarded-Uri", "/api/principal")
+                .header("X-Forwarded-Proto", "https")
+                .build(),
+            java.net.http.HttpResponse.BodyHandlers.discarding(),
+        )
+
+        assertThat(response.statusCode()).isEqualTo(401)
+        assertThat(response.headers().firstValue("WWW-Authenticate").orElse(""))
+            .startsWith("Bearer realm=")
+    }
+
+    @ParameterizedTest(name = "member XHR on board-gated → 403 (host={0})")
+    @MethodSource("boardGatedHosts")
+    fun member_xhr_on_board_host_returns_403(host: String, @Suppress("UNUSED_PARAMETER") required: Role) {
+        val member = userFactory.createUserWithRole(Role.MEMBER)
+
+        val response = java.net.http.HttpClient.newHttpClient().send(
+            java.net.http.HttpRequest.newBuilder()
+                .uri(java.net.URI.create("$baseUrl/oauth2/forward-auth"))
+                .GET()
+                .header("Accept", "application/json")
+                .header("Cookie", "$authCookieName=${sessionTokenFor(member.username)}")
+                .header("X-Forwarded-Host", host)
+                .build(),
+            java.net.http.HttpResponse.BodyHandlers.discarding(),
+        )
+
+        assertThat(response.statusCode()).isEqualTo(403)
+    }
+
     @Test
     fun `unknown host falls back to ADMIN-required and rejects board`() {
         val board = userFactory.createUserWithRole(Role.BOARD)


### PR DESCRIPTION
## Summary

Signed-in user opens Stalwart webadmin (`stalwart.esa-blueshell.nl/manage/...`); the SPA's XHR to its own `/api/principal` returns 302 to `v2.esa-blueshell.nl/login?…`. Browser auto-follows the redirect, hits cross-origin CORS, and the SPA surfaces a generic network error:

```
Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote
resource at https://v2.esa-blueshell.nl/login?redirect=...
(Reason: CORS header 'Access-Control-Allow-Origin' missing). Status code: 405.
```

`ForwardAuthController.kt` returns a 302 for every unauthenticated/under-privileged request — which works fine for top-level navigation but breaks any SPA-driven XHR.

## Fix

Branch on `Accept`:
- `text/html` (browser navigating to the host) → keep the existing 302 to `/login` or `/unauthorized` so users still land on a friendly page.
- Anything else (XHR / JSON / `*/*`) → return `401` with `WWW-Authenticate: Bearer realm="…/login"` for anonymous, `403` for authenticated-but-wrong-role. No CORS hop.

System tests parametrised across all five gated hosts (vault, headlamp, traefik, listmonk, stalwart) cover the new contract.

## Confirmed locally with the diagnostic

```
no-cookie       -> HTTP 302  redirect=https://v2.esa-blueshell.nl/login?…
no-cookie+html  -> HTTP 302  redirect=https://v2.esa-blueshell.nl/login?…
```

After the fix:
- HTML Accept → 302 (unchanged)
- JSON Accept → 401 with `WWW-Authenticate`
- Admin-gated host with BOARD user + JSON Accept → 403 (no redirect)

## Test plan
- [x] `./gradlew :services:system-tests:compileTestKotlin` green
- [ ] CI green
- [ ] After deploy: open Stalwart webadmin while signed in — XHRs return 401 (if cookie isn't attaching) or succeed; no CORS errors in console

## Not in this PR
If after this the SPA still gets 401 while the user is signed in, that's a separate cookie-attachment issue (BSH_AUTH not travelling to the subdomain or not being sent on the XHR). With 401 we'll see that cleanly in the SPA's network tab instead of CORS noise.