### PR TITLE
system-tests: drop explicit Playwright install, bump to 1.59.0

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -297,9 +297,6 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           yarn-version: ${{ env.YARN_VERSION }}
 
-      - name: Install Playwright browser for system tests
-        run: ./gradlew --no-daemon :services:system-tests:installChromium
-
       - name: Start instrumented frontend for system tests
         run: |
           set -euo pipefail

--- a/services/system-tests/build.gradle.kts
+++ b/services/system-tests/build.gradle.kts
@@ -59,7 +59,7 @@ dependencies {
     testImplementation("io.rest-assured:spring-mock-mvc:6.0.0")
     testImplementation("io.mockk:mockk:1.14.9")
     testImplementation("org.mockito.kotlin:mockito-kotlin:6.2.3")
-    testImplementation("com.microsoft.playwright:playwright:1.58.0")
+    testImplementation("com.microsoft.playwright:playwright:1.59.0")
     testImplementation("com.github.javafaker:javafaker:1.0.2")
     testImplementation("io.github.classgraph:classgraph:4.8.184")
 
@@ -131,24 +131,6 @@ tasks.withType<Test>().configureEach {
             }
         }
     }
-}
-
-// Playwright install helpers — required by CI before `test` runs.
-tasks.register<JavaExec>("installPlaywrightDeps") {
-    group = "playwright"
-    description = "Installs Playwright OS dependencies"
-    classpath = sourceSets["test"].runtimeClasspath
-    mainClass.set("com.microsoft.playwright.CLI")
-    args("install-deps")
-}
-
-tasks.register<JavaExec>("installChromium") {
-    group = "playwright"
-    description = "Installs Chromium (Playwright)"
-    dependsOn("installPlaywrightDeps")
-    classpath = sourceSets["test"].runtimeClasspath
-    mainClass.set("com.microsoft.playwright.CLI")
-    args("install", "chromium")
 }
 
 // Drives `/oauth2/jwks` against a real api wired to Vault Transit. Requires


### PR DESCRIPTION
## Summary
- Delete the `installPlaywrightDeps` and `installChromium` Gradle tasks from `services/system-tests/build.gradle.kts`. `Playwright.create()` auto-installs Chromium on first call (and caches under `~/.cache/ms-playwright/`), so the explicit tasks are dead weight.
- Delete the matching `Install Playwright browser for system tests` step from the `system-tests` job in `.github/workflows/validate.yml`.
- Bump the Playwright Maven dep from `1.58.0` to `1.59.0` to match `personal-stack-2` (no compile breaks, no behaviour change in our tests).

Rationale: align the website system-test Playwright setup with `personal-stack-2`, which never had install tasks — `Playwright.create()` handles browser provisioning transparently on `ubuntu-latest`. This is the first of four stacked PRs that walk the website's system-test stack onto the `personal-stack-2` shape. The remaining three move the architecture from in-process `@SpringBootTest` to a dockerised compose stack.

If the on-demand install proves too slow per shard, follow up by adding `actions/cache@v4` keyed on `~/.cache/ms-playwright/` + the Playwright version. Personal-stack-2 doesn't bother with that cache and is fine; expect the same here.

## Test plan
- [ ] CI green on this branch: all 6 `system-tests` shards pass without the explicit install step.
- [ ] Watch wall-clock for shard 1 — should be roughly equivalent to today (the dropped CI step ran the same install the first test would trigger).
- [ ] `fe-e2e` job is untouched; its NPM-side `yarn playwright install --with-deps chromium` step remains.