### PR TITLE
system-tests: add Spring-free Playwright + HTTP fixtures

### DIFF
--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/PlaywrightShardCondition.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/PlaywrightShardCondition.kt
@@ -1,0 +1,37 @@
+package net.blueshell.systemtests
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult
+import org.junit.jupiter.api.extension.ExecutionCondition
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/**
+ * Skips test classes that don't belong to this shard. Replaces the
+ * SHARD_TOTAL/SHARD_INDEX env-var + Gradle-doFirst filter the website
+ * carried before — now sharding is per-class via system properties
+ * `-Dtest.shard.index=N -Dtest.shard.count=M`, matching personal-stack-2.
+ *
+ * Partition is stable: a class with a given FQCN always lands on the
+ * same shard, so failure triage is straightforward.
+ */
+class PlaywrightShardCondition : ExecutionCondition {
+    override fun evaluateExecutionCondition(context: ExtensionContext): ConditionEvaluationResult {
+        val total = TestEnvironment.shardCount ?: return ConditionEvaluationResult.enabled(NO_SHARDING)
+        val index = TestEnvironment.shardIndex
+            ?: return ConditionEvaluationResult.disabled("test.shard.index unset (count=$total)")
+        if (index !in 1..total) {
+            return ConditionEvaluationResult.disabled("test.shard.index=$index outside 1..$total")
+        }
+        val fqcn = context.testClass.map { it.name }.orElse(null)
+            ?: return ConditionEvaluationResult.enabled("no test class — skipping shard check")
+        val mine = Math.floorMod(fqcn.hashCode(), total) == index - 1
+        return if (mine) {
+            ConditionEvaluationResult.enabled("shard $index/$total owns $fqcn")
+        } else {
+            ConditionEvaluationResult.disabled("shard $index/$total does not own $fqcn")
+        }
+    }
+
+    companion object {
+        private const val NO_SHARDING = "sharding disabled (test.shard.count unset)"
+    }
+}

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/PlaywrightTestBase.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/PlaywrightTestBase.kt
@@ -1,0 +1,94 @@
+package net.blueshell.systemtests
+
+import com.microsoft.playwright.Browser
+import com.microsoft.playwright.BrowserContext
+import com.microsoft.playwright.BrowserType
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.Playwright
+import com.microsoft.playwright.PlaywrightException
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Spring-free base class for browser-driven system tests. Mirrors the
+ * shape of personal-stack-2's PlaywrightTestBase: one Browser per class,
+ * one BrowserContext per test, headless Chromium, default 5s timeouts.
+ *
+ * The shared lifecycle lives here so concrete tests can layer on
+ * domain-specific helpers without re-implementing setup.
+ */
+@ExtendWith(PlaywrightShardCondition::class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class PlaywrightTestBase {
+    protected val apiUrl: String = TestEnvironment.apiUrl
+    protected val frontendUrl: String = TestEnvironment.frontendUrl
+
+    private lateinit var playwright: Playwright
+    private lateinit var browser: Browser
+    protected lateinit var context: BrowserContext
+    protected lateinit var page: Page
+
+    @BeforeAll
+    fun launchBrowser() {
+        playwright = Playwright.create()
+        browser = playwright.chromium().launch(
+            BrowserType.LaunchOptions().setHeadless(true),
+        )
+    }
+
+    @AfterAll
+    fun closeBrowser() {
+        if (::browser.isInitialized) browser.close()
+        if (::playwright.isInitialized) playwright.close()
+    }
+
+    @BeforeEach
+    fun createContext() {
+        context = browser.newContext(
+            Browser.NewContextOptions().setIgnoreHTTPSErrors(true),
+        )
+        context.setDefaultTimeout(DEFAULT_TIMEOUT_MS)
+        context.setDefaultNavigationTimeout(DEFAULT_TIMEOUT_MS)
+        page = context.newPage()
+        page.setDefaultTimeout(DEFAULT_TIMEOUT_MS)
+        page.setDefaultNavigationTimeout(DEFAULT_TIMEOUT_MS)
+    }
+
+    @AfterEach
+    fun closeContext() {
+        if (::context.isInitialized) context.close()
+    }
+
+    /**
+     * Retries `page.navigate(url)` a few times on ECONNREFUSED — useful
+     * during the brief window after `docker compose up --wait` reports
+     * healthy while traefik / nginx is still binding ports.
+     */
+    protected fun navigateWithRetry(url: String, attempts: Int = 3) {
+        var lastException: PlaywrightException? = null
+        repeat(attempts) { attempt ->
+            try {
+                page.navigate(url)
+                return
+            } catch (e: PlaywrightException) {
+                if (e.message?.contains("ERR_CONNECTION_REFUSED") == true) {
+                    lastException = e
+                    if (attempt < attempts - 1) {
+                        Thread.sleep(2_000L * (attempt + 1))
+                    }
+                } else {
+                    throw e
+                }
+            }
+        }
+        throw lastException!!
+    }
+
+    companion object {
+        const val DEFAULT_TIMEOUT_MS: Double = 5_000.0
+    }
+}

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestEnvironment.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestEnvironment.kt
@@ -1,0 +1,22 @@
+package net.blueshell.systemtests
+
+/**
+ * URLs and shard config read from `-D` system properties. Tests pick these
+ * up at JVM startup. Defaults target a local dev compose stack so a Gradle
+ * run with no -D flags still works against `docker compose up` from the
+ * repo root.
+ *
+ * Mirrors personal-stack-2's pattern of carrying test config as system
+ * properties prefixed `test.*` rather than env vars.
+ */
+object TestEnvironment {
+    val apiUrl: String get() = sys("test.api.url", "http://localhost:8080")
+    val frontendUrl: String get() = sys("test.frontend.url", "http://localhost:3000")
+    val mailhogUrl: String get() = sys("test.mailhog.url", "http://localhost:8025")
+
+    val shardIndex: Int? get() = System.getProperty("test.shard.index")?.toIntOrNull()
+    val shardCount: Int? get() = System.getProperty("test.shard.count")?.toIntOrNull()?.takeIf { it > 1 }
+
+    private fun sys(key: String, default: String): String =
+        System.getProperty(key)?.takeIf { it.isNotBlank() } ?: default
+}

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -1,0 +1,169 @@
+package net.blueshell.systemtests
+
+import io.restassured.RestAssured.given
+import io.restassured.http.ContentType
+import io.restassured.specification.RequestSpecification
+import java.net.ConnectException
+import java.sql.DriverManager
+import java.util.UUID
+
+/**
+ * Shared HTTP + JDBC helper for system tests. Models the same shape as
+ * personal-stack-2's TestHelper: the public api drives behaviour over
+ * HTTP (register, login, etc.), and JDBC fills the gaps where the api
+ * doesn't expose an admin path (granting roles, looking up tokens).
+ *
+ * This is the migration target for the in-process @Autowired
+ * UserRepository / UserFactory / JwtTokenGenerator usages that the
+ * existing FrontendSystemTestBase / OidcSystemTestBase still carry.
+ */
+object TestHelper {
+    private const val API_RETRY_ATTEMPTS = 3
+    private const val API_RETRY_DELAY_MS = 2_000L
+
+    val apiBaseUrl: String get() = TestEnvironment.apiUrl
+
+    private val dbUrl: String
+        get() = System.getProperty("test.db.url", "jdbc:mariadb://localhost:3306/blueshell")
+    private val dbUser: String
+        get() = System.getProperty("test.db.user", "blueshell")
+    private val dbPassword: String
+        get() = System.getProperty("test.db.password", "ci-blueshell")
+
+    fun givenApi(): RequestSpecification = given().relaxedHTTPSValidation()
+
+    private fun <T> retryOnConnectionFailure(action: () -> T): T {
+        var lastException: Exception? = null
+        repeat(API_RETRY_ATTEMPTS) { attempt ->
+            try {
+                return action()
+            } catch (e: Exception) {
+                if (e is ConnectException || e.cause is ConnectException) {
+                    lastException = e
+                    if (attempt < API_RETRY_ATTEMPTS - 1) {
+                        Thread.sleep(API_RETRY_DELAY_MS * (attempt + 1))
+                    }
+                } else {
+                    throw e
+                }
+            }
+        }
+        throw lastException!!
+    }
+
+    /**
+     * Register a new user via the public POST /users endpoint and activate
+     * their account by reading the activation token straight from the db.
+     * Mirrors personal-stack-2's `registerAndConfirm` step-for-step.
+     */
+    fun registerAndActivate(
+        username: String = "sys_${UUID.randomUUID().toString().take(8)}",
+        password: String = "Test1234!",
+        email: String = "$username@systemtest.example.com",
+    ): RegisteredUser {
+        retryOnConnectionFailure {
+            givenApi()
+                .baseUri(apiBaseUrl)
+                .contentType(ContentType.JSON)
+                .body(
+                    """{"username":"$username","email":"$email","firstName":"Test","surname":"User","password":"$password"}""",
+                ).`when`()
+                .post("/users")
+                .then()
+                .statusCode(201)
+        }
+
+        val token = activationTokenFromDb(username)
+
+        retryOnConnectionFailure {
+            givenApi()
+                .baseUri(apiBaseUrl)
+                .contentType(ContentType.JSON)
+                .body("""{"token":"$token","password":"$password"}""")
+                .`when`()
+                .post("/user/activate")
+                .then()
+                .statusCode(200)
+        }
+
+        return RegisteredUser(username, email, password)
+    }
+
+    /**
+     * Hits the JDBC layer to elevate a user's role. The api's PUT
+     * /users/{id}/roles requires an admin caller, so the first admin
+     * has to be minted directly — matches the makeUserAdmin pattern
+     * in personal-stack-2.
+     */
+    fun grantRole(username: String, role: String) {
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            conn.prepareStatement("UPDATE user SET role = ? WHERE username = ?").use { stmt ->
+                stmt.setString(1, role)
+                stmt.setString(2, username)
+                require(stmt.executeUpdate() == 1) { "Failed to set role=$role on username=$username" }
+            }
+        }
+    }
+
+    fun registerActivateAndPromote(
+        role: String,
+        username: String = "${role.lowercase()}_${UUID.randomUUID().toString().take(8)}",
+        password: String = "Test1234!",
+    ): RegisteredUser {
+        val user = registerAndActivate(username = username, password = password)
+        grantRole(user.username, role)
+        return user
+    }
+
+    /**
+     * Hits POST /auth and returns the Set-Cookie payload(s) so callers can
+     * forward them into a Playwright BrowserContext or a follow-up HTTP
+     * request. The api's session model uses a "login" cookie alongside
+     * CSRF tokens — both are returned verbatim.
+     */
+    fun login(user: RegisteredUser): LoginCookies {
+        val response = retryOnConnectionFailure {
+            givenApi()
+                .baseUri(apiBaseUrl)
+                .contentType(ContentType.JSON)
+                .body("""{"username":"${user.username}","password":"${user.password}"}""")
+                .`when`()
+                .post("/auth")
+        }
+        require(response.statusCode in 200..204) {
+            "Login for ${user.username} failed: ${response.statusCode} ${response.asString()}"
+        }
+        return LoginCookies(
+            login = response.cookie("login") ?: error("no login cookie in /auth response"),
+            csrf = response.cookie("XSRF-TOKEN"),
+        )
+    }
+
+    private fun activationTokenFromDb(username: String): String =
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            conn.prepareStatement(
+                """
+                SELECT t.token FROM activation_token t
+                JOIN user u ON u.id = t.user_id
+                WHERE u.username = ?
+                ORDER BY t.created_at DESC LIMIT 1
+                """.trimIndent(),
+            ).use { stmt ->
+                stmt.setString(1, username)
+                val rs = stmt.executeQuery()
+                require(rs.next()) { "No activation token found for $username" }
+                rs.getString("token")
+            }
+        }
+
+    data class RegisteredUser(
+        val username: String,
+        val email: String,
+        val password: String,
+    )
+
+    data class LoginCookies(
+        val login: String,
+        val csrf: String?,
+    )
+}


### PR DESCRIPTION
## Why

The system-tests project couples to api internals: every test extends a Spring Boot test base that boots the full `ApiApplication` in-process and pulls repositories and factories in via `@Autowired`. That makes the suite sensitive to non-public api changes, prevents running it against a real deployed instance, and forces every test to pay the Spring-context startup cost.

## What this achieves

A Spring-free toolkit lives alongside the existing tests, ready for adoption. New tests can be written against the HTTP-based surface from day one, and existing tests can be moved off the in-process model incrementally without disturbing the rest of the suite. The build script and the current tests are left alone.

## How

Four new files under `services/system-tests/src/test/kotlin/net/blueshell/systemtests/`:

- **`TestEnvironment`** — central read of `test.api.url`, `test.frontend.url`, `test.mailhog.url`, `test.shard.index`, and `test.shard.count` from system properties. Defaults target a local `docker compose up`, so a bare `./gradlew test` works without flags.

- **`PlaywrightShardCondition`** — JUnit `ExecutionCondition` that partitions test classes by stable FQCN hash modulo `test.shard.count`. A class always lands on the same shard, so failure triage stays predictable. No-op when `test.shard.count` is unset, which is why installing it on a shared base disrupts nothing.

- **`PlaywrightTestBase`** — one `Browser` per class, one `BrowserContext` per test, headless Chromium, 5s default timeouts. Carries a `navigateWithRetry` that absorbs the brief connection-refused window after a stack comes up.

- **`TestHelper`** — `registerAndActivate`, `grantRole`, `registerActivateAndPromote`, and `login`. Combines HTTP for behaviour (`POST /users`, `POST /user/activate`, `POST /auth`) with direct JDBC where the api exposes no admin path (role grants, activation-token lookup). The schema-specific SQL targets the `user.role` column and the `activation_token` table — these are placeholders pending verification the first time `TestHelper` is exercised against the live schema.