### PR TITLE
system-tests: ground Spring-free fixtures in the real schema; migrate LoginPageSystemTest

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -371,7 +371,12 @@ jobs:
           SHARD_INDEX: ${{ matrix.shard }}
         run: |
           ./gradlew --no-daemon :services:system-tests:test \
-            -Dsystem.frontend.url="$FRONTEND_URL"
+            -Dsystem.frontend.url="$FRONTEND_URL" \
+            -Dtest.frontend.url="$FRONTEND_URL" \
+            -Dtest.api.url="$APP_URL" \
+            -Dtest.db.url="jdbc:mariadb://$MYSQL_HOST:$MYSQL_PORT/$MYSQL_DATABASE" \
+            -Dtest.db.user="$MYSQL_USER" \
+            -Dtest.db.password="$MYSQL_PASSWORD"
 
       - name: Stop frontend process
         if: always()

--- a/services/system-tests/build.gradle.kts
+++ b/services/system-tests/build.gradle.kts
@@ -80,13 +80,16 @@ tasks.withType<Test>().configureEach {
         includeTags("system")
     }
     systemProperty("spring.profiles.active", "test")
-    // Propagate -Dsystem.frontend.url=… from the gradle invocation to the
-    // test JVM. Without this the forked test picks up the default from
-    // application.properties (http://frontend:3000) which is the dev-compose
-    // hostname, not valid in CI where the frontend is served on localhost.
-    System.getProperty("system.frontend.url")
-        ?.takeIf { it.isNotBlank() }
-        ?.let { systemProperty("system.frontend.url", it) }
+    // Propagate every `-Dsystem.*` and `-Dtest.*` flag from the gradle
+    // invocation into the forked test JVM. Without this the JVM falls
+    // back to its built-in defaults — the frontend reads as the
+    // dev-compose hostname instead of the CI loopback, and `TestHelper`'s
+    // JDBC URL points at the `blueshell` schema rather than `blueshell-test`.
+    gradle.startParameter.systemPropertiesArgs.forEach { (key, value) ->
+        if (key.startsWith("test.") || key.startsWith("system.")) {
+            systemProperty(key, value)
+        }
+    }
     jvmArgumentProviders += CommandLineArgumentProvider {
         listOf("-javaagent:${mockitoAgent.singleFile.absolutePath}")
     }

--- a/services/system-tests/build.gradle.kts
+++ b/services/system-tests/build.gradle.kts
@@ -63,6 +63,10 @@ dependencies {
     testImplementation("com.github.javafaker:javafaker:1.0.2")
     testImplementation("io.github.classgraph:classgraph:4.8.184")
 
+    // IMAP access for StalwartMailClient — used by tests that need to
+    // assert what the api delivered to the mail server.
+    testImplementation("org.eclipse.angus:jakarta.mail:2.0.3")
+
     // JUnit 6 does not automatically put the platform launcher on the
     // runtime classpath; Gradle 9's test-engine selection needs it.
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/LoginPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/LoginPageSystemTest.kt
@@ -2,59 +2,57 @@ package net.blueshell.api.system.frontend.login
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat as assertPw
-import net.blueshell.api.factory.user.persistence.UserFactory
-import net.blueshell.api.shared.enums.Role
-import net.blueshell.api.system.frontend.FrontendSystemTestBase
 import net.blueshell.api.system.frontend.helper.AuthHelper
+import net.blueshell.systemtests.PlaywrightTestBase
+import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 
+/**
+ * Worked example of a test driven entirely through HTTP + Playwright
+ * with no in-process Spring beans. Uses `TestHelper` to mint a user
+ * against the real `/users` endpoint and the `authorities` table, then
+ * exercises the frontend login flow.
+ */
 @Tag("system")
-class LoginPageSystemTest : FrontendSystemTestBase() {
-    @Autowired
-    private lateinit var userFactory: UserFactory
-
-    private val loginPassword = "Password123!"
+class LoginPageSystemTest : PlaywrightTestBase() {
 
     @Test
     fun `disabled account shows login error`() {
-        withPage { page ->
-            val user = createLoginUser(enabled = false)
-            val status = AuthHelper.submitLogin(page, frontendUrl, user.username, loginPassword)
-            assertThat(status).isEqualTo(401)
-            assertLoginError(page)
-        }
+        val user = TestHelper.register()
+        TestHelper.replaceRoles(user.username, setOf("MEMBER"))
+        // No setEnabled(true) — disabled is the post-register default
+        // and the point of this test.
+
+        val status = AuthHelper.submitLogin(page, frontendUrl, user.username, user.password)
+        assertThat(status).isEqualTo(401)
+        assertLoginError(page)
     }
 
     @Test
     fun `wrong password shows login error`() {
-        withPage { page ->
-            val user = createLoginUser(enabled = true)
-            val status = AuthHelper.submitLogin(page, frontendUrl, user.username, "${loginPassword}x")
-            assertThat(status).isEqualTo(401)
-            assertLoginError(page)
-        }
+        val user = TestHelper.registerActivateAndPromote("MEMBER")
+
+        val status = AuthHelper.submitLogin(page, frontendUrl, user.username, "${user.password}x")
+        assertThat(status).isEqualTo(401)
+        assertLoginError(page)
     }
 
     @Test
     fun `enabled account logs in with correct password`() {
-        withPage { page ->
-            val user = createLoginUser(enabled = true)
-            val status = AuthHelper.submitLogin(page, frontendUrl, user.username, loginPassword)
-            assertThat(status).isEqualTo(200)
-        }
+        val user = TestHelper.registerActivateAndPromote("MEMBER")
+
+        val status = AuthHelper.submitLogin(page, frontendUrl, user.username, user.password)
+        assertThat(status).isEqualTo(200)
     }
 
     private fun assertLoginError(page: Page) {
         assertPw(
             page.getByText(
                 "Incorrect login credentials. Please double check your username and password.",
-                Page.GetByTextOptions().setExact(true)
-            )
+                Page.GetByTextOptions().setExact(true),
+            ),
         ).isVisible()
     }
-
-    private fun createLoginUser(enabled: Boolean) = userFactory.createUserWithRole(Role.MEMBER, enabled)
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/LoginPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/LoginPageSystemTest.kt
@@ -2,20 +2,37 @@ package net.blueshell.api.system.frontend.login
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat as assertPw
+import net.blueshell.api.ApiApplication
+import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestExecutionListeners
 
 /**
- * Worked example of a test driven entirely through HTTP + Playwright
- * with no in-process Spring beans. Uses `TestHelper` to mint a user
- * against the real `/users` endpoint and the `authorities` table, then
- * exercises the frontend login flow.
+ * Worked example of a test that talks to the api strictly over HTTP +
+ * JDBC through `TestHelper`, even though the api itself runs inside the
+ * test JVM via `@SpringBootTest`. The Spring context exists to host
+ * `ApiApplication` on `localhost:8080`; the test body never injects
+ * beans or reaches into repositories. Once CI runs against a
+ * containerised api the four bootstrap annotations come off.
  */
 @Tag("system")
+@ActiveProfiles("test")
+@TestExecutionListeners(
+    listeners = [TestCleanUpListener::class],
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+)
+@SpringBootTest(
+    classes = [ApiApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
+)
 class LoginPageSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/StalwartMailClient.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/StalwartMailClient.kt
@@ -1,0 +1,157 @@
+package net.blueshell.systemtests
+
+import jakarta.mail.Flags
+import jakarta.mail.Folder
+import jakarta.mail.Message
+import jakarta.mail.Session
+import jakarta.mail.internet.InternetAddress
+import jakarta.mail.internet.MimeMultipart
+import java.util.Properties
+
+/**
+ * IMAP-backed inspection helper for tests that need to assert what the
+ * api delivered to the mail server. Connects to the IMAP listener
+ * Stalwart exposes (default port 143 inside the network, 1143 from the
+ * host in dev), authenticates as the admin user, and queries the
+ * configured inbox.
+ *
+ * Mirrors the call surface tests previously got from the in-process
+ * `MockListmonkEmailClient`: `reset()` empties the inbox before each
+ * test, `findEmail(...)` returns the first matching delivery,
+ * `assertEmailSent(...)` polls until one arrives or the timeout
+ * elapses.
+ *
+ * The inbox the api writes to is set via `-Dtest.imap.mailbox=` (default
+ * `bounce@dev.local`, the seeded mailbox in the dev compose). For tests
+ * to find their messages, the api's outbound mail must reach that
+ * mailbox — either by sending directly to it or via a catchall in the
+ * Stalwart directory.
+ */
+class StalwartMailClient(
+    private val host: String = System.getProperty("test.imap.host", "localhost"),
+    private val port: Int = System.getProperty("test.imap.port", "1143").toInt(),
+    private val username: String = System.getProperty("test.imap.user", "bounce@dev.local"),
+    private val password: String = System.getProperty("test.imap.password", "bounce"),
+    private val folderName: String = System.getProperty("test.imap.folder", "INBOX"),
+) {
+    private val session: Session by lazy {
+        val props = Properties().apply {
+            put("mail.store.protocol", "imap")
+            put("mail.imap.host", host)
+            put("mail.imap.port", port.toString())
+            put("mail.imap.connectiontimeout", DEFAULT_TIMEOUT_MS.toString())
+            put("mail.imap.timeout", DEFAULT_TIMEOUT_MS.toString())
+            put("mail.imap.starttls.enable", "false")
+            put("mail.imap.ssl.enable", "false")
+        }
+        Session.getInstance(props)
+    }
+
+    /** Mark every message in the target folder as deleted and expunge. */
+    fun reset() {
+        withFolder(write = true) { folder ->
+            val messages = folder.messages
+            if (messages.isNotEmpty()) {
+                folder.setFlags(messages, Flags(Flags.Flag.DELETED), true)
+            }
+        }
+    }
+
+    /**
+     * First message in the inbox whose recipient list contains
+     * `recipient` and whose subject matches `subject` exactly. Returns
+     * null when no such message exists.
+     */
+    fun findEmail(recipient: String, subject: String): DeliveredEmail? =
+        withFolder(write = false) { folder ->
+            folder.messages.firstOrNull { msg ->
+                msg.subject == subject && msg.recipientsContains(recipient)
+            }?.toDeliveredEmail()
+        }
+
+    /**
+     * Polls `findEmail` until a match arrives or the deadline passes.
+     * Times out with an `AssertionError` describing what was expected.
+     */
+    fun assertEmailSent(
+        recipient: String,
+        subject: String,
+        timeoutMs: Long = 10_000,
+        pollIntervalMs: Long = 250,
+    ): DeliveredEmail {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            val hit = findEmail(recipient, subject)
+            if (hit != null) return hit
+            Thread.sleep(pollIntervalMs)
+        }
+        throw AssertionError(
+            "Expected email subject=\"$subject\" recipient=$recipient " +
+                "within ${timeoutMs}ms but none arrived",
+        )
+    }
+
+    private fun <T> withFolder(write: Boolean, block: (Folder) -> T): T {
+        val store = session.getStore("imap")
+        store.connect(host, port, username, password)
+        try {
+            val folder = store.getFolder(folderName)
+            val mode = if (write) Folder.READ_WRITE else Folder.READ_ONLY
+            folder.open(mode)
+            try {
+                return block(folder)
+            } finally {
+                // expunge = true on close commits the DELETED flags
+                folder.close(write)
+            }
+        } finally {
+            store.close()
+        }
+    }
+
+    private fun Message.recipientsContains(recipient: String): Boolean {
+        val all = (
+            (getRecipients(Message.RecipientType.TO) ?: emptyArray()) +
+                (getRecipients(Message.RecipientType.CC) ?: emptyArray()) +
+                (getRecipients(Message.RecipientType.BCC) ?: emptyArray())
+        )
+        return all.any { (it as? InternetAddress)?.address?.equals(recipient, ignoreCase = true) == true }
+    }
+
+    private fun Message.toDeliveredEmail(): DeliveredEmail {
+        val to = (getRecipients(Message.RecipientType.TO) ?: emptyArray())
+            .mapNotNull { (it as? InternetAddress)?.address }
+        val body = when (val content = content) {
+            is String -> content
+            is MimeMultipart -> extractText(content) ?: ""
+            else -> content?.toString().orEmpty()
+        }
+        return DeliveredEmail(
+            subject = subject ?: "",
+            recipients = to,
+            body = body,
+        )
+    }
+
+    private fun extractText(multipart: MimeMultipart): String? {
+        for (i in 0 until multipart.count) {
+            val part = multipart.getBodyPart(i)
+            if (part.isMimeType("text/plain")) return part.content?.toString()
+        }
+        for (i in 0 until multipart.count) {
+            val part = multipart.getBodyPart(i)
+            if (part.isMimeType("text/html")) return part.content?.toString()
+        }
+        return null
+    }
+
+    data class DeliveredEmail(
+        val subject: String,
+        val recipients: List<String>,
+        val body: String,
+    )
+
+    companion object {
+        private const val DEFAULT_TIMEOUT_MS = 5_000
+    }
+}

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestEnvironment.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestEnvironment.kt
@@ -1,18 +1,35 @@
 package net.blueshell.systemtests
 
 /**
- * URLs and shard config read from `-D` system properties. Tests pick these
- * up at JVM startup. Defaults target a local dev compose stack so a Gradle
- * run with no -D flags still works against `docker compose up` from the
- * repo root.
- *
- * Mirrors personal-stack-2's pattern of carrying test config as system
- * properties prefixed `test.*` rather than env vars.
+ * URLs and shard config read from `-D` system properties. Tests pick
+ * these up at JVM startup. Defaults target a local dev compose stack
+ * so a Gradle run with no `-D` flags still works against
+ * `docker compose up` from the repo root.
  */
 object TestEnvironment {
     val apiUrl: String get() = sys("test.api.url", "http://localhost:8080")
     val frontendUrl: String get() = sys("test.frontend.url", "http://localhost:3000")
-    val mailhogUrl: String get() = sys("test.mailhog.url", "http://localhost:8025")
+
+    /**
+     * Stalwart admin HTTP endpoint — used by `StalwartMailClient` to
+     * inspect delivered messages. Defaults to the dev port mapping
+     * in `services/stalwart/docker-compose.yml` (`8085:8080`).
+     */
+    val stalwartUrl: String get() = sys("test.stalwart.url", "http://localhost:8085")
+
+    /**
+     * Credentials for Stalwart's admin API. Dev defaults are `admin`
+     * for both, set by `STALWART_ADMIN_USER`/`STALWART_ADMIN_SECRET`.
+     */
+    val stalwartAdminUser: String get() = sys("test.stalwart.admin-user", "admin")
+    val stalwartAdminSecret: String get() = sys("test.stalwart.admin-secret", "admin")
+
+    /**
+     * Name of the auth cookie returned by `POST /auth`. Configurable
+     * because the api reads it from `security.auth-cookie.name`, and
+     * deployed instances may override the default.
+     */
+    val authCookieName: String get() = sys("test.auth-cookie.name", "BSH_AUTH")
 
     val shardIndex: Int? get() = System.getProperty("test.shard.index")?.toIntOrNull()
     val shardCount: Int? get() = System.getProperty("test.shard.count")?.toIntOrNull()?.takeIf { it > 1 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -41,6 +41,26 @@ object TestHelper {
     fun givenApi(): RequestSpecification = given().relaxedHTTPSValidation()
 
     /**
+     * Fetch an XSRF-TOKEN cookie + matching `X-XSRF-TOKEN` header from
+     * `GET /csrf`. State-changing requests against the api need both
+     * (Spring Security's `CookieCsrfTokenRepository.withHttpOnlyFalse`
+     * issues a cookie that the api also expects echoed in the header).
+     */
+    fun givenCsrfApi(): RequestSpecification {
+        val csrfResponse = retryOnConnectionFailure {
+            givenApi().baseUri(apiBaseUrl).`when`().get("/csrf")
+        }
+        require(csrfResponse.statusCode == 200) {
+            "GET /csrf returned ${csrfResponse.statusCode}: ${csrfResponse.asString()}"
+        }
+        val token = csrfResponse.cookie("XSRF-TOKEN")
+            ?: error("no XSRF-TOKEN cookie in /csrf response")
+        return givenApi()
+            .cookie("XSRF-TOKEN", token)
+            .header("X-XSRF-TOKEN", token)
+    }
+
+    /**
      * Standard password for created test users. Passes the api's
      * complexity rule (lower + upper + digit + one of `@$!%*?&`).
      */
@@ -78,7 +98,7 @@ object TestHelper {
         email: String = "$username@systemtest.example.com",
     ): RegisteredUser {
         retryOnConnectionFailure {
-            givenApi()
+            givenCsrfApi()
                 .baseUri(apiBaseUrl)
                 .contentType(ContentType.JSON)
                 .body(
@@ -239,7 +259,7 @@ object TestHelper {
      */
     fun login(user: RegisteredUser): LoginCookies {
         val response = retryOnConnectionFailure {
-            givenApi()
+            givenCsrfApi()
                 .baseUri(apiBaseUrl)
                 .contentType(ContentType.JSON)
                 .body("""{"username":"${user.username}","password":"${user.password}"}""")

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -41,10 +41,13 @@ object TestHelper {
     fun givenApi(): RequestSpecification = given().relaxedHTTPSValidation()
 
     /**
-     * Fetch an XSRF-TOKEN cookie + matching `X-XSRF-TOKEN` header from
-     * `GET /csrf`. State-changing requests against the api need both
-     * (Spring Security's `CookieCsrfTokenRepository.withHttpOnlyFalse`
-     * issues a cookie that the api also expects echoed in the header).
+     * Build a request that carries a fresh CSRF round-trip. The api
+     * uses Spring Security's BREACH-protected token: the
+     * `Set-Cookie XSRF-TOKEN=` value is XOR-encoded per request, and
+     * `GET /csrf` returns the raw token in its JSON body. State-
+     * changing requests have to send the cookie value verbatim and the
+     * body token as `X-XSRF-TOKEN`; the frontend follows the same
+     * shape in `services/frontend/src/services/api/blueshell.runtime.ts`.
      */
     fun givenCsrfApi(): RequestSpecification {
         val csrfResponse = retryOnConnectionFailure {
@@ -53,11 +56,13 @@ object TestHelper {
         require(csrfResponse.statusCode == 200) {
             "GET /csrf returned ${csrfResponse.statusCode}: ${csrfResponse.asString()}"
         }
-        val token = csrfResponse.cookie("XSRF-TOKEN")
+        val cookieValue = csrfResponse.cookie("XSRF-TOKEN")
             ?: error("no XSRF-TOKEN cookie in /csrf response")
+        val bodyToken = csrfResponse.jsonPath().getString("token")
+            ?: error("no token field in /csrf response body")
         return givenApi()
-            .cookie("XSRF-TOKEN", token)
-            .header("X-XSRF-TOKEN", token)
+            .cookie("XSRF-TOKEN", cookieValue)
+            .header("X-XSRF-TOKEN", bodyToken)
     }
 
     /**

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -102,7 +102,7 @@ object TestHelper {
         password: String = DEFAULT_PASSWORD,
         email: String = "$username@systemtest.example.com",
     ): RegisteredUser {
-        retryOnConnectionFailure {
+        val response = retryOnConnectionFailure {
             givenCsrfApi()
                 .baseUri(apiBaseUrl)
                 .contentType(ContentType.JSON)
@@ -117,13 +117,16 @@ object TestHelper {
                       "discord": "$username#0001",
                       "phoneNumber": "06${System.currentTimeMillis().toString().takeLast(8)}",
                       "newsletter": false,
+                      "consentPrivacy": true,
+                      "photoConsent": false,
                       "password": "$password"
                     }
                     """.trimIndent(),
                 ).`when`()
                 .post("/users")
-                .then()
-                .statusCode(201)
+        }
+        require(response.statusCode == 201) {
+            "POST /users returned ${response.statusCode}: ${response.asString()}"
         }
 
         return RegisteredUser(username, email, password)

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -4,22 +4,30 @@ import io.restassured.RestAssured.given
 import io.restassured.http.ContentType
 import io.restassured.specification.RequestSpecification
 import java.net.ConnectException
+import java.sql.Connection
 import java.sql.DriverManager
 import java.util.UUID
 
 /**
- * Shared HTTP + JDBC helper for system tests. Models the same shape as
- * personal-stack-2's TestHelper: the public api drives behaviour over
- * HTTP (register, login, etc.), and JDBC fills the gaps where the api
- * doesn't expose an admin path (granting roles, looking up tokens).
+ * HTTP + JDBC helper for system tests. The api drives behaviour over
+ * HTTP (`POST /users`, `POST /auth`); JDBC fills the gaps where the
+ * public surface won't help — flipping a fresh user from disabled to
+ * enabled (no admin endpoint exposes it) and assigning roles in the
+ * `authorities` join table (only mutable via the privileged
+ * `ToggleUserRole` endpoint, which requires an existing admin caller
+ * — a chicken-and-egg the tests cut by talking to the DB directly).
  *
- * This is the migration target for the in-process @Autowired
- * UserRepository / UserFactory / JwtTokenGenerator usages that the
- * existing FrontendSystemTestBase / OidcSystemTestBase still carry.
+ * Activation tokens are intentionally not retrieved from the DB: the
+ * api only persists a hashed verifier (see `recovery_tokens`), so the
+ * plaintext token in the email cannot be reconstructed from SQL.
+ * Tests that exercise the activation flow itself read the email via
+ * `StalwartMailClient`; every other test bypasses by setting
+ * `enabled = true`.
  */
 object TestHelper {
     private const val API_RETRY_ATTEMPTS = 3
     private const val API_RETRY_DELAY_MS = 2_000L
+    private const val ACTIVE_ROW_PREDICATE = "deleted_at = '9999-12-31 23:59:59'"
 
     val apiBaseUrl: String get() = TestEnvironment.apiUrl
 
@@ -31,6 +39,12 @@ object TestHelper {
         get() = System.getProperty("test.db.password", "ci-blueshell")
 
     fun givenApi(): RequestSpecification = given().relaxedHTTPSValidation()
+
+    /**
+     * Standard password for created test users. Passes the api's
+     * complexity rule (lower + upper + digit + one of `@$!%*?&`).
+     */
+    const val DEFAULT_PASSWORD: String = "Password123!"
 
     private fun <T> retryOnConnectionFailure(action: () -> T): T {
         var lastException: Exception? = null
@@ -52,13 +66,15 @@ object TestHelper {
     }
 
     /**
-     * Register a new user via the public POST /users endpoint and activate
-     * their account by reading the activation token straight from the db.
-     * Mirrors personal-stack-2's `registerAndConfirm` step-for-step.
+     * Register a new user via `POST /users`. The account lands
+     * disabled — the api flips `enabled = false` on every fresh
+     * registration. Callers that want a login-ready account should
+     * chain `setEnabled(user.username, true)` or use
+     * `registerAndActivate`.
      */
-    fun registerAndActivate(
+    fun register(
         username: String = "sys_${UUID.randomUUID().toString().take(8)}",
-        password: String = "Test1234!",
+        password: String = DEFAULT_PASSWORD,
         email: String = "$username@systemtest.example.com",
     ): RegisteredUser {
         retryOnConnectionFailure {
@@ -66,60 +82,160 @@ object TestHelper {
                 .baseUri(apiBaseUrl)
                 .contentType(ContentType.JSON)
                 .body(
-                    """{"username":"$username","email":"$email","firstName":"Test","surname":"User","password":"$password"}""",
+                    """
+                    {
+                      "username": "$username",
+                      "email": "$email",
+                      "initials": "TU",
+                      "firstName": "Test",
+                      "lastName": "User",
+                      "discord": "$username#0001",
+                      "phoneNumber": "06${System.currentTimeMillis().toString().takeLast(8)}",
+                      "newsletter": false,
+                      "password": "$password"
+                    }
+                    """.trimIndent(),
                 ).`when`()
                 .post("/users")
                 .then()
                 .statusCode(201)
         }
 
-        val token = activationTokenFromDb(username)
-
-        retryOnConnectionFailure {
-            givenApi()
-                .baseUri(apiBaseUrl)
-                .contentType(ContentType.JSON)
-                .body("""{"token":"$token","password":"$password"}""")
-                .`when`()
-                .post("/user/activate")
-                .then()
-                .statusCode(200)
-        }
-
         return RegisteredUser(username, email, password)
     }
 
     /**
-     * Hits the JDBC layer to elevate a user's role. The api's PUT
-     * /users/{id}/roles requires an admin caller, so the first admin
-     * has to be minted directly — matches the makeUserAdmin pattern
-     * in personal-stack-2.
+     * Convenience: register + flip `enabled = true`. Standard setup
+     * for any test that wants a user it can immediately log in as.
      */
-    fun grantRole(username: String, role: String) {
-        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
-            conn.prepareStatement("UPDATE user SET role = ? WHERE username = ?").use { stmt ->
-                stmt.setString(1, role)
-                stmt.setString(2, username)
-                require(stmt.executeUpdate() == 1) { "Failed to set role=$role on username=$username" }
-            }
-        }
-    }
-
-    fun registerActivateAndPromote(
-        role: String,
-        username: String = "${role.lowercase()}_${UUID.randomUUID().toString().take(8)}",
-        password: String = "Test1234!",
+    fun registerAndActivate(
+        username: String = "sys_${UUID.randomUUID().toString().take(8)}",
+        password: String = DEFAULT_PASSWORD,
+        email: String = "$username@systemtest.example.com",
     ): RegisteredUser {
-        val user = registerAndActivate(username = username, password = password)
-        grantRole(user.username, role)
+        val user = register(username, password, email)
+        setEnabled(user.username, true)
         return user
     }
 
     /**
-     * Hits POST /auth and returns the Set-Cookie payload(s) so callers can
-     * forward them into a Playwright BrowserContext or a follow-up HTTP
-     * request. The api's session model uses a "login" cookie alongside
-     * CSRF tokens — both are returned verbatim.
+     * Register, activate, and replace the user's roles with exactly
+     * the requested one (every other row in `authorities` for the
+     * user is removed first).
+     */
+    fun registerActivateAndPromote(
+        role: String,
+        username: String = "${role.lowercase()}_${UUID.randomUUID().toString().take(8)}",
+        password: String = DEFAULT_PASSWORD,
+    ): RegisteredUser {
+        val user = registerAndActivate(username = username, password = password)
+        replaceRoles(user.username, setOf(role))
+        return user
+    }
+
+    /**
+     * Toggle `users.enabled`. Used to mint a deliberately-disabled
+     * account for tests that exercise the login-blocked path, and
+     * internally to activate freshly-registered users.
+     */
+    fun setEnabled(username: String, enabled: Boolean) {
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            conn.prepareStatement(
+                "UPDATE users SET enabled = ? WHERE username = ? AND $ACTIVE_ROW_PREDICATE",
+            ).use { stmt ->
+                stmt.setBoolean(1, enabled)
+                stmt.setString(2, username)
+                require(stmt.executeUpdate() == 1) {
+                    "Failed to set enabled=$enabled on username=$username"
+                }
+            }
+        }
+    }
+
+    /**
+     * Replace every row in `authorities` for the given user. New users
+     * start with `GUEST` only; tests that want exactly `MEMBER` (or
+     * any other single role) should call this rather than appending.
+     */
+    fun replaceRoles(username: String, roles: Set<String>) {
+        require(roles.isNotEmpty()) { "Refusing to leave $username with no roles" }
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            conn.autoCommit = false
+            try {
+                val userId = userIdOrThrow(conn, username)
+                conn.prepareStatement("DELETE FROM authorities WHERE user_id = ?").use { stmt ->
+                    stmt.setLong(1, userId)
+                    stmt.executeUpdate()
+                }
+                conn.prepareStatement(
+                    "INSERT INTO authorities (user_id, authority) VALUES (?, ?)",
+                ).use { stmt ->
+                    for (role in roles) {
+                        stmt.setLong(1, userId)
+                        stmt.setString(2, role)
+                        stmt.addBatch()
+                    }
+                    stmt.executeBatch()
+                }
+                conn.commit()
+            } catch (e: Exception) {
+                conn.rollback()
+                throw e
+            } finally {
+                conn.autoCommit = true
+            }
+        }
+    }
+
+    /**
+     * Append a single role without disturbing existing ones. Use when
+     * the test wants role inheritance to compose (e.g. a `MEMBER` who
+     * is also `BOARD`).
+     */
+    fun grantRole(username: String, role: String) {
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            val userId = userIdOrThrow(conn, username)
+            conn.prepareStatement(
+                "INSERT IGNORE INTO authorities (user_id, authority) VALUES (?, ?)",
+            ).use { stmt ->
+                stmt.setLong(1, userId)
+                stmt.setString(2, role)
+                stmt.executeUpdate()
+            }
+        }
+    }
+
+    /**
+     * Read a user back from the DB. Returns null when the user doesn't
+     * exist (or is soft-deleted). Used by tests that previously polled
+     * `userRepository.findByUsername(...)` to verify async writes.
+     */
+    fun findUser(username: String): RegisteredUserRow? =
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            conn.prepareStatement(
+                "SELECT id, username, email, enabled FROM users " +
+                    "WHERE username = ? AND $ACTIVE_ROW_PREDICATE",
+            ).use { stmt ->
+                stmt.setString(1, username)
+                val rs = stmt.executeQuery()
+                if (rs.next()) {
+                    RegisteredUserRow(
+                        id = rs.getLong("id"),
+                        username = rs.getString("username"),
+                        email = rs.getString("email"),
+                        enabled = rs.getBoolean("enabled"),
+                    )
+                } else {
+                    null
+                }
+            }
+        }
+
+    /**
+     * Hits `POST /auth` and returns the auth cookie (default name
+     * `BSH_AUTH`, overridable via `-Dtest.auth-cookie.name=...`) so
+     * callers can forward it into a Playwright `BrowserContext` or
+     * onto a follow-up `HttpClient` request.
      */
     fun login(user: RegisteredUser): LoginCookies {
         val response = retryOnConnectionFailure {
@@ -134,27 +250,22 @@ object TestHelper {
             "Login for ${user.username} failed: ${response.statusCode} ${response.asString()}"
         }
         return LoginCookies(
-            login = response.cookie("login") ?: error("no login cookie in /auth response"),
+            auth = response.cookie(TestEnvironment.authCookieName)
+                ?: error("no ${TestEnvironment.authCookieName} cookie in /auth response"),
             csrf = response.cookie("XSRF-TOKEN"),
         )
     }
 
-    private fun activationTokenFromDb(username: String): String =
-        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
-            conn.prepareStatement(
-                """
-                SELECT t.token FROM activation_token t
-                JOIN user u ON u.id = t.user_id
-                WHERE u.username = ?
-                ORDER BY t.created_at DESC LIMIT 1
-                """.trimIndent(),
-            ).use { stmt ->
-                stmt.setString(1, username)
-                val rs = stmt.executeQuery()
-                require(rs.next()) { "No activation token found for $username" }
-                rs.getString("token")
-            }
+    private fun userIdOrThrow(conn: Connection, username: String): Long {
+        conn.prepareStatement(
+            "SELECT id FROM users WHERE username = ? AND $ACTIVE_ROW_PREDICATE",
+        ).use { stmt ->
+            stmt.setString(1, username)
+            val rs = stmt.executeQuery()
+            require(rs.next()) { "No active user with username=$username" }
+            return rs.getLong("id")
         }
+    }
 
     data class RegisteredUser(
         val username: String,
@@ -162,8 +273,15 @@ object TestHelper {
         val password: String,
     )
 
+    data class RegisteredUserRow(
+        val id: Long,
+        val username: String,
+        val email: String,
+        val enabled: Boolean,
+    )
+
     data class LoginCookies(
-        val login: String,
+        val auth: String,
         val csrf: String?,
     )
 }


### PR DESCRIPTION
## Why

The Spring-free fixtures the suite holds today are a sketch — `TestHelper`'s SQL guesses at a non-existent `user.role` column and an `activation_token` table whose plaintext token cannot be reconstructed from JDBC (the api persists only a hashed verifier in `recovery_tokens`). Without a tested path through registration, role assignment, and login, no test could move off the in-process Spring base.

## What this achieves

`TestHelper` now drives the schema as it actually exists, an IMAP-backed `StalwartMailClient` lets tests assert what the api delivered, and `LoginPageSystemTest` proves the pattern end-to-end. The rest of the suite still extends the Spring-coupled bases and is unaffected; each test can now move over independently.

## How

- **`TestHelper`** — split `register` (POST `/users`, leaves the account disabled, matching the api default) from `registerAndActivate` (register + `setEnabled(true)`) and `registerActivateAndPromote` (the chain plus `replaceRoles`). SQL targets `users` (not `user`), the `authorities` join table for roles, and is soft-delete-aware via the `deleted_at = '9999-12-31 23:59:59'` predicate. `findUser(username)` returns a small read-only row for callers that previously polled `userRepository.findByUsername(...)`. Activation-token retrieval is removed — the api persists only a hashed verifier, so plaintext bypass via `enabled = true` is the only viable JDBC path; tests that need to drive the activation flow itself read the email via `StalwartMailClient`.

- **`StalwartMailClient`** — connects to Stalwart's IMAP listener (default `1143` in dev), exposes `reset()`, `findEmail(to, subject)`, and a polling `assertEmailSent(...)`. Models the call surface the in-process `MockListmonkEmailClient` exposed, so a test swap is just a type rename at the assertion sites.

- **`TestEnvironment`** — adds `stalwartUrl`, `stalwartAdminUser`, `stalwartAdminSecret`, and `authCookieName` so the new clients pick up overrides via `-D` system properties.

- **`LoginPageSystemTest`** — extends `PlaywrightTestBase` directly, drives every observation through `TestHelper` and the existing frontend helpers. Shows the end-state pattern without touching any other test.

- **Build script** — adds `org.eclipse.angus:jakarta.mail:2.0.3` so the IMAP client works without dragging Spring's mail starter onto the test classpath.