### PR TITLE
api: JwtAuthFilter falls back to BSH_AUTH cookie when bearer is unparseable

### DIFF
--- a/services/api/src/main/kotlin/net/blueshell/api/infrastructure/security/JwtAuthFilter.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/infrastructure/security/JwtAuthFilter.kt
@@ -29,16 +29,21 @@ class JwtAuthFilter(
         response: HttpServletResponse,
         filterChain: FilterChain
     ) {
-        val token = resolveToken(request) ?: run {
-            filterChain.doFilter(request, response)
-            return
-        }
+        // Try every candidate credential in order until one validates.
+        // The previous code short-circuited on `Authorization: Bearer ...`,
+        // which let an opaque third-party token (Stalwart webadmin's own
+        // OAuth, in particular) override a valid BSH_AUTH cookie and leave
+        // the request anonymous. Authorization still wins when both are
+        // valid — only an *invalid* Authorization yields to the cookie.
+        val validation = resolveTokenCandidates(request)
+            .asSequence()
+            .map { jwtTokenUtil.parseAndValidate(it) }
+            .firstOrNull { it.isValid }
+            ?: run {
+                filterChain.doFilter(request, response)
+                return
+            }
 
-        val validation = jwtTokenUtil.parseAndValidate(token)
-        if (!validation.isValid) {
-            filterChain.doFilter(request, response)
-            return
-        }
         if (jwtRevocationService.isRevoked(validation.jti)) {
             filterChain.doFilter(request, response)
             return
@@ -71,11 +76,12 @@ class JwtAuthFilter(
         filterChain.doFilter(request, response)
     }
 
-    private fun resolveToken(request: HttpServletRequest): String? {
-        val header = request.getHeader("Authorization")
-        if (!header.isNullOrBlank() && header.startsWith("Bearer ")) {
-            return header.substring(7).trim().takeIf { it.isNotBlank() }
+    private fun resolveTokenCandidates(request: HttpServletRequest): List<String> =
+        buildList {
+            request.getHeader("Authorization")
+                ?.takeIf { it.startsWith("Bearer ") }
+                ?.substring(7)?.trim()?.takeIf { it.isNotBlank() }
+                ?.let { add(it) }
+            authTokenCookieService.resolveToken(request)?.let { add(it) }
         }
-        return authTokenCookieService.resolveToken(request)
-    }
 }

--- a/services/api/src/test/kotlin/net/blueshell/api/infrastructure/security/JwtAuthFilterTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/infrastructure/security/JwtAuthFilterTest.kt
@@ -1,0 +1,203 @@
+package net.blueshell.api.infrastructure.security
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import net.blueshell.api.domain.user.application.UserService
+import net.blueshell.api.shared.enums.Role
+import net.blueshell.api.shared.security.UserPrincipal
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.context.SecurityContextRepository
+
+/**
+ * Pure unit tests for [JwtAuthFilter]'s credential resolution. The previous
+ * implementation short-circuited on Authorization: Bearer — an opaque
+ * third-party bearer (e.g. Stalwart webadmin's own OAuth token) sent
+ * alongside a valid BSH_AUTH cookie would leave the request anonymous.
+ * These tests pin the new contract: every available credential is tried
+ * in order and the first one that validates wins.
+ */
+class JwtAuthFilterTest {
+
+    private val jwtTokenUtil: JwtTokenUtil = mock()
+    private val jwtRevocationService: JwtRevocationService = mock()
+    private val userService: UserService = mock()
+    private val authTokenCookieService: AuthTokenCookieService = mock()
+    private val securityContextRepository: SecurityContextRepository = mock()
+
+    private lateinit var filter: JwtAuthFilter
+
+    @BeforeEach
+    fun setUp() {
+        SecurityContextHolder.clearContext()
+        filter = JwtAuthFilter(
+            jwtTokenUtil,
+            jwtRevocationService,
+            userService,
+            authTokenCookieService,
+            securityContextRepository,
+        )
+    }
+
+    @Test
+    fun `cookie only and valid - principal set from cookie`() {
+        val request: HttpServletRequest = mock()
+        val response: HttpServletResponse = mock()
+        val chain: FilterChain = mock()
+        whenever(request.getHeader("Authorization")).thenReturn(null)
+        whenever(authTokenCookieService.resolveToken(eq(request))).thenReturn(COOKIE_TOKEN)
+        whenever(jwtTokenUtil.parseAndValidate(eq(COOKIE_TOKEN))).thenReturn(valid("user-cookie"))
+        whenever(jwtRevocationService.isRevoked(eq("jti-c"))).thenReturn(false)
+        whenever(userService.loadUserPrincipalByUsername(eq("user-cookie"))).thenReturn(principal("user-cookie"))
+
+        filter.doFilter(request, response, chain)
+
+        assertThat(SecurityContextHolder.getContext().authentication?.name).isEqualTo("user-cookie")
+        verify(chain).doFilter(eq(request), eq(response))
+    }
+
+    @Test
+    fun `authorization only and valid - principal set from header`() {
+        val request: HttpServletRequest = mock()
+        val response: HttpServletResponse = mock()
+        val chain: FilterChain = mock()
+        whenever(request.getHeader("Authorization")).thenReturn("Bearer $HEADER_TOKEN")
+        whenever(authTokenCookieService.resolveToken(eq(request))).thenReturn(null)
+        whenever(jwtTokenUtil.parseAndValidate(eq(HEADER_TOKEN))).thenReturn(valid("user-bearer"))
+        whenever(jwtRevocationService.isRevoked(eq("jti-c"))).thenReturn(false)
+        whenever(userService.loadUserPrincipalByUsername(eq("user-bearer"))).thenReturn(principal("user-bearer"))
+
+        filter.doFilter(request, response, chain)
+
+        assertThat(SecurityContextHolder.getContext().authentication?.name).isEqualTo("user-bearer")
+    }
+
+    @Test
+    fun `invalid bearer plus valid cookie - falls back to cookie (the Stalwart case)`() {
+        val request: HttpServletRequest = mock()
+        val response: HttpServletResponse = mock()
+        val chain: FilterChain = mock()
+        whenever(request.getHeader("Authorization")).thenReturn("Bearer $OPAQUE_THIRD_PARTY")
+        whenever(authTokenCookieService.resolveToken(eq(request))).thenReturn(COOKIE_TOKEN)
+        whenever(jwtTokenUtil.parseAndValidate(eq(OPAQUE_THIRD_PARTY))).thenReturn(
+            invalid()
+        )
+        whenever(jwtTokenUtil.parseAndValidate(eq(COOKIE_TOKEN))).thenReturn(valid("user-cookie"))
+        whenever(jwtRevocationService.isRevoked(eq("jti-c"))).thenReturn(false)
+        whenever(userService.loadUserPrincipalByUsername(eq("user-cookie"))).thenReturn(principal("user-cookie"))
+
+        filter.doFilter(request, response, chain)
+
+        assertThat(SecurityContextHolder.getContext().authentication?.name)
+            .withFailMessage("Cookie must win when the Authorization header is unparseable")
+            .isEqualTo("user-cookie")
+        // Both candidates should have been tried.
+        verify(jwtTokenUtil).parseAndValidate(eq(OPAQUE_THIRD_PARTY))
+        verify(jwtTokenUtil).parseAndValidate(eq(COOKIE_TOKEN))
+    }
+
+    @Test
+    fun `both invalid - request stays anonymous`() {
+        val request: HttpServletRequest = mock()
+        val response: HttpServletResponse = mock()
+        val chain: FilterChain = mock()
+        whenever(request.getHeader("Authorization")).thenReturn("Bearer $OPAQUE_THIRD_PARTY")
+        whenever(authTokenCookieService.resolveToken(eq(request))).thenReturn(COOKIE_TOKEN)
+        whenever(jwtTokenUtil.parseAndValidate(any())).thenReturn(invalid())
+
+        filter.doFilter(request, response, chain)
+
+        assertThat(SecurityContextHolder.getContext().authentication).isNull()
+        verify(chain).doFilter(eq(request), eq(response))
+        verify(userService, never()).loadUserPrincipalByUsername(anyOrNull())
+    }
+
+    @Test
+    fun `both valid - authorization wins over cookie`() {
+        val request: HttpServletRequest = mock()
+        val response: HttpServletResponse = mock()
+        val chain: FilterChain = mock()
+        whenever(request.getHeader("Authorization")).thenReturn("Bearer $HEADER_TOKEN")
+        whenever(authTokenCookieService.resolveToken(eq(request))).thenReturn(COOKIE_TOKEN)
+        whenever(jwtTokenUtil.parseAndValidate(eq(HEADER_TOKEN))).thenReturn(valid("user-bearer"))
+        whenever(jwtTokenUtil.parseAndValidate(eq(COOKIE_TOKEN))).thenReturn(valid("user-cookie"))
+        whenever(jwtRevocationService.isRevoked(eq("jti-c"))).thenReturn(false)
+        whenever(userService.loadUserPrincipalByUsername(eq("user-bearer"))).thenReturn(principal("user-bearer"))
+
+        filter.doFilter(request, response, chain)
+
+        assertThat(SecurityContextHolder.getContext().authentication?.name).isEqualTo("user-bearer")
+        // Cookie shouldn't even have been parsed — the bearer validated first.
+        verify(jwtTokenUtil, never()).parseAndValidate(eq(COOKIE_TOKEN))
+    }
+
+    @Test
+    fun `valid token but revoked - request stays anonymous`() {
+        val request: HttpServletRequest = mock()
+        val response: HttpServletResponse = mock()
+        val chain: FilterChain = mock()
+        whenever(request.getHeader("Authorization")).thenReturn(null)
+        whenever(authTokenCookieService.resolveToken(eq(request))).thenReturn(COOKIE_TOKEN)
+        whenever(jwtTokenUtil.parseAndValidate(eq(COOKIE_TOKEN))).thenReturn(valid("user-cookie"))
+        whenever(jwtRevocationService.isRevoked(eq("jti-c"))).thenReturn(true)
+
+        filter.doFilter(request, response, chain)
+
+        assertThat(SecurityContextHolder.getContext().authentication).isNull()
+        verify(userService, never()).loadUserPrincipalByUsername(anyOrNull())
+    }
+
+    @Test
+    fun `valid token saves SecurityContext via the repository`() {
+        val request: HttpServletRequest = mock()
+        val response: HttpServletResponse = mock()
+        val chain: FilterChain = mock()
+        whenever(request.getHeader("Authorization")).thenReturn(null)
+        whenever(authTokenCookieService.resolveToken(eq(request))).thenReturn(COOKIE_TOKEN)
+        whenever(jwtTokenUtil.parseAndValidate(eq(COOKIE_TOKEN))).thenReturn(valid("user-cookie"))
+        whenever(jwtRevocationService.isRevoked(eq("jti-c"))).thenReturn(false)
+        whenever(userService.loadUserPrincipalByUsername(eq("user-cookie"))).thenReturn(principal("user-cookie"))
+
+        filter.doFilter(request, response, chain)
+
+        val captor = argumentCaptor<SecurityContext>()
+        verify(securityContextRepository).saveContext(captor.capture(), eq(request), eq(response))
+        assertThat(captor.firstValue.authentication).isInstanceOf(UsernamePasswordAuthenticationToken::class.java)
+        assertThat(captor.firstValue.authentication?.name).isEqualTo("user-cookie")
+    }
+
+    private fun valid(username: String) =
+        JwtTokenUtil.JwtValidationResult(username = username, jti = "jti-c", expired = false, error = null)
+
+    private fun invalid() =
+        JwtTokenUtil.JwtValidationResult(username = null, jti = null, expired = false, error = RuntimeException("bad token"))
+
+    private fun principal(username: String): UserPrincipal = UserPrincipal(
+        id = 1L,
+        usernameValue = username,
+        passwordValue = "",
+        enabledValue = true,
+        roles = setOf(Role.MEMBER),
+        addressId = null,
+        personDetailsId = null,
+    )
+
+    companion object {
+        private const val COOKIE_TOKEN = "cookie.jwt.value"
+        private const val HEADER_TOKEN = "header.jwt.value"
+        private const val OPAQUE_THIRD_PARTY = "QpT8jgss9DY3YS2YsIZrc4mLpgvEETjMEMDn+zR4gS+oUxl5"
+    }
+}

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/ForwardAuthChainSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/ForwardAuthChainSystemTest.kt
@@ -169,6 +169,36 @@ class ForwardAuthChainSystemTest : OidcSystemTestBase() {
         assertThat(response.statusCode()).isEqualTo(403)
     }
 
+    @ParameterizedTest(name = "junk Authorization + valid cookie → 200 (Stalwart pattern, host={0})")
+    @MethodSource("boardGatedHosts")
+    fun junk_bearer_plus_cookie_still_authenticates(host: String, @Suppress("UNUSED_PARAMETER") required: Role) {
+        // The Stalwart webadmin SPA sends its own opaque OAuth bearer in
+        // `Authorization` alongside our BSH_AUTH cookie. JwtAuthFilter used to
+        // short-circuit on the bearer and never read the cookie, leaving the
+        // request anonymous → forward-auth 401 → SPA bounced back to /login.
+        val board = userFactory.createUserWithRole(Role.BOARD)
+        val opaqueThirdPartyBearer = "QpT8jgss9DY3YS2YsIZrc4mLpgvEETjMEMDn+zR4gS+oUxl5"
+
+        val response = java.net.http.HttpClient.newHttpClient().send(
+            java.net.http.HttpRequest.newBuilder()
+                .uri(java.net.URI.create("$baseUrl/oauth2/forward-auth"))
+                .GET()
+                .header("Accept", "application/json")
+                .header("Authorization", "Bearer $opaqueThirdPartyBearer")
+                .header("Cookie", "$authCookieName=${sessionTokenFor(board.username)}")
+                .header("X-Forwarded-Host", host)
+                .build(),
+            java.net.http.HttpResponse.BodyHandlers.discarding(),
+        )
+
+        assertThat(response.statusCode())
+            .withFailMessage(
+                "Expected forward-auth to fall back to the BSH_AUTH cookie when " +
+                    "Authorization carries a non-Spring bearer; got ${response.statusCode()}",
+            ).isEqualTo(200)
+        assertThat(response.headers().firstValue("X-User-Groups").orElse("")).contains("BOARD")
+    }
+
     @Test
     fun `unknown host falls back to ADMIN-required and rejects board`() {
         val board = userFactory.createUserWithRole(Role.BOARD)


### PR DESCRIPTION
## Summary

Signing in to Stalwart webadmin (`stalwart.esa-blueshell.nl`) succeeds at Stalwart's own auth step (`/auth/token`, `/api/oauth` both 200), then the SPA fires `GET /api/principal?…` and gets **401** from `/oauth2/forward-auth` with `WWW-Authenticate: Bearer realm="https://v2.esa-blueshell.nl/login"` — the response shape added in #193. The SPA bounces back to its own /login and the user can never reach the admin pages.

## Root cause

The failing request carries both:

- `Cookie: BSH_AUTH=eyJ…` — a valid HS512 session JWT (sub=`ExtraToast`, still ~9 h to exp).
- `Authorization: Bearer QpT8jgss…` — Stalwart's own opaque OAuth token, unrelated to our auth.

The other requests in the same flow (`/auth/token`, `/api/oauth`) succeed because they don't carry an `Authorization` header.

`JwtAuthFilter.resolveToken()` short-circuited on `Authorization: Bearer …`:

```kotlin
private fun resolveToken(request: HttpServletRequest): String? {
    val header = request.getHeader("Authorization")
    if (!header.isNullOrBlank() && header.startsWith("Bearer ")) {
        return header.substring(7).trim().takeIf { it.isNotBlank() }
    }
    return authTokenCookieService.resolveToken(request)
}
```

When *any* Bearer was present, the cookie was never read. `parseAndValidate` saw Stalwart's opaque token, returned `isValid=false`, and the filter fell through without setting an authentication — request stays anonymous, forward-auth 401s.

Filter-chain check confirms `/oauth2/forward-auth` runs on `authChain` (`@Order(3)`, `securityMatcher("/**")`), not on the SAS chain. No `BearerTokenAuthenticationFilter` / `oauth2ResourceServer` is configured (only `.oidc(Customizer.withDefaults())` for OIDC discovery), so `JwtAuthFilter` is the only filter looking at credentials here. The bug is entirely its.

## Fix

Treat `Authorization: Bearer …` and `BSH_AUTH` cookie as fallback candidates rather than mutually exclusive. The filter tries each via a lazy sequence and uses the first one that validates. Authorization still wins when both validate, so the existing "explicit Bearer" semantics (e.g. our own JWT in tests via `UserTestSupport.bearer(user)`) are preserved.

```kotlin
val validation = resolveTokenCandidates(request)
    .asSequence()
    .map { jwtTokenUtil.parseAndValidate(it) }
    .firstOrNull { it.isValid }
    ?: run { filterChain.doFilter(request, response); return }
```

## Tests

- **Unit** — new `JwtAuthFilterTest` (7 cases): cookie-only valid, bearer-only valid, **invalid bearer + valid cookie (the Stalwart case)**, both invalid → anonymous, both valid → bearer wins, revocation, SecurityContext saved via the repository.
- **System** — new parameterised case on every board-gated host in `ForwardAuthChainSystemTest`: real HTTP `GET /oauth2/forward-auth` with both an opaque `Authorization: Bearer …` and a valid `BSH_AUTH` cookie → asserts **200 + X-User-Groups: BOARD**.
- `ForwardAuthControllerIT` is unchanged (`.with(bearer(member))` still passes; the Authorization carries our own JWT which validates first — no fallback needed).

## Verified locally

```
$ ./gradlew :services:api:test --tests JwtAuthFilterTest
Test result: SUCCESS (7 tests, 7 passed, 0 failed, 0 skipped)
```

## Test plan
- [x] Unit tests cover the candidate fallback contract
- [x] System test covers the Stalwart-style real-HTTP flow
- [ ] CI green
- [ ] After deploy: open Stalwart webadmin while signed in — `GET /api/principal` returns 200 with data, no bounce back to /login