### PR TITLE
ci: scaffold compose-based system-test stack (build-images job + helpers)

### DIFF
--- a/.github/actions/prepare-ci-host/action.yml
+++ b/.github/actions/prepare-ci-host/action.yml
@@ -1,0 +1,28 @@
+name: Prepare CI Host
+description: Download CI-built Docker images from artifacts and load them onto the runner.
+
+inputs:
+  artifact-pattern:
+    description: Artifact pattern to download.
+    required: false
+    default: image-*
+  artifact-path:
+    description: Directory where image artifacts are downloaded.
+    required: false
+    default: /tmp/images
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: ${{ inputs.artifact-pattern }}
+        path: ${{ inputs.artifact-path }}
+    - shell: bash
+      run: |
+        set -euo pipefail
+        for tar in "${{ inputs.artifact-path }}"/image-*/*.tar; do
+          echo "Loading $tar"
+          docker load -i "$tar"
+        done
+        docker images

--- a/.github/scripts/dump-compose-ci-diagnostics.sh
+++ b/.github/scripts/dump-compose-ci-diagnostics.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# On system-test failure, dump everything useful about the running
+# docker-compose stack: container state, logs per service, and the
+# tail of the compose-wide journal. Output goes to stdout so the
+# GitHub Actions log captures it.
+
+set -Euo pipefail
+
+compose_args=(-f docker-compose.yml -f docker-compose.ci.yml)
+
+echo "==== docker compose ps ===="
+docker compose "${compose_args[@]}" ps || true
+
+echo "==== docker compose logs (tail 400 per service) ===="
+docker compose "${compose_args[@]}" logs --tail=400 --no-color || true
+
+echo "==== docker ps -a ===="
+docker ps -a || true

--- a/.github/scripts/start-system-test-stack.sh
+++ b/.github/scripts/start-system-test-stack.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Bring up the docker-compose stack used by the system-tests job.
+# Composes the dev stack with docker-compose.ci.yml so the api and
+# frontend services run from the CI-built `:ci`-tagged images that
+# .github/actions/prepare-ci-host loaded onto the runner.
+
+set -Eeuo pipefail
+
+compose_args=(-f docker-compose.yml -f docker-compose.ci.yml)
+
+echo "Starting long-lived system test services..."
+docker compose "${compose_args[@]}" up -d --no-build --wait --timeout 300

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -230,6 +230,53 @@ jobs:
             services/api/build/reports/tests/integrationTest
           if-no-files-found: warn
 
+  build-images:
+    # Build the production Docker images for api + frontend and export
+    # them as tar artifacts. Consumed by the system-tests job once it
+    # migrates onto the docker-compose stack (mirrors personal-stack-2).
+    # For now the artifacts are unused — the job exists so we can
+    # validate the build path + warm the gha layer cache.
+    name: Build Image (${{ matrix.service.name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: [ api-static, fe-static ]
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - name: api
+            context: .
+            dockerfile: services/api/Dockerfile
+          - name: frontend
+            context: services/frontend
+            dockerfile: services/frontend/Dockerfile
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build ${{ matrix.service.name }} image
+        run: |
+          set -euo pipefail
+          docker buildx build \
+            --progress=plain \
+            --load \
+            -f "${{ matrix.service.dockerfile }}" \
+            -t "blueshell-website/${{ matrix.service.name }}:ci" \
+            --cache-from "type=gha,scope=${{ matrix.service.name }}" \
+            --cache-to "type=gha,mode=max,scope=${{ matrix.service.name }}" \
+            "${{ matrix.service.context }}"
+
+      - name: Export image to tar
+        run: docker save "blueshell-website/${{ matrix.service.name }}:ci" -o "/tmp/${{ matrix.service.name }}.tar"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: image-${{ matrix.service.name }}
+          path: /tmp/${{ matrix.service.name }}.tar
+          retention-days: 1
+
   system-tests:
     # Shard the system-test class set across N parallel matrix jobs so
     # the wall-clock cost scales sub-linearly with new classes. The Gradle

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,53 @@
+# CI override for the system-tests stack.
+#
+# Layers on top of docker-compose.yml so the api and frontend services
+# run from the CI-built `:ci` images (production Dockerfiles, not the
+# hot-reload Dockerfile-dev variants). The `pull_policy: never` + `image:`
+# combo forces compose to use the image that .github/actions/prepare-ci-host
+# loaded onto the runner.
+#
+# Used by .github/scripts/start-system-test-stack.sh:
+#   docker compose -f docker-compose.yml -f docker-compose.ci.yml up --wait
+
+services:
+  # ── Use CI-built images (override dev build directive) ───────────
+  api:
+    image: blueshell-website/api:ci
+    pull_policy: never
+    build: !reset null
+    # Drop the dev source-mount + Playwright cache mounts; the prod
+    # image is self-contained.
+    volumes: !reset []
+    environment:
+      - TZ=Europe/Amsterdam
+      - SPRING_PROFILES_ACTIVE=prod
+      - APP_URL=http://localhost:8080
+      - FRONTEND_URL=http://localhost:3000
+      - MYSQL_HOST=db
+      - MYSQL_PORT=3306
+      - MYSQL_DATABASE=blueshell
+      - MYSQL_USER=blueshell
+      - MYSQL_PASSWORD=ci-blueshell
+      - JWT_SECRET=YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh
+      - STORAGE_LOCATION=/tmp/storage
+      - BREVO_API_KEY=ci-stub
+      - BREVO_FOLDER_CONTRIBUTION_PERIODS_ID=1234
+    env_file: !reset []
+
+  frontend:
+    image: blueshell-website/frontend:ci
+    pull_policy: never
+    build: !reset null
+    volumes: !reset []
+    environment:
+      - TZ=Europe/Amsterdam
+
+  # ── CI-specific MariaDB credentials ───────────────────────────────
+  db:
+    env_file: !reset []
+    environment:
+      - MYSQL_ROOT_PASSWORD=ci-blueshell-root
+      - MYSQL_DATABASE=blueshell
+      - MYSQL_USER=blueshell
+      - MYSQL_PASSWORD=ci-blueshell
+      - TZ=Europe/Amsterdam


### PR DESCRIPTION
## Summary
- Add a `build-images` matrix job in `.github/workflows/validate.yml` that builds the production `api` and `frontend` Dockerfiles, tags them `blueshell-website/<svc>:ci`, exports tarballs, uploads them as artifacts, and warms a per-service gha layer cache.
- Add a `prepare-ci-host` composite action that downloads those artifacts and `docker load`s them onto the test runner.
- Add `.github/scripts/start-system-test-stack.sh` (compose up --wait against `docker-compose.yml + docker-compose.ci.yml`) and `.github/scripts/dump-compose-ci-diagnostics.sh` (ps + per-service log dump on failure).
- Add `docker-compose.ci.yml`: pins `api` and `frontend` to the CI-built `:ci` images, sets `pull_policy: never`, clears the `build:` directive via `!reset null`, and supplies CI credentials for `db`.

This is PR 2/4 in the migration plan to align the website system-test setup with `personal-stack-2`. **Nothing here is wired into the existing `system-tests` job yet** — the new pieces are inert until the follow-up PRs migrate `FrontendSystemTestBase` off `@SpringBootTest` (PR C) and rewire the `system-tests` job to use the compose stack (PR D).

## Test plan
- [x] `docker compose -f docker-compose.yml -f docker-compose.ci.yml config` resolves cleanly; `api`/`frontend` end up with `image: blueshell-website/<svc>:ci`, `pull_policy: never`, no `build:` block (`!reset null` worked).
- [x] `python -c 'import yaml; yaml.safe_load(open(...))'` passes on `validate.yml` and `prepare-ci-host/action.yml`.
- [x] `bash -n` passes on both new scripts.
- [ ] CI: `build-images` matrix succeeds for both `api` and `frontend`; artifacts upload; cache populates.
- [ ] CI: no other job regresses (the new job is independent of `system-tests`).
- [ ] Locally: `docker compose -f docker-compose.yml -f docker-compose.ci.yml up --wait` after pre-loading `:ci` images (build them by hand or via `docker buildx build -f services/api/Dockerfile -t blueshell-website/api:ci .`). Curl `localhost:8080/health` and `localhost:3000`.