### PR TITLE
system-tests: take the OIDC subtree off Spring

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -371,7 +371,12 @@ jobs:
           SHARD_INDEX: ${{ matrix.shard }}
         run: |
           ./gradlew --no-daemon :services:system-tests:test \
-            -Dsystem.frontend.url="$FRONTEND_URL"
+            -Dsystem.frontend.url="$FRONTEND_URL" \
+            -Dtest.frontend.url="$FRONTEND_URL" \
+            -Dtest.api.url="$APP_URL" \
+            -Dtest.db.url="jdbc:mariadb://$MYSQL_HOST:$MYSQL_PORT/$MYSQL_DATABASE" \
+            -Dtest.db.user="$MYSQL_USER" \
+            -Dtest.db.password="$MYSQL_PASSWORD"
 
       - name: Stop frontend process
         if: always()

--- a/services/system-tests/build.gradle.kts
+++ b/services/system-tests/build.gradle.kts
@@ -80,13 +80,16 @@ tasks.withType<Test>().configureEach {
         includeTags("system")
     }
     systemProperty("spring.profiles.active", "test")
-    // Propagate -Dsystem.frontend.url=… from the gradle invocation to the
-    // test JVM. Without this the forked test picks up the default from
-    // application.properties (http://frontend:3000) which is the dev-compose
-    // hostname, not valid in CI where the frontend is served on localhost.
-    System.getProperty("system.frontend.url")
-        ?.takeIf { it.isNotBlank() }
-        ?.let { systemProperty("system.frontend.url", it) }
+    // Propagate every `-Dsystem.*` and `-Dtest.*` flag from the gradle
+    // invocation into the forked test JVM. Without this the JVM falls
+    // back to its built-in defaults — the frontend reads as the
+    // dev-compose hostname instead of the CI loopback, and `TestHelper`'s
+    // JDBC URL points at the `blueshell` schema rather than `blueshell-test`.
+    gradle.startParameter.systemPropertiesArgs.forEach { (key, value) ->
+        if (key.startsWith("test.") || key.startsWith("system.")) {
+            systemProperty(key, value)
+        }
+    }
     jvmArgumentProviders += CommandLineArgumentProvider {
         listOf("-javaagent:${mockitoAgent.singleFile.absolutePath}")
     }

--- a/services/system-tests/build.gradle.kts
+++ b/services/system-tests/build.gradle.kts
@@ -63,6 +63,10 @@ dependencies {
     testImplementation("com.github.javafaker:javafaker:1.0.2")
     testImplementation("io.github.classgraph:classgraph:4.8.184")
 
+    // IMAP access for StalwartMailClient — used by tests that need to
+    // assert what the api delivered to the mail server.
+    testImplementation("org.eclipse.angus:jakarta.mail:2.0.3")
+
     // JUnit 6 does not automatically put the platform launcher on the
     // runtime classpath; Gradle 9's test-engine selection needs it.
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/LoginPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/LoginPageSystemTest.kt
@@ -2,59 +2,57 @@ package net.blueshell.api.system.frontend.login
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat as assertPw
-import net.blueshell.api.factory.user.persistence.UserFactory
-import net.blueshell.api.shared.enums.Role
-import net.blueshell.api.system.frontend.FrontendSystemTestBase
 import net.blueshell.api.system.frontend.helper.AuthHelper
+import net.blueshell.systemtests.PlaywrightTestBase
+import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 
+/**
+ * Worked example of a test driven entirely through HTTP + Playwright
+ * with no in-process Spring beans. Uses `TestHelper` to mint a user
+ * against the real `/users` endpoint and the `authorities` table, then
+ * exercises the frontend login flow.
+ */
 @Tag("system")
-class LoginPageSystemTest : FrontendSystemTestBase() {
-    @Autowired
-    private lateinit var userFactory: UserFactory
-
-    private val loginPassword = "Password123!"
+class LoginPageSystemTest : PlaywrightTestBase() {
 
     @Test
     fun `disabled account shows login error`() {
-        withPage { page ->
-            val user = createLoginUser(enabled = false)
-            val status = AuthHelper.submitLogin(page, frontendUrl, user.username, loginPassword)
-            assertThat(status).isEqualTo(401)
-            assertLoginError(page)
-        }
+        val user = TestHelper.register()
+        TestHelper.replaceRoles(user.username, setOf("MEMBER"))
+        // No setEnabled(true) — disabled is the post-register default
+        // and the point of this test.
+
+        val status = AuthHelper.submitLogin(page, frontendUrl, user.username, user.password)
+        assertThat(status).isEqualTo(401)
+        assertLoginError(page)
     }
 
     @Test
     fun `wrong password shows login error`() {
-        withPage { page ->
-            val user = createLoginUser(enabled = true)
-            val status = AuthHelper.submitLogin(page, frontendUrl, user.username, "${loginPassword}x")
-            assertThat(status).isEqualTo(401)
-            assertLoginError(page)
-        }
+        val user = TestHelper.registerActivateAndPromote("MEMBER")
+
+        val status = AuthHelper.submitLogin(page, frontendUrl, user.username, "${user.password}x")
+        assertThat(status).isEqualTo(401)
+        assertLoginError(page)
     }
 
     @Test
     fun `enabled account logs in with correct password`() {
-        withPage { page ->
-            val user = createLoginUser(enabled = true)
-            val status = AuthHelper.submitLogin(page, frontendUrl, user.username, loginPassword)
-            assertThat(status).isEqualTo(200)
-        }
+        val user = TestHelper.registerActivateAndPromote("MEMBER")
+
+        val status = AuthHelper.submitLogin(page, frontendUrl, user.username, user.password)
+        assertThat(status).isEqualTo(200)
     }
 
     private fun assertLoginError(page: Page) {
         assertPw(
             page.getByText(
                 "Incorrect login credentials. Please double check your username and password.",
-                Page.GetByTextOptions().setExact(true)
-            )
+                Page.GetByTextOptions().setExact(true),
+            ),
         ).isVisible()
     }
-
-    private fun createLoginUser(enabled: Boolean) = userFactory.createUserWithRole(Role.MEMBER, enabled)
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/LoginPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/LoginPageSystemTest.kt
@@ -2,20 +2,37 @@ package net.blueshell.api.system.frontend.login
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat as assertPw
+import net.blueshell.api.ApiApplication
+import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestExecutionListeners
 
 /**
- * Worked example of a test driven entirely through HTTP + Playwright
- * with no in-process Spring beans. Uses `TestHelper` to mint a user
- * against the real `/users` endpoint and the `authorities` table, then
- * exercises the frontend login flow.
+ * Worked example of a test that talks to the api strictly over HTTP +
+ * JDBC through `TestHelper`, even though the api itself runs inside the
+ * test JVM via `@SpringBootTest`. The Spring context exists to host
+ * `ApiApplication` on `localhost:8080`; the test body never injects
+ * beans or reaches into repositories. Once CI runs against a
+ * containerised api the four bootstrap annotations come off.
  */
 @Tag("system")
+@ActiveProfiles("test")
+@TestExecutionListeners(
+    listeners = [TestCleanUpListener::class],
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+)
+@SpringBootTest(
+    classes = [ApiApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
+)
 class LoginPageSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/AuthorizeRedirectSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/AuthorizeRedirectSystemTest.kt
@@ -1,6 +1,6 @@
 package net.blueshell.api.system.oidc
 
-import net.blueshell.api.shared.enums.Role
+import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -66,13 +66,13 @@ class AuthorizeRedirectSystemTest : OidcSystemTestBase() {
 
     @Test
     fun `member hitting admin-only headlamp authorize is blocked by 403`() {
-        val member = userFactory.createUserWithRole(Role.MEMBER)
+        val member = TestHelper.registerActivateAndPromote("MEMBER")
         val pkce = OidcTestHelper.newPkce()
         val redirect = "https://headlamp.esa-blueshell.nl/oidc-callback"
 
         val response = get(
             authorizeUrl("headlamp", pkce, redirect),
-            sessionToken = sessionTokenFor(member.username),
+            sessionToken = sessionTokenFor(member),
         )
 
         assertThat(response.statusCode()).isEqualTo(403)
@@ -80,12 +80,12 @@ class AuthorizeRedirectSystemTest : OidcSystemTestBase() {
 
     @Test
     fun `member hitting admin-only vault authorize is blocked by 403`() {
-        val member = userFactory.createUserWithRole(Role.MEMBER)
+        val member = TestHelper.registerActivateAndPromote("MEMBER")
         val redirect = "https://vault.esa-blueshell.nl/ui/vault/auth/oidc/oidc/callback"
 
         val response = get(
             authorizeUrl("vault", pkce = null, redirect = redirect),
-            sessionToken = sessionTokenFor(member.username),
+            sessionToken = sessionTokenFor(member),
         )
 
         assertThat(response.statusCode()).isEqualTo(403)
@@ -93,13 +93,13 @@ class AuthorizeRedirectSystemTest : OidcSystemTestBase() {
 
     @Test
     fun `admin authorize for headlamp redirects to client redirect_uri with code`() {
-        val admin = userFactory.createUserWithRole(Role.ADMIN)
+        val admin = TestHelper.registerActivateAndPromote("ADMIN")
         val pkce = OidcTestHelper.newPkce()
         val redirect = "https://headlamp.esa-blueshell.nl/oidc-callback"
 
         val response = get(
             authorizeUrl("headlamp", pkce, redirect),
-            sessionToken = sessionTokenFor(admin.username),
+            sessionToken = sessionTokenFor(admin),
         )
 
         assertThat(response.statusCode()).isEqualTo(302)
@@ -111,12 +111,12 @@ class AuthorizeRedirectSystemTest : OidcSystemTestBase() {
 
     @Test
     fun `admin authorize for vault redirects to client redirect_uri with code`() {
-        val admin = userFactory.createUserWithRole(Role.ADMIN)
+        val admin = TestHelper.registerActivateAndPromote("ADMIN")
         val redirect = "https://vault.esa-blueshell.nl/ui/vault/auth/oidc/oidc/callback"
 
         val response = get(
             authorizeUrl("vault", pkce = null, redirect = redirect),
-            sessionToken = sessionTokenFor(admin.username),
+            sessionToken = sessionTokenFor(admin),
         )
 
         assertThat(response.statusCode()).isEqualTo(302)

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/ForwardAuthChainSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/ForwardAuthChainSystemTest.kt
@@ -1,6 +1,6 @@
 package net.blueshell.api.system.oidc
 
-import net.blueshell.api.shared.enums.Role
+import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -10,13 +10,10 @@ import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 
 /**
- * Lifts the existing ForwardAuthControllerIT integration test to the
- * system-test layer: drives /oauth2/forward-auth over real HTTP against
- * the embedded server. Parametrized across every host the controller
- * gates today (vault, headlamp, listmonk, stalwart, traefik) so a future
- * host added to HOST_ROLE without a system-test entry fails this suite.
- *
- * Models personal-stack's ForwardAuthChainSystemTest pattern.
+ * System-test coverage for `/oauth2/forward-auth`. Parametrized across
+ * every host the controller gates today (vault, headlamp, listmonk,
+ * stalwart, traefik) so a future host added to `HOST_ROLE` without a
+ * matching system-test entry fails this suite.
  */
 @Tag("system")
 class ForwardAuthChainSystemTest : OidcSystemTestBase() {
@@ -26,15 +23,15 @@ class ForwardAuthChainSystemTest : OidcSystemTestBase() {
 
         @JvmStatic
         fun adminGatedHosts(): Stream<Arguments> = Stream.of(
-            Arguments.of("vault.esa-blueshell.nl", Role.ADMIN),
-            Arguments.of("headlamp.esa-blueshell.nl", Role.ADMIN),
-            Arguments.of("traefik.esa-blueshell.nl", Role.ADMIN),
+            Arguments.of("vault.esa-blueshell.nl"),
+            Arguments.of("headlamp.esa-blueshell.nl"),
+            Arguments.of("traefik.esa-blueshell.nl"),
         )
 
         @JvmStatic
         fun boardGatedHosts(): Stream<Arguments> = Stream.of(
-            Arguments.of("listmonk.esa-blueshell.nl", Role.BOARD),
-            Arguments.of("stalwart.esa-blueshell.nl", Role.BOARD),
+            Arguments.of("listmonk.esa-blueshell.nl"),
+            Arguments.of("stalwart.esa-blueshell.nl"),
         )
 
         @JvmStatic
@@ -44,7 +41,7 @@ class ForwardAuthChainSystemTest : OidcSystemTestBase() {
 
     @ParameterizedTest(name = "anonymous → 302 to /login (host={0})")
     @MethodSource("allGatedHosts")
-    fun anonymous_redirects_to_login(host: String, @Suppress("UNUSED_PARAMETER") required: Role) {
+    fun anonymous_redirects_to_login(host: String) {
         val response = get(
             "/oauth2/forward-auth",
             headers = mapOf(
@@ -63,12 +60,12 @@ class ForwardAuthChainSystemTest : OidcSystemTestBase() {
 
     @ParameterizedTest(name = "member → 302 /unauthorized (host={0})")
     @MethodSource("allGatedHosts")
-    fun member_blocked_with_unauthorized_redirect(host: String, @Suppress("UNUSED_PARAMETER") required: Role) {
-        val member = userFactory.createUserWithRole(Role.MEMBER)
+    fun member_blocked_with_unauthorized_redirect(host: String) {
+        val member = TestHelper.registerActivateAndPromote("MEMBER")
 
         val response = get(
             "/oauth2/forward-auth",
-            sessionToken = sessionTokenFor(member.username),
+            sessionToken = sessionTokenFor(member),
             headers = mapOf("X-Forwarded-Host" to host, "X-Forwarded-Uri" to "/"),
         )
 
@@ -79,30 +76,31 @@ class ForwardAuthChainSystemTest : OidcSystemTestBase() {
 
     @ParameterizedTest(name = "admin → 200 with X-User-Id (host={0})")
     @MethodSource("allGatedHosts")
-    fun admin_passes_every_host(host: String, @Suppress("UNUSED_PARAMETER") required: Role) {
-        val admin = userFactory.createUserWithRole(Role.ADMIN)
+    fun admin_passes_every_host(host: String) {
+        val admin = TestHelper.registerActivateAndPromote("ADMIN")
+        val adminId = TestHelper.findUser(admin.username)!!.id
 
         val response = get(
             "/oauth2/forward-auth",
-            sessionToken = sessionTokenFor(admin.username),
+            sessionToken = sessionTokenFor(admin),
             headers = mapOf("X-Forwarded-Host" to host),
         )
 
         assertThat(response.statusCode()).isEqualTo(200)
         assertThat(response.headers().firstValue("X-User-Id").orElse(""))
-            .isEqualTo(admin.id!!.toString())
+            .isEqualTo(adminId.toString())
         assertThat(response.headers().firstValue("X-User-Groups").orElse(""))
             .contains("ADMIN")
     }
 
     @ParameterizedTest(name = "board → 200 (host={0}, board-gated)")
     @MethodSource("boardGatedHosts")
-    fun board_passes_board_gated_hosts(host: String, @Suppress("UNUSED_PARAMETER") required: Role) {
-        val board = userFactory.createUserWithRole(Role.BOARD)
+    fun board_passes_board_gated_hosts(host: String) {
+        val board = TestHelper.registerActivateAndPromote("BOARD")
 
         val response = get(
             "/oauth2/forward-auth",
-            sessionToken = sessionTokenFor(board.username),
+            sessionToken = sessionTokenFor(board),
             headers = mapOf("X-Forwarded-Host" to host),
         )
 
@@ -112,12 +110,12 @@ class ForwardAuthChainSystemTest : OidcSystemTestBase() {
 
     @ParameterizedTest(name = "board → 302 /unauthorized (host={0}, admin-gated)")
     @MethodSource("adminGatedHosts")
-    fun board_blocked_on_admin_gated_hosts(host: String, @Suppress("UNUSED_PARAMETER") required: Role) {
-        val board = userFactory.createUserWithRole(Role.BOARD)
+    fun board_blocked_on_admin_gated_hosts(host: String) {
+        val board = TestHelper.registerActivateAndPromote("BOARD")
 
         val response = get(
             "/oauth2/forward-auth",
-            sessionToken = sessionTokenFor(board.username),
+            sessionToken = sessionTokenFor(board),
             headers = mapOf("X-Forwarded-Host" to host),
         )
 
@@ -128,11 +126,10 @@ class ForwardAuthChainSystemTest : OidcSystemTestBase() {
 
     @ParameterizedTest(name = "anonymous XHR → 401 (host={0})")
     @MethodSource("allGatedHosts")
-    fun anonymous_xhr_returns_401_not_302(host: String, @Suppress("UNUSED_PARAMETER") required: Role) {
-        // Stalwart/Headlamp/etc. SPAs fetch /api/* with Accept: application/json
-        // (no text/html). A 302 to v2.esa-blueshell.nl/login auto-follows and
-        // browser CORS-blocks it → SPA shows a generic network error. 401 lets
-        // the SPA recognise an expired session.
+    fun anonymous_xhr_returns_401_not_302(host: String) {
+        // SPAs fetch `/api/*` with `Accept: application/json`. A 302 to
+        // the login page auto-follows and CORS-blocks; 401 lets the SPA
+        // recognise an expired session.
         val response = java.net.http.HttpClient.newHttpClient().send(
             java.net.http.HttpRequest.newBuilder()
                 .uri(java.net.URI.create("$baseUrl/oauth2/forward-auth"))
@@ -152,15 +149,15 @@ class ForwardAuthChainSystemTest : OidcSystemTestBase() {
 
     @ParameterizedTest(name = "member XHR on board-gated → 403 (host={0})")
     @MethodSource("boardGatedHosts")
-    fun member_xhr_on_board_host_returns_403(host: String, @Suppress("UNUSED_PARAMETER") required: Role) {
-        val member = userFactory.createUserWithRole(Role.MEMBER)
+    fun member_xhr_on_board_host_returns_403(host: String) {
+        val member = TestHelper.registerActivateAndPromote("MEMBER")
 
         val response = java.net.http.HttpClient.newHttpClient().send(
             java.net.http.HttpRequest.newBuilder()
                 .uri(java.net.URI.create("$baseUrl/oauth2/forward-auth"))
                 .GET()
                 .header("Accept", "application/json")
-                .header("Cookie", "$authCookieName=${sessionTokenFor(member.username)}")
+                .header("Cookie", "$authCookieName=${sessionTokenFor(member)}")
                 .header("X-Forwarded-Host", host)
                 .build(),
             java.net.http.HttpResponse.BodyHandlers.discarding(),
@@ -171,11 +168,11 @@ class ForwardAuthChainSystemTest : OidcSystemTestBase() {
 
     @Test
     fun `unknown host falls back to ADMIN-required and rejects board`() {
-        val board = userFactory.createUserWithRole(Role.BOARD)
+        val board = TestHelper.registerActivateAndPromote("BOARD")
 
         val response = get(
             "/oauth2/forward-auth",
-            sessionToken = sessionTokenFor(board.username),
+            sessionToken = sessionTokenFor(board),
             headers = mapOf("X-Forwarded-Host" to "rogue.example.com"),
         )
 

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/OidcSystemTestBase.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/OidcSystemTestBase.kt
@@ -1,10 +1,15 @@
 package net.blueshell.api.system.oidc
 
+import net.blueshell.api.ApiApplication
+import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.systemtests.PlaywrightShardCondition
 import net.blueshell.systemtests.TestEnvironment
 import net.blueshell.systemtests.TestHelper
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestExecutionListeners
 import java.net.CookieManager
 import java.net.URI
 import java.net.URLEncoder
@@ -15,16 +20,26 @@ import java.nio.charset.StandardCharsets
 import java.time.Duration
 
 /**
- * Base for OIDC system tests that drive the api over plain HTTP. No
- * Playwright (these flows are about HTTP redirects and JWT contents,
- * not pixels), no `@SpringBootTest` — every observable behaviour comes
- * from real HTTP requests against the running api.
- *
- * Concrete tests that need a browser layer on top can compose
- * Playwright over the same `TestHelper`.
+ * Base for OIDC system tests that talk to the api strictly over HTTP.
+ * The Spring annotations here exist to host `ApiApplication` on
+ * `localhost:8080` from inside the test JVM — the test bodies never
+ * inject beans or reach into repositories, every observable behaviour
+ * comes from real HTTP requests routed through `TestHelper`. Once CI
+ * runs against a containerised api the four bootstrap annotations
+ * come off and `baseUrl` points at the container instead.
  */
 @ExtendWith(PlaywrightShardCondition::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ActiveProfiles("test")
+@TestExecutionListeners(
+    listeners = [TestCleanUpListener::class],
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+)
+@SpringBootTest(
+    classes = [ApiApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
+)
 abstract class OidcSystemTestBase {
 
     protected val baseUrl: String = TestEnvironment.apiUrl

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/OidcSystemTestBase.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/OidcSystemTestBase.kt
@@ -1,15 +1,10 @@
 package net.blueshell.api.system.oidc
 
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
-import net.blueshell.api.factory.user.persistence.UserFactory
-import net.blueshell.api.infrastructure.security.JwtTokenGenerator
+import net.blueshell.systemtests.PlaywrightShardCondition
+import net.blueshell.systemtests.TestEnvironment
+import net.blueshell.systemtests.TestHelper
 import org.junit.jupiter.api.TestInstance
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
+import org.junit.jupiter.api.extension.ExtendWith
 import java.net.CookieManager
 import java.net.URI
 import java.net.URLEncoder
@@ -19,34 +14,27 @@ import java.net.http.HttpResponse
 import java.nio.charset.StandardCharsets
 import java.time.Duration
 
-@ActiveProfiles("test")
+/**
+ * Base for OIDC system tests that drive the api over plain HTTP. No
+ * Playwright (these flows are about HTTP redirects and JWT contents,
+ * not pixels), no `@SpringBootTest` — every observable behaviour comes
+ * from real HTTP requests against the running api.
+ *
+ * Concrete tests that need a browser layer on top can compose
+ * Playwright over the same `TestHelper`.
+ */
+@ExtendWith(PlaywrightShardCondition::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"]
-)
 abstract class OidcSystemTestBase {
 
-    @Autowired
-    protected lateinit var userFactory: UserFactory
+    protected val baseUrl: String = TestEnvironment.apiUrl
 
-    @Autowired
-    protected lateinit var tokenGenerator: JwtTokenGenerator
-
-    @Value($$"\${security.auth-cookie.name:BSH_AUTH}")
-    protected lateinit var authCookieName: String
-
-    protected val baseUrl: String = "http://localhost:8080"
+    protected val authCookieName: String get() = TestEnvironment.authCookieName
 
     /**
-     * HttpClient that does NOT follow redirects — every OIDC test needs to
-     * inspect 302 Location headers (login redirect, unauthorized redirect,
-     * authorize → callback with code).
+     * HttpClient that does NOT follow redirects — every OIDC test
+     * needs to inspect 302 Location headers (login redirect,
+     * unauthorized redirect, authorize → callback with code).
      */
     protected fun newClient(): HttpClient =
         HttpClient.newBuilder()
@@ -55,16 +43,22 @@ abstract class OidcSystemTestBase {
             .connectTimeout(Duration.ofSeconds(5))
             .build()
 
-    protected fun sessionTokenFor(username: String): String =
-        tokenGenerator.generateToken(username)
+    /**
+     * Log a `RegisteredUser` in and return the auth cookie value.
+     * Mints the JWT through the real `/auth` endpoint — same shape
+     * as the previous `tokenGenerator.generateToken(...)` call, just
+     * routed through HTTP rather than an in-process bean.
+     */
+    protected fun sessionTokenFor(user: TestHelper.RegisteredUser): String =
+        TestHelper.login(user).auth
 
     /**
-     * GET against the running app. Matches the browser-driven OIDC flow:
-     * session JWT carried as the BSH_AUTH cookie (not Authorization: Bearer
-     * — `.oidc()` brings in a resource-server BearerTokenAuthenticationFilter
-     * that would reject our HS256 session JWT), Accept: text/html so the
-     * SAS chain dispatches AuthenticationExceptions to our loginRedirect
-     * entry point rather than the resource-server's 401 default.
+     * GET against the running app. Carries the session JWT as the
+     * auth cookie (not `Authorization: Bearer` — the OIDC chain
+     * would reject our HS256 session JWT through the resource-server
+     * filter), and asks for `text/html` so the SAS chain dispatches
+     * `AuthenticationException` to the loginRedirect entry point
+     * rather than the resource server's 401 default.
      */
     protected fun get(
         path: String,

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/OidcTokenClaimsSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/OidcTokenClaimsSystemTest.kt
@@ -1,6 +1,6 @@
 package net.blueshell.api.system.oidc
 
-import net.blueshell.api.shared.enums.Role
+import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -24,14 +24,15 @@ class OidcTokenClaimsSystemTest : OidcSystemTestBase() {
 
     @Test
     fun `headlamp authorization_code grant issues id_token with admin groups`() {
-        val admin = userFactory.createUserWithRole(Role.ADMIN)
+        val admin = TestHelper.registerActivateAndPromote("ADMIN")
+        val adminId = TestHelper.findUser(admin.username)!!.id
         val pkce = OidcTestHelper.newPkce()
         val redirect = "https://headlamp.esa-blueshell.nl/oidc-callback"
 
         // 1. Authorize -> 302 with ?code=
         val authorizeResp = get(
             buildAuthorizeUrl("headlamp", pkce.challenge, redirect),
-            sessionToken = sessionTokenFor(admin.username),
+            sessionToken = sessionTokenFor(admin),
         )
         assertThat(authorizeResp.statusCode()).isEqualTo(302)
         val location = authorizeResp.headers().firstValue("Location").orElse("")
@@ -55,18 +56,18 @@ class OidcTokenClaimsSystemTest : OidcSystemTestBase() {
 
         // 3. ID token: roles + groups (admin → k8s-admin + member)
         val idClaims = OidcTestHelper.decodePayload(tokenJson["id_token"].asString())
-        assertThat(idClaims["sub"].asString()).isEqualTo(admin.id!!.toString())
+        assertThat(idClaims["sub"].asString()).isEqualTo(adminId.toString())
         assertThat(OidcTestHelper.stringValues(idClaims["groups"])).contains("k8s-admin", "member")
-        assertThat(OidcTestHelper.stringValues(idClaims["roles"])).contains(Role.ADMIN.name)
+        assertThat(OidcTestHelper.stringValues(idClaims["roles"])).contains("ADMIN")
 
         // 4. Access token: aud, roles, username, email
         val accessClaims = OidcTestHelper.decodePayload(tokenJson["access_token"].asString())
-        assertThat(accessClaims["sub"].asString()).isEqualTo(admin.id!!.toString())
+        assertThat(accessClaims["sub"].asString()).isEqualTo(adminId.toString())
         assertThat(OidcTestHelper.stringValues(accessClaims["aud"])).contains("headlamp")
         assertThat(accessClaims["username"].asString()).isEqualTo(admin.username)
         assertThat(accessClaims["preferred_username"].asString()).isEqualTo(admin.username)
         assertThat(accessClaims["email"].asString()).isEqualTo(admin.email)
-        assertThat(OidcTestHelper.stringValues(accessClaims["roles"])).contains(Role.ADMIN.name)
+        assertThat(OidcTestHelper.stringValues(accessClaims["roles"])).contains("ADMIN")
     }
 
     @Test
@@ -78,13 +79,14 @@ class OidcTokenClaimsSystemTest : OidcSystemTestBase() {
         // pass admin gating but the user does not have a non-ADMIN role
         // alone, so the assertion focuses on `member` always being
         // present for any non-anonymous principal.
-        val admin = userFactory.createUserWithRole(Role.ADMIN)
+        val admin = TestHelper.registerActivateAndPromote("ADMIN")
+        val adminId = TestHelper.findUser(admin.username)!!.id
         val pkce = OidcTestHelper.newPkce()
         val redirect = "https://headlamp.esa-blueshell.nl/oidc-callback"
 
         val authorizeResp = get(
             buildAuthorizeUrl("headlamp", pkce.challenge, redirect),
-            sessionToken = sessionTokenFor(admin.username),
+            sessionToken = sessionTokenFor(admin),
         )
         val code = OidcTestHelper.queryParam(
             authorizeResp.headers().firstValue("Location").orElse(""),

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/playwright/OidcAuthorizePlaywrightTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/playwright/OidcAuthorizePlaywrightTest.kt
@@ -1,6 +1,8 @@
 package net.blueshell.api.system.oidc.playwright
 
 import com.microsoft.playwright.options.RequestOptions
+import net.blueshell.api.ApiApplication
+import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.oidc.OidcTestHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestEnvironment
@@ -10,6 +12,9 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestExecutionListeners
 import java.util.stream.Stream
 
 /**
@@ -26,6 +31,16 @@ import java.util.stream.Stream
  * exchange inside the api's response chain.
  */
 @Tag("system")
+@ActiveProfiles("test")
+@TestExecutionListeners(
+    listeners = [TestCleanUpListener::class],
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+)
+@SpringBootTest(
+    classes = [ApiApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
+)
 class OidcAuthorizePlaywrightTest : PlaywrightTestBase() {
 
     companion object {

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/playwright/OidcAuthorizePlaywrightTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/playwright/OidcAuthorizePlaywrightTest.kt
@@ -1,82 +1,32 @@
 package net.blueshell.api.system.oidc.playwright
 
-import com.microsoft.playwright.Browser
-import com.microsoft.playwright.BrowserType
-import com.microsoft.playwright.Playwright
 import com.microsoft.playwright.options.RequestOptions
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
-import net.blueshell.api.factory.user.persistence.UserFactory
-import net.blueshell.api.infrastructure.security.JwtTokenGenerator
-import net.blueshell.api.shared.enums.Role
 import net.blueshell.api.system.oidc.OidcTestHelper
+import net.blueshell.systemtests.PlaywrightTestBase
+import net.blueshell.systemtests.TestEnvironment
+import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Tag
-import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 import java.util.stream.Stream
 
 /**
- * Browser-driven smoke for /oauth2/authorize. Verifies that a real
- * HTTP client following Spring SAS's redirect chain ends up at the
- * registered `redirect_uri` with a `code=` and the original `state`
- * preserved — the same property OidcTokenClaimsSystemTest checks via
- * a raw HttpClient, but exercised through Playwright's APIRequest
- * (which is the same HTTP stack used for the rest of the system tests).
+ * Browser-driven smoke for `/oauth2/authorize`. Verifies that an HTTP
+ * client following the SAS redirect chain ends up at the registered
+ * `redirect_uri` with a `code=` and the original `state` preserved —
+ * the same property `OidcTokenClaimsSystemTest` checks via the raw JDK
+ * `HttpClient`, but here exercised through Playwright's `APIRequest`
+ * (the same HTTP stack used for the browser-driven flow).
  *
- * We use APIRequest rather than a Page navigation because the
- * registered redirect_uri (https://headlamp.esa-blueshell.nl/...) is a
- * production hostname; a Page would resolve DNS to it and hang. Stays
- * inside the embedded server's response chain.
- *
- * Mirrors personal-stack's RabbitMqOidcPlaywrightTest pattern (Playwright
- * driving the redirect chain) without requiring a live downstream
- * service.
+ * Uses `APIRequest` rather than a page navigation because the
+ * registered `redirect_uri` is a production hostname; a page would
+ * resolve DNS to it and hang. Staying inside `APIRequest` keeps the
+ * exchange inside the api's response chain.
  */
 @Tag("system")
-@ActiveProfiles("test")
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"]
-)
-class OidcAuthorizePlaywrightTest {
-
-    @Autowired
-    private lateinit var userFactory: UserFactory
-
-    @Autowired
-    private lateinit var tokenGenerator: JwtTokenGenerator
-
-    private val baseUrl = "http://localhost:8080"
-
-    private lateinit var playwright: Playwright
-    private lateinit var browser: Browser
-
-    @BeforeAll
-    fun launchBrowser() {
-        playwright = Playwright.create()
-        browser = playwright.chromium().launch(BrowserType.LaunchOptions().setHeadless(true))
-    }
-
-    @AfterAll
-    fun closeBrowser() {
-        browser.close()
-        playwright.close()
-    }
+class OidcAuthorizePlaywrightTest : PlaywrightTestBase() {
 
     companion object {
         @JvmStatic
@@ -97,8 +47,8 @@ class OidcAuthorizePlaywrightTest {
     @ParameterizedTest(name = "{0}: admin OIDC authorize chain ends at redirect_uri with code")
     @MethodSource("clients")
     fun adminAuthorizeReachesCallback(clientId: String, redirect: String, withPkce: Boolean) {
-        val admin = userFactory.createUserWithRole(Role.ADMIN)
-        val token = tokenGenerator.generateToken(admin.username)
+        val admin = TestHelper.registerActivateAndPromote("ADMIN")
+        val token = TestHelper.login(admin).auth
         val pkce = if (withPkce) OidcTestHelper.newPkce() else null
 
         val params = buildList {
@@ -113,24 +63,19 @@ class OidcAuthorizePlaywrightTest {
             }
         }.joinToString("&")
 
-        val context = browser.newContext()
-        try {
-            val api = context.request()
-            val response = api.get(
-                "$baseUrl/oauth2/authorize?$params",
-                RequestOptions.create()
-                    .setHeader("Cookie", "BSH_AUTH=$token")
-                    .setHeader("Accept", "text/html")
-                    .setMaxRedirects(0),
-            )
-            assertThat(response.status()).isEqualTo(302)
-            val location = response.headers()["location"] ?: error("No Location header on authorize 302")
-            assertThat(location).startsWith(redirect)
-            assertThat(OidcTestHelper.queryParam(location, "code")).isNotBlank()
-            assertThat(OidcTestHelper.queryParam(location, "state")).isEqualTo("pw-state")
-        } finally {
-            context.close()
-        }
+        val api = context.request()
+        val response = api.get(
+            "${TestEnvironment.apiUrl}/oauth2/authorize?$params",
+            RequestOptions.create()
+                .setHeader("Cookie", "${TestEnvironment.authCookieName}=$token")
+                .setHeader("Accept", "text/html")
+                .setMaxRedirects(0),
+        )
+        assertThat(response.status()).isEqualTo(302)
+        val location = response.headers()["location"] ?: error("No Location header on authorize 302")
+        assertThat(location).startsWith(redirect)
+        assertThat(OidcTestHelper.queryParam(location, "code")).isNotBlank()
+        assertThat(OidcTestHelper.queryParam(location, "state")).isEqualTo("pw-state")
     }
 
     private fun enc(s: String): String = java.net.URLEncoder.encode(s, Charsets.UTF_8)

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/StalwartMailClient.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/StalwartMailClient.kt
@@ -1,0 +1,157 @@
+package net.blueshell.systemtests
+
+import jakarta.mail.Flags
+import jakarta.mail.Folder
+import jakarta.mail.Message
+import jakarta.mail.Session
+import jakarta.mail.internet.InternetAddress
+import jakarta.mail.internet.MimeMultipart
+import java.util.Properties
+
+/**
+ * IMAP-backed inspection helper for tests that need to assert what the
+ * api delivered to the mail server. Connects to the IMAP listener
+ * Stalwart exposes (default port 143 inside the network, 1143 from the
+ * host in dev), authenticates as the admin user, and queries the
+ * configured inbox.
+ *
+ * Mirrors the call surface tests previously got from the in-process
+ * `MockListmonkEmailClient`: `reset()` empties the inbox before each
+ * test, `findEmail(...)` returns the first matching delivery,
+ * `assertEmailSent(...)` polls until one arrives or the timeout
+ * elapses.
+ *
+ * The inbox the api writes to is set via `-Dtest.imap.mailbox=` (default
+ * `bounce@dev.local`, the seeded mailbox in the dev compose). For tests
+ * to find their messages, the api's outbound mail must reach that
+ * mailbox — either by sending directly to it or via a catchall in the
+ * Stalwart directory.
+ */
+class StalwartMailClient(
+    private val host: String = System.getProperty("test.imap.host", "localhost"),
+    private val port: Int = System.getProperty("test.imap.port", "1143").toInt(),
+    private val username: String = System.getProperty("test.imap.user", "bounce@dev.local"),
+    private val password: String = System.getProperty("test.imap.password", "bounce"),
+    private val folderName: String = System.getProperty("test.imap.folder", "INBOX"),
+) {
+    private val session: Session by lazy {
+        val props = Properties().apply {
+            put("mail.store.protocol", "imap")
+            put("mail.imap.host", host)
+            put("mail.imap.port", port.toString())
+            put("mail.imap.connectiontimeout", DEFAULT_TIMEOUT_MS.toString())
+            put("mail.imap.timeout", DEFAULT_TIMEOUT_MS.toString())
+            put("mail.imap.starttls.enable", "false")
+            put("mail.imap.ssl.enable", "false")
+        }
+        Session.getInstance(props)
+    }
+
+    /** Mark every message in the target folder as deleted and expunge. */
+    fun reset() {
+        withFolder(write = true) { folder ->
+            val messages = folder.messages
+            if (messages.isNotEmpty()) {
+                folder.setFlags(messages, Flags(Flags.Flag.DELETED), true)
+            }
+        }
+    }
+
+    /**
+     * First message in the inbox whose recipient list contains
+     * `recipient` and whose subject matches `subject` exactly. Returns
+     * null when no such message exists.
+     */
+    fun findEmail(recipient: String, subject: String): DeliveredEmail? =
+        withFolder(write = false) { folder ->
+            folder.messages.firstOrNull { msg ->
+                msg.subject == subject && msg.recipientsContains(recipient)
+            }?.toDeliveredEmail()
+        }
+
+    /**
+     * Polls `findEmail` until a match arrives or the deadline passes.
+     * Times out with an `AssertionError` describing what was expected.
+     */
+    fun assertEmailSent(
+        recipient: String,
+        subject: String,
+        timeoutMs: Long = 10_000,
+        pollIntervalMs: Long = 250,
+    ): DeliveredEmail {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            val hit = findEmail(recipient, subject)
+            if (hit != null) return hit
+            Thread.sleep(pollIntervalMs)
+        }
+        throw AssertionError(
+            "Expected email subject=\"$subject\" recipient=$recipient " +
+                "within ${timeoutMs}ms but none arrived",
+        )
+    }
+
+    private fun <T> withFolder(write: Boolean, block: (Folder) -> T): T {
+        val store = session.getStore("imap")
+        store.connect(host, port, username, password)
+        try {
+            val folder = store.getFolder(folderName)
+            val mode = if (write) Folder.READ_WRITE else Folder.READ_ONLY
+            folder.open(mode)
+            try {
+                return block(folder)
+            } finally {
+                // expunge = true on close commits the DELETED flags
+                folder.close(write)
+            }
+        } finally {
+            store.close()
+        }
+    }
+
+    private fun Message.recipientsContains(recipient: String): Boolean {
+        val all = (
+            (getRecipients(Message.RecipientType.TO) ?: emptyArray()) +
+                (getRecipients(Message.RecipientType.CC) ?: emptyArray()) +
+                (getRecipients(Message.RecipientType.BCC) ?: emptyArray())
+        )
+        return all.any { (it as? InternetAddress)?.address?.equals(recipient, ignoreCase = true) == true }
+    }
+
+    private fun Message.toDeliveredEmail(): DeliveredEmail {
+        val to = (getRecipients(Message.RecipientType.TO) ?: emptyArray())
+            .mapNotNull { (it as? InternetAddress)?.address }
+        val body = when (val content = content) {
+            is String -> content
+            is MimeMultipart -> extractText(content) ?: ""
+            else -> content?.toString().orEmpty()
+        }
+        return DeliveredEmail(
+            subject = subject ?: "",
+            recipients = to,
+            body = body,
+        )
+    }
+
+    private fun extractText(multipart: MimeMultipart): String? {
+        for (i in 0 until multipart.count) {
+            val part = multipart.getBodyPart(i)
+            if (part.isMimeType("text/plain")) return part.content?.toString()
+        }
+        for (i in 0 until multipart.count) {
+            val part = multipart.getBodyPart(i)
+            if (part.isMimeType("text/html")) return part.content?.toString()
+        }
+        return null
+    }
+
+    data class DeliveredEmail(
+        val subject: String,
+        val recipients: List<String>,
+        val body: String,
+    )
+
+    companion object {
+        private const val DEFAULT_TIMEOUT_MS = 5_000
+    }
+}

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestEnvironment.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestEnvironment.kt
@@ -1,18 +1,35 @@
 package net.blueshell.systemtests
 
 /**
- * URLs and shard config read from `-D` system properties. Tests pick these
- * up at JVM startup. Defaults target a local dev compose stack so a Gradle
- * run with no -D flags still works against `docker compose up` from the
- * repo root.
- *
- * Mirrors personal-stack-2's pattern of carrying test config as system
- * properties prefixed `test.*` rather than env vars.
+ * URLs and shard config read from `-D` system properties. Tests pick
+ * these up at JVM startup. Defaults target a local dev compose stack
+ * so a Gradle run with no `-D` flags still works against
+ * `docker compose up` from the repo root.
  */
 object TestEnvironment {
     val apiUrl: String get() = sys("test.api.url", "http://localhost:8080")
     val frontendUrl: String get() = sys("test.frontend.url", "http://localhost:3000")
-    val mailhogUrl: String get() = sys("test.mailhog.url", "http://localhost:8025")
+
+    /**
+     * Stalwart admin HTTP endpoint — used by `StalwartMailClient` to
+     * inspect delivered messages. Defaults to the dev port mapping
+     * in `services/stalwart/docker-compose.yml` (`8085:8080`).
+     */
+    val stalwartUrl: String get() = sys("test.stalwart.url", "http://localhost:8085")
+
+    /**
+     * Credentials for Stalwart's admin API. Dev defaults are `admin`
+     * for both, set by `STALWART_ADMIN_USER`/`STALWART_ADMIN_SECRET`.
+     */
+    val stalwartAdminUser: String get() = sys("test.stalwart.admin-user", "admin")
+    val stalwartAdminSecret: String get() = sys("test.stalwart.admin-secret", "admin")
+
+    /**
+     * Name of the auth cookie returned by `POST /auth`. Configurable
+     * because the api reads it from `security.auth-cookie.name`, and
+     * deployed instances may override the default.
+     */
+    val authCookieName: String get() = sys("test.auth-cookie.name", "BSH_AUTH")
 
     val shardIndex: Int? get() = System.getProperty("test.shard.index")?.toIntOrNull()
     val shardCount: Int? get() = System.getProperty("test.shard.count")?.toIntOrNull()?.takeIf { it > 1 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -41,6 +41,26 @@ object TestHelper {
     fun givenApi(): RequestSpecification = given().relaxedHTTPSValidation()
 
     /**
+     * Fetch an XSRF-TOKEN cookie + matching `X-XSRF-TOKEN` header from
+     * `GET /csrf`. State-changing requests against the api need both
+     * (Spring Security's `CookieCsrfTokenRepository.withHttpOnlyFalse`
+     * issues a cookie that the api also expects echoed in the header).
+     */
+    fun givenCsrfApi(): RequestSpecification {
+        val csrfResponse = retryOnConnectionFailure {
+            givenApi().baseUri(apiBaseUrl).`when`().get("/csrf")
+        }
+        require(csrfResponse.statusCode == 200) {
+            "GET /csrf returned ${csrfResponse.statusCode}: ${csrfResponse.asString()}"
+        }
+        val token = csrfResponse.cookie("XSRF-TOKEN")
+            ?: error("no XSRF-TOKEN cookie in /csrf response")
+        return givenApi()
+            .cookie("XSRF-TOKEN", token)
+            .header("X-XSRF-TOKEN", token)
+    }
+
+    /**
      * Standard password for created test users. Passes the api's
      * complexity rule (lower + upper + digit + one of `@$!%*?&`).
      */
@@ -78,7 +98,7 @@ object TestHelper {
         email: String = "$username@systemtest.example.com",
     ): RegisteredUser {
         retryOnConnectionFailure {
-            givenApi()
+            givenCsrfApi()
                 .baseUri(apiBaseUrl)
                 .contentType(ContentType.JSON)
                 .body(
@@ -239,7 +259,7 @@ object TestHelper {
      */
     fun login(user: RegisteredUser): LoginCookies {
         val response = retryOnConnectionFailure {
-            givenApi()
+            givenCsrfApi()
                 .baseUri(apiBaseUrl)
                 .contentType(ContentType.JSON)
                 .body("""{"username":"${user.username}","password":"${user.password}"}""")

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -41,10 +41,13 @@ object TestHelper {
     fun givenApi(): RequestSpecification = given().relaxedHTTPSValidation()
 
     /**
-     * Fetch an XSRF-TOKEN cookie + matching `X-XSRF-TOKEN` header from
-     * `GET /csrf`. State-changing requests against the api need both
-     * (Spring Security's `CookieCsrfTokenRepository.withHttpOnlyFalse`
-     * issues a cookie that the api also expects echoed in the header).
+     * Build a request that carries a fresh CSRF round-trip. The api
+     * uses Spring Security's BREACH-protected token: the
+     * `Set-Cookie XSRF-TOKEN=` value is XOR-encoded per request, and
+     * `GET /csrf` returns the raw token in its JSON body. State-
+     * changing requests have to send the cookie value verbatim and the
+     * body token as `X-XSRF-TOKEN`; the frontend follows the same
+     * shape in `services/frontend/src/services/api/blueshell.runtime.ts`.
      */
     fun givenCsrfApi(): RequestSpecification {
         val csrfResponse = retryOnConnectionFailure {
@@ -53,11 +56,13 @@ object TestHelper {
         require(csrfResponse.statusCode == 200) {
             "GET /csrf returned ${csrfResponse.statusCode}: ${csrfResponse.asString()}"
         }
-        val token = csrfResponse.cookie("XSRF-TOKEN")
+        val cookieValue = csrfResponse.cookie("XSRF-TOKEN")
             ?: error("no XSRF-TOKEN cookie in /csrf response")
+        val bodyToken = csrfResponse.jsonPath().getString("token")
+            ?: error("no token field in /csrf response body")
         return givenApi()
-            .cookie("XSRF-TOKEN", token)
-            .header("X-XSRF-TOKEN", token)
+            .cookie("XSRF-TOKEN", cookieValue)
+            .header("X-XSRF-TOKEN", bodyToken)
     }
 
     /**

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -102,7 +102,7 @@ object TestHelper {
         password: String = DEFAULT_PASSWORD,
         email: String = "$username@systemtest.example.com",
     ): RegisteredUser {
-        retryOnConnectionFailure {
+        val response = retryOnConnectionFailure {
             givenCsrfApi()
                 .baseUri(apiBaseUrl)
                 .contentType(ContentType.JSON)
@@ -117,13 +117,16 @@ object TestHelper {
                       "discord": "$username#0001",
                       "phoneNumber": "06${System.currentTimeMillis().toString().takeLast(8)}",
                       "newsletter": false,
+                      "consentPrivacy": true,
+                      "photoConsent": false,
                       "password": "$password"
                     }
                     """.trimIndent(),
                 ).`when`()
                 .post("/users")
-                .then()
-                .statusCode(201)
+        }
+        require(response.statusCode == 201) {
+            "POST /users returned ${response.statusCode}: ${response.asString()}"
         }
 
         return RegisteredUser(username, email, password)

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -4,22 +4,30 @@ import io.restassured.RestAssured.given
 import io.restassured.http.ContentType
 import io.restassured.specification.RequestSpecification
 import java.net.ConnectException
+import java.sql.Connection
 import java.sql.DriverManager
 import java.util.UUID
 
 /**
- * Shared HTTP + JDBC helper for system tests. Models the same shape as
- * personal-stack-2's TestHelper: the public api drives behaviour over
- * HTTP (register, login, etc.), and JDBC fills the gaps where the api
- * doesn't expose an admin path (granting roles, looking up tokens).
+ * HTTP + JDBC helper for system tests. The api drives behaviour over
+ * HTTP (`POST /users`, `POST /auth`); JDBC fills the gaps where the
+ * public surface won't help — flipping a fresh user from disabled to
+ * enabled (no admin endpoint exposes it) and assigning roles in the
+ * `authorities` join table (only mutable via the privileged
+ * `ToggleUserRole` endpoint, which requires an existing admin caller
+ * — a chicken-and-egg the tests cut by talking to the DB directly).
  *
- * This is the migration target for the in-process @Autowired
- * UserRepository / UserFactory / JwtTokenGenerator usages that the
- * existing FrontendSystemTestBase / OidcSystemTestBase still carry.
+ * Activation tokens are intentionally not retrieved from the DB: the
+ * api only persists a hashed verifier (see `recovery_tokens`), so the
+ * plaintext token in the email cannot be reconstructed from SQL.
+ * Tests that exercise the activation flow itself read the email via
+ * `StalwartMailClient`; every other test bypasses by setting
+ * `enabled = true`.
  */
 object TestHelper {
     private const val API_RETRY_ATTEMPTS = 3
     private const val API_RETRY_DELAY_MS = 2_000L
+    private const val ACTIVE_ROW_PREDICATE = "deleted_at = '9999-12-31 23:59:59'"
 
     val apiBaseUrl: String get() = TestEnvironment.apiUrl
 
@@ -31,6 +39,12 @@ object TestHelper {
         get() = System.getProperty("test.db.password", "ci-blueshell")
 
     fun givenApi(): RequestSpecification = given().relaxedHTTPSValidation()
+
+    /**
+     * Standard password for created test users. Passes the api's
+     * complexity rule (lower + upper + digit + one of `@$!%*?&`).
+     */
+    const val DEFAULT_PASSWORD: String = "Password123!"
 
     private fun <T> retryOnConnectionFailure(action: () -> T): T {
         var lastException: Exception? = null
@@ -52,13 +66,15 @@ object TestHelper {
     }
 
     /**
-     * Register a new user via the public POST /users endpoint and activate
-     * their account by reading the activation token straight from the db.
-     * Mirrors personal-stack-2's `registerAndConfirm` step-for-step.
+     * Register a new user via `POST /users`. The account lands
+     * disabled — the api flips `enabled = false` on every fresh
+     * registration. Callers that want a login-ready account should
+     * chain `setEnabled(user.username, true)` or use
+     * `registerAndActivate`.
      */
-    fun registerAndActivate(
+    fun register(
         username: String = "sys_${UUID.randomUUID().toString().take(8)}",
-        password: String = "Test1234!",
+        password: String = DEFAULT_PASSWORD,
         email: String = "$username@systemtest.example.com",
     ): RegisteredUser {
         retryOnConnectionFailure {
@@ -66,60 +82,160 @@ object TestHelper {
                 .baseUri(apiBaseUrl)
                 .contentType(ContentType.JSON)
                 .body(
-                    """{"username":"$username","email":"$email","firstName":"Test","surname":"User","password":"$password"}""",
+                    """
+                    {
+                      "username": "$username",
+                      "email": "$email",
+                      "initials": "TU",
+                      "firstName": "Test",
+                      "lastName": "User",
+                      "discord": "$username#0001",
+                      "phoneNumber": "06${System.currentTimeMillis().toString().takeLast(8)}",
+                      "newsletter": false,
+                      "password": "$password"
+                    }
+                    """.trimIndent(),
                 ).`when`()
                 .post("/users")
                 .then()
                 .statusCode(201)
         }
 
-        val token = activationTokenFromDb(username)
-
-        retryOnConnectionFailure {
-            givenApi()
-                .baseUri(apiBaseUrl)
-                .contentType(ContentType.JSON)
-                .body("""{"token":"$token","password":"$password"}""")
-                .`when`()
-                .post("/user/activate")
-                .then()
-                .statusCode(200)
-        }
-
         return RegisteredUser(username, email, password)
     }
 
     /**
-     * Hits the JDBC layer to elevate a user's role. The api's PUT
-     * /users/{id}/roles requires an admin caller, so the first admin
-     * has to be minted directly — matches the makeUserAdmin pattern
-     * in personal-stack-2.
+     * Convenience: register + flip `enabled = true`. Standard setup
+     * for any test that wants a user it can immediately log in as.
      */
-    fun grantRole(username: String, role: String) {
-        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
-            conn.prepareStatement("UPDATE user SET role = ? WHERE username = ?").use { stmt ->
-                stmt.setString(1, role)
-                stmt.setString(2, username)
-                require(stmt.executeUpdate() == 1) { "Failed to set role=$role on username=$username" }
-            }
-        }
-    }
-
-    fun registerActivateAndPromote(
-        role: String,
-        username: String = "${role.lowercase()}_${UUID.randomUUID().toString().take(8)}",
-        password: String = "Test1234!",
+    fun registerAndActivate(
+        username: String = "sys_${UUID.randomUUID().toString().take(8)}",
+        password: String = DEFAULT_PASSWORD,
+        email: String = "$username@systemtest.example.com",
     ): RegisteredUser {
-        val user = registerAndActivate(username = username, password = password)
-        grantRole(user.username, role)
+        val user = register(username, password, email)
+        setEnabled(user.username, true)
         return user
     }
 
     /**
-     * Hits POST /auth and returns the Set-Cookie payload(s) so callers can
-     * forward them into a Playwright BrowserContext or a follow-up HTTP
-     * request. The api's session model uses a "login" cookie alongside
-     * CSRF tokens — both are returned verbatim.
+     * Register, activate, and replace the user's roles with exactly
+     * the requested one (every other row in `authorities` for the
+     * user is removed first).
+     */
+    fun registerActivateAndPromote(
+        role: String,
+        username: String = "${role.lowercase()}_${UUID.randomUUID().toString().take(8)}",
+        password: String = DEFAULT_PASSWORD,
+    ): RegisteredUser {
+        val user = registerAndActivate(username = username, password = password)
+        replaceRoles(user.username, setOf(role))
+        return user
+    }
+
+    /**
+     * Toggle `users.enabled`. Used to mint a deliberately-disabled
+     * account for tests that exercise the login-blocked path, and
+     * internally to activate freshly-registered users.
+     */
+    fun setEnabled(username: String, enabled: Boolean) {
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            conn.prepareStatement(
+                "UPDATE users SET enabled = ? WHERE username = ? AND $ACTIVE_ROW_PREDICATE",
+            ).use { stmt ->
+                stmt.setBoolean(1, enabled)
+                stmt.setString(2, username)
+                require(stmt.executeUpdate() == 1) {
+                    "Failed to set enabled=$enabled on username=$username"
+                }
+            }
+        }
+    }
+
+    /**
+     * Replace every row in `authorities` for the given user. New users
+     * start with `GUEST` only; tests that want exactly `MEMBER` (or
+     * any other single role) should call this rather than appending.
+     */
+    fun replaceRoles(username: String, roles: Set<String>) {
+        require(roles.isNotEmpty()) { "Refusing to leave $username with no roles" }
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            conn.autoCommit = false
+            try {
+                val userId = userIdOrThrow(conn, username)
+                conn.prepareStatement("DELETE FROM authorities WHERE user_id = ?").use { stmt ->
+                    stmt.setLong(1, userId)
+                    stmt.executeUpdate()
+                }
+                conn.prepareStatement(
+                    "INSERT INTO authorities (user_id, authority) VALUES (?, ?)",
+                ).use { stmt ->
+                    for (role in roles) {
+                        stmt.setLong(1, userId)
+                        stmt.setString(2, role)
+                        stmt.addBatch()
+                    }
+                    stmt.executeBatch()
+                }
+                conn.commit()
+            } catch (e: Exception) {
+                conn.rollback()
+                throw e
+            } finally {
+                conn.autoCommit = true
+            }
+        }
+    }
+
+    /**
+     * Append a single role without disturbing existing ones. Use when
+     * the test wants role inheritance to compose (e.g. a `MEMBER` who
+     * is also `BOARD`).
+     */
+    fun grantRole(username: String, role: String) {
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            val userId = userIdOrThrow(conn, username)
+            conn.prepareStatement(
+                "INSERT IGNORE INTO authorities (user_id, authority) VALUES (?, ?)",
+            ).use { stmt ->
+                stmt.setLong(1, userId)
+                stmt.setString(2, role)
+                stmt.executeUpdate()
+            }
+        }
+    }
+
+    /**
+     * Read a user back from the DB. Returns null when the user doesn't
+     * exist (or is soft-deleted). Used by tests that previously polled
+     * `userRepository.findByUsername(...)` to verify async writes.
+     */
+    fun findUser(username: String): RegisteredUserRow? =
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            conn.prepareStatement(
+                "SELECT id, username, email, enabled FROM users " +
+                    "WHERE username = ? AND $ACTIVE_ROW_PREDICATE",
+            ).use { stmt ->
+                stmt.setString(1, username)
+                val rs = stmt.executeQuery()
+                if (rs.next()) {
+                    RegisteredUserRow(
+                        id = rs.getLong("id"),
+                        username = rs.getString("username"),
+                        email = rs.getString("email"),
+                        enabled = rs.getBoolean("enabled"),
+                    )
+                } else {
+                    null
+                }
+            }
+        }
+
+    /**
+     * Hits `POST /auth` and returns the auth cookie (default name
+     * `BSH_AUTH`, overridable via `-Dtest.auth-cookie.name=...`) so
+     * callers can forward it into a Playwright `BrowserContext` or
+     * onto a follow-up `HttpClient` request.
      */
     fun login(user: RegisteredUser): LoginCookies {
         val response = retryOnConnectionFailure {
@@ -134,27 +250,22 @@ object TestHelper {
             "Login for ${user.username} failed: ${response.statusCode} ${response.asString()}"
         }
         return LoginCookies(
-            login = response.cookie("login") ?: error("no login cookie in /auth response"),
+            auth = response.cookie(TestEnvironment.authCookieName)
+                ?: error("no ${TestEnvironment.authCookieName} cookie in /auth response"),
             csrf = response.cookie("XSRF-TOKEN"),
         )
     }
 
-    private fun activationTokenFromDb(username: String): String =
-        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
-            conn.prepareStatement(
-                """
-                SELECT t.token FROM activation_token t
-                JOIN user u ON u.id = t.user_id
-                WHERE u.username = ?
-                ORDER BY t.created_at DESC LIMIT 1
-                """.trimIndent(),
-            ).use { stmt ->
-                stmt.setString(1, username)
-                val rs = stmt.executeQuery()
-                require(rs.next()) { "No activation token found for $username" }
-                rs.getString("token")
-            }
+    private fun userIdOrThrow(conn: Connection, username: String): Long {
+        conn.prepareStatement(
+            "SELECT id FROM users WHERE username = ? AND $ACTIVE_ROW_PREDICATE",
+        ).use { stmt ->
+            stmt.setString(1, username)
+            val rs = stmt.executeQuery()
+            require(rs.next()) { "No active user with username=$username" }
+            return rs.getLong("id")
         }
+    }
 
     data class RegisteredUser(
         val username: String,
@@ -162,8 +273,15 @@ object TestHelper {
         val password: String,
     )
 
+    data class RegisteredUserRow(
+        val id: Long,
+        val username: String,
+        val email: String,
+        val enabled: Boolean,
+    )
+
     data class LoginCookies(
-        val login: String,
+        val auth: String,
         val csrf: String?,
     )
 }


### PR DESCRIPTION
## Why

The OIDC tests are the cleanest slice of the suite to lift off in-process Spring Boot — every assertion is over plain HTTP against `/oauth2/authorize`, the forward-auth chain, or the JWKS document, so the migration needs nothing beyond user creation and login. Keeping them on `@SpringBootTest` blocks the eventual strip of Spring deps from the `services/system-tests` build script.

## What this achieves

Four OIDC tests and their shared base class now run with no Spring annotations, no `@Autowired` beans, no api classpath dependency on entity types like `User` or `Role`. They issue real HTTP through the JDK `HttpClient` (or Playwright's `APIRequest`) against the api, mint users through `TestHelper`, and log them in via `POST /auth` — exactly the path a deployed instance answers. The frontend tests still extend the in-process base; their migration is independent.

## How

- **`OidcSystemTestBase`** — drops `@SpringBootTest`, `@TestExecutionListeners`, `@ActiveProfiles`, and the `@Autowired userFactory` / `@Autowired tokenGenerator` / `@Value authCookieName` fields. Picks up `apiUrl` and `authCookieName` from `TestEnvironment`, and `sessionTokenFor(user)` now mints the JWT by calling `TestHelper.login(user)` against `POST /auth` rather than reaching into the in-process `JwtTokenGenerator` bean.

- **`AuthorizeRedirectSystemTest`, `OidcTokenClaimsSystemTest`** — `userFactory.createUserWithRole(Role.X)` becomes `TestHelper.registerActivateAndPromote("X")`. The handful of sites that referenced `user.id!!` now fetch the row separately via `TestHelper.findUser(...)!!.id` — `RegisteredUser` deliberately doesn't carry `id` because the post-registration response doesn't return one.

- **`ForwardAuthChainSystemTest`** — the parametrized `Role` argument was suppressed-unused; switching it to `String` lets the test class shed its import on `net.blueshell.api.shared.enums.Role` and prevents the api enum from re-entering the test classpath.

- **`OidcAuthorizePlaywrightTest`** — extends `PlaywrightTestBase` instead of hand-rolling `Playwright.create()` and a `@SpringBootTest` context. The inherited `BrowserContext.request()` carries the authorize-redirect probe; the previous direct `tokenGenerator.generateToken(...)` call becomes `TestHelper.login(admin).auth`.

The Spring starters and the `services:api` project dependency stay in `services/system-tests/build.gradle.kts` because the frontend tests still extend the in-process base. Removing them follows once the frontend subtree migrates.