### PR TITLE
system-tests: migrate AddressPageSystemTest off Spring; clean up post-merge regression

### DIFF
--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/ActivationPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/ActivationPageSystemTest.kt
@@ -45,9 +45,12 @@ class ActivationPageSystemTest : FrontendSystemTestBase() {
                 LoginDomainHelper.clickActivateMemberSubmit(page)
             }
             assertThat(response.status()).isEqualTo(200)
-            assertThat(
-                page.locator("[data-testid='activate-member-success-alert']").count()
-            ).isGreaterThan(0)
+            // The success alert mounts in Vue's `.then` block, which
+            // runs after `waitForResponse` returns. Poll with
+            // `.first().waitFor()` rather than asserting `.count()`
+            // straight away, otherwise a fast network + slow render
+            // intermittently lands on `count == 0`.
+            page.locator("[data-testid='activate-member-success-alert']").first().waitFor()
         }
 
         waitFor(
@@ -105,9 +108,10 @@ class ActivationPageSystemTest : FrontendSystemTestBase() {
             }
             assertThat(response.status()).isEqualTo(200)
             assertThat(response.text()).contains("/membership/signUp?step=2")
-            assertThat(
-                page.locator("[data-testid='activate-user-success-state']").count()
-            ).isGreaterThan(0)
+            // Same render race as the member-activation success path —
+            // wait for the success-state locator rather than asserting
+            // `.count()` straight after `waitForResponse` returns.
+            page.locator("[data-testid='activate-user-success-state']").first().waitFor()
         }
 
         waitFor(

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AddressPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AddressPageSystemTest.kt
@@ -1,124 +1,124 @@
 package net.blueshell.api.system.frontend.login
 
-import com.microsoft.playwright.Page
-import net.blueshell.api.factory.user.persistence.UserFactory
-import net.blueshell.api.shared.enums.Role
-import net.blueshell.api.system.frontend.FrontendSystemTestBase
+import net.blueshell.api.ApiApplication
+import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AddressFormHelper
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.LoginDomainHelper
+import net.blueshell.systemtests.PlaywrightTestBase
+import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestExecutionListeners
 
 @Tag("system")
-class AddressPageSystemTest : FrontendSystemTestBase() {
-
-    @Autowired
-    private lateinit var userFactory: UserFactory
+@ActiveProfiles("test")
+@TestExecutionListeners(
+    listeners = [TestCleanUpListener::class],
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+)
+@SpringBootTest(
+    classes = [ApiApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
+)
+class AddressPageSystemTest : PlaywrightTestBase() {
 
     @Test
     fun `creates address from account address page`() {
-        val user = userFactory.createUserWithRole(Role.GUEST, enabled = true)
+        val user = TestHelper.registerActivateAndPromote("GUEST")
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, user.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, user.username, user.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            page.navigate("$frontendUrl/account/addresses")
-            page.waitForURL("**/account/addresses**")
+        page.navigate("$frontendUrl/account/addresses")
+        page.waitForURL("**/account/addresses**")
 
-            AddressFormHelper.fill(
-                page = page,
-                fields = AddressFormHelper.Fields(
-                    street = "Oude Markt",
-                    houseNumber = "12",
-                    zipCode = "7511GA",
-                    city = "Enschede"
-                )
-            )
-
-            val response = page.waitForResponse("**/addresses") {
-                LoginDomainHelper.clickAddressSubmit(page)
-            }
-            assertThat(response.status()).isEqualTo(201)
-        }
-
-        val persisted = waitForOptional(
-            producer = { userRepository.findByUsername(user.username) },
-            onTimeoutMessage = { "Expected user ${user.username} to exist after creating address" }
+        AddressFormHelper.fill(
+            page = page,
+            fields = AddressFormHelper.Fields(
+                street = "Oude Markt",
+                houseNumber = "12",
+                zipCode = "7511GA",
+                city = "Enschede",
+            ),
         )
 
-        assertThat(persisted.address).isNotNull
-        assertThat(persisted.address?.street).isEqualTo("Oude Markt")
-        assertThat(persisted.address?.houseNumber).isEqualTo("12")
-        assertThat(persisted.address?.zipCode).isEqualTo("7511GA")
-        assertThat(persisted.address?.city).isEqualTo("Enschede")
-        assertThat(persisted.address?.country).isEqualTo("NL")
+        val response = page.waitForResponse("**/addresses") {
+            LoginDomainHelper.clickAddressSubmit(page)
+        }
+        assertThat(response.status()).isEqualTo(201)
+
+        val persisted = pollForAddress(user.username)
+        assertThat(persisted.street).isEqualTo("Oude Markt")
+        assertThat(persisted.houseNumber).isEqualTo("12")
+        assertThat(persisted.zipCode).isEqualTo("7511GA")
+        assertThat(persisted.city).isEqualTo("Enschede")
+        assertThat(persisted.country).isEqualTo("NL")
     }
 
     @Test
     fun `updates address from account address page`() {
-        val user = userFactory.createUserWithRole(Role.GUEST, enabled = true)
-        user.replaceAddress(
-            userFactory.buildAddress(
-                user = user,
-                country = "NL",
-                city = "Oldenzaal",
-                street = "Stationsstraat",
-                houseNumber = "1",
-                zipCode = "7571CE"
-            )
+        val user = TestHelper.registerActivateAndPromote("GUEST")
+        val addressId = TestHelper.attachAddress(
+            username = user.username,
+            country = "NL",
+            city = "Oldenzaal",
+            street = "Stationsstraat",
+            houseNumber = "1",
+            zipCode = "7571CE",
         )
-        userRepository.saveAndFlush(user)
 
-        val withAddress = waitForOptional(
-            producer = { userRepository.findByUsername(user.username) },
-            onTimeoutMessage = { "Expected user ${user.username} with address before update test" }
-        )
-        val addressId = checkNotNull(withAddress.addressId) { "Expected persisted address id for ${user.username}" }
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, user.username, user.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, user.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
-
-            val loadResponse = page.waitForResponse("**/addresses/$addressId") {
-                page.navigate("$frontendUrl/account/addresses/$addressId")
-            }
-            assertThat(loadResponse.status()).isEqualTo(200)
-            page.waitForURL("**/account/addresses/**")
-
-            AddressFormHelper.fill(
-                page = page,
-                fields = AddressFormHelper.Fields(
-                    street = "Boddenkampsingel",
-                    houseNumber = "80",
-                    zipCode = "7514AR",
-                    city = "Enschede"
-                )
-            )
-
-            val updateResponse = page.waitForResponse("**/addresses/$addressId") {
-                LoginDomainHelper.clickAddressSubmit(page)
-            }
-            assertThat(updateResponse.status()).isEqualTo(200)
+        val loadResponse = page.waitForResponse("**/addresses/$addressId") {
+            page.navigate("$frontendUrl/account/addresses/$addressId")
         }
+        assertThat(loadResponse.status()).isEqualTo(200)
+        page.waitForURL("**/account/addresses/**")
 
-        val updated = waitForOptional(
-            producer = { userRepository.findByUsername(user.username) },
-            onTimeoutMessage = { "Expected user ${user.username} after updating address" }
+        AddressFormHelper.fill(
+            page = page,
+            fields = AddressFormHelper.Fields(
+                street = "Boddenkampsingel",
+                houseNumber = "80",
+                zipCode = "7514AR",
+                city = "Enschede",
+            ),
         )
 
-        assertThat(updated.address).isNotNull
-        assertThat(updated.address?.street).isEqualTo("Boddenkampsingel")
-        assertThat(updated.address?.houseNumber).isEqualTo("80")
-        assertThat(updated.address?.zipCode).isEqualTo("7514AR")
-        assertThat(updated.address?.city).isEqualTo("Enschede")
-        assertThat(updated.address?.country).isEqualTo("NL")
+        val updateResponse = page.waitForResponse("**/addresses/$addressId") {
+            LoginDomainHelper.clickAddressSubmit(page)
+        }
+        assertThat(updateResponse.status()).isEqualTo(200)
+
+        val updated = pollForAddress(user.username) { it.street == "Boddenkampsingel" }
+        assertThat(updated.street).isEqualTo("Boddenkampsingel")
+        assertThat(updated.houseNumber).isEqualTo("80")
+        assertThat(updated.zipCode).isEqualTo("7514AR")
+        assertThat(updated.city).isEqualTo("Enschede")
+        assertThat(updated.country).isEqualTo("NL")
     }
 
-    private companion object {
-        const val DEFAULT_PASSWORD = "Password123!"
+    /**
+     * Polls until an address row appears for the user (or, optionally,
+     * until the row satisfies a predicate — used by the update test to
+     * wait for the new street value to land).
+     */
+    private fun pollForAddress(
+        username: String,
+        predicate: (TestHelper.AddressRow) -> Boolean = { true },
+    ): TestHelper.AddressRow {
+        val deadline = System.currentTimeMillis() + 6_000
+        while (System.currentTimeMillis() < deadline) {
+            val row = TestHelper.findAddress(username)
+            if (row != null && predicate(row)) return row
+            Thread.sleep(200)
+        }
+        throw AssertionError("No address row matching predicate for $username within 6s")
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AddressPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AddressPageSystemTest.kt
@@ -64,7 +64,7 @@ class AddressPageSystemTest : PlaywrightTestBase() {
     fun `updates address from account address page`() {
         val user = TestHelper.registerActivateAndPromote("GUEST")
         val addressId = TestHelper.attachAddress(
-            username = user.username,
+            user = user,
             country = "NL",
             city = "Oldenzaal",
             street = "Stationsstraat",

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/ForwardAuthChainSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/ForwardAuthChainSystemTest.kt
@@ -168,12 +168,12 @@ class ForwardAuthChainSystemTest : OidcSystemTestBase() {
 
     @ParameterizedTest(name = "junk Authorization + valid cookie → 200 (Stalwart pattern, host={0})")
     @MethodSource("boardGatedHosts")
-    fun junk_bearer_plus_cookie_still_authenticates(host: String, @Suppress("UNUSED_PARAMETER") required: Role) {
+    fun junk_bearer_plus_cookie_still_authenticates(host: String) {
         // The Stalwart webadmin SPA sends its own opaque OAuth bearer in
         // `Authorization` alongside our BSH_AUTH cookie. JwtAuthFilter used to
         // short-circuit on the bearer and never read the cookie, leaving the
         // request anonymous → forward-auth 401 → SPA bounced back to /login.
-        val board = userFactory.createUserWithRole(Role.BOARD)
+        val board = TestHelper.registerActivateAndPromote("BOARD")
         val opaqueThirdPartyBearer = "QpT8jgss9DY3YS2YsIZrc4mLpgvEETjMEMDn+zR4gS+oUxl5"
 
         val response = java.net.http.HttpClient.newHttpClient().send(
@@ -182,7 +182,7 @@ class ForwardAuthChainSystemTest : OidcSystemTestBase() {
                 .GET()
                 .header("Accept", "application/json")
                 .header("Authorization", "Bearer $opaqueThirdPartyBearer")
-                .header("Cookie", "$authCookieName=${sessionTokenFor(board.username)}")
+                .header("Cookie", "$authCookieName=${sessionTokenFor(board)}")
                 .header("X-Forwarded-Host", host)
                 .build(),
             java.net.http.HttpResponse.BodyHandlers.discarding(),

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -270,51 +270,38 @@ object TestHelper {
      * test edits through the UI. Returns the new address id.
      */
     fun attachAddress(
-        username: String,
+        user: RegisteredUser,
         country: String = "NL",
         city: String,
         street: String,
         houseNumber: String,
         zipCode: String,
     ): Long {
-        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
-            conn.autoCommit = false
-            try {
-                val userId = userIdOrThrow(conn, username)
-                val addressId = conn.prepareStatement(
-                    "INSERT INTO addresses (country, city, street, house_number, zip_code, " +
-                        "created_at, last_updated_at, deleted_at, version) " +
-                        "VALUES (?, ?, ?, ?, ?, NOW(), NOW(), '9999-12-31 23:59:59', 0)",
-                    java.sql.Statement.RETURN_GENERATED_KEYS,
-                ).use { stmt ->
-                    stmt.setString(1, country)
-                    stmt.setString(2, city)
-                    stmt.setString(3, street)
-                    stmt.setString(4, houseNumber)
-                    stmt.setString(5, zipCode)
-                    stmt.executeUpdate()
-                    val keys = stmt.generatedKeys
-                    require(keys.next()) { "INSERT addresses produced no id" }
-                    keys.getLong(1)
-                }
-                conn.prepareStatement(
-                    "UPDATE users SET address_id = ? WHERE id = ? AND $ACTIVE_ROW_PREDICATE",
-                ).use { stmt ->
-                    stmt.setLong(1, addressId)
-                    stmt.setLong(2, userId)
-                    require(stmt.executeUpdate() == 1) {
-                        "Failed to link address $addressId to user $username"
+        val cookies = login(user)
+        val userId = findUser(user.username)!!.id
+        val response = retryOnConnectionFailure {
+            givenCsrfApi()
+                .baseUri(apiBaseUrl)
+                .cookie(TestEnvironment.authCookieName, cookies.auth)
+                .contentType(ContentType.JSON)
+                .body(
+                    """
+                    {
+                      "userId": $userId,
+                      "country": "$country",
+                      "city": "$city",
+                      "street": "$street",
+                      "houseNumber": "$houseNumber",
+                      "zipCode": "$zipCode"
                     }
-                }
-                conn.commit()
-                return addressId
-            } catch (e: Exception) {
-                conn.rollback()
-                throw e
-            } finally {
-                conn.autoCommit = true
-            }
+                    """.trimIndent(),
+                ).`when`()
+                .post("/addresses")
         }
+        require(response.statusCode == 201) {
+            "POST /addresses returned ${response.statusCode}: ${response.asString()}"
+        }
+        return response.jsonPath().getLong("id")
     }
 
     /**

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -234,6 +234,90 @@ object TestHelper {
     }
 
     /**
+     * Read the address row currently linked to `username`, if any. Used
+     * by tests that previously inspected `User.address?.field` after a
+     * Playwright-driven form submit.
+     */
+    fun findAddress(username: String): AddressRow? =
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            conn.prepareStatement(
+                "SELECT a.id, a.country, a.city, a.street, a.house_number, a.zip_code " +
+                    "FROM addresses a " +
+                    "JOIN users u ON u.address_id = a.id " +
+                    "WHERE u.username = ? AND u.$ACTIVE_ROW_PREDICATE " +
+                    "AND a.$ACTIVE_ROW_PREDICATE",
+            ).use { stmt ->
+                stmt.setString(1, username)
+                val rs = stmt.executeQuery()
+                if (rs.next()) {
+                    AddressRow(
+                        id = rs.getLong("id"),
+                        country = rs.getString("country"),
+                        city = rs.getString("city"),
+                        street = rs.getString("street"),
+                        houseNumber = rs.getString("house_number"),
+                        zipCode = rs.getString("zip_code"),
+                    )
+                } else {
+                    null
+                }
+            }
+        }
+
+    /**
+     * Insert an `addresses` row for `username` and point the user's
+     * `address_id` column at it. Pre-seeds the address that a follow-up
+     * test edits through the UI. Returns the new address id.
+     */
+    fun attachAddress(
+        username: String,
+        country: String = "NL",
+        city: String,
+        street: String,
+        houseNumber: String,
+        zipCode: String,
+    ): Long {
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            conn.autoCommit = false
+            try {
+                val userId = userIdOrThrow(conn, username)
+                val addressId = conn.prepareStatement(
+                    "INSERT INTO addresses (country, city, street, house_number, zip_code, " +
+                        "created_at, last_updated_at, deleted_at, version) " +
+                        "VALUES (?, ?, ?, ?, ?, NOW(), NOW(), '9999-12-31 23:59:59', 0)",
+                    java.sql.Statement.RETURN_GENERATED_KEYS,
+                ).use { stmt ->
+                    stmt.setString(1, country)
+                    stmt.setString(2, city)
+                    stmt.setString(3, street)
+                    stmt.setString(4, houseNumber)
+                    stmt.setString(5, zipCode)
+                    stmt.executeUpdate()
+                    val keys = stmt.generatedKeys
+                    require(keys.next()) { "INSERT addresses produced no id" }
+                    keys.getLong(1)
+                }
+                conn.prepareStatement(
+                    "UPDATE users SET address_id = ? WHERE id = ? AND $ACTIVE_ROW_PREDICATE",
+                ).use { stmt ->
+                    stmt.setLong(1, addressId)
+                    stmt.setLong(2, userId)
+                    require(stmt.executeUpdate() == 1) {
+                        "Failed to link address $addressId to user $username"
+                    }
+                }
+                conn.commit()
+                return addressId
+            } catch (e: Exception) {
+                conn.rollback()
+                throw e
+            } finally {
+                conn.autoCommit = true
+            }
+        }
+    }
+
+    /**
      * Read a user back from the DB. Returns null when the user doesn't
      * exist (or is soft-deleted). Used by tests that previously polled
      * `userRepository.findByUsername(...)` to verify async writes.
@@ -306,6 +390,15 @@ object TestHelper {
         val username: String,
         val email: String,
         val enabled: Boolean,
+    )
+
+    data class AddressRow(
+        val id: Long,
+        val country: String?,
+        val city: String?,
+        val street: String?,
+        val houseNumber: String?,
+        val zipCode: String?,
     )
 
     data class LoginCookies(


### PR DESCRIPTION
## Why

`AddressPageSystemTest` was still extending the in-process Spring base, holding back the rest of the suite migration. Every test that still injects `UserFactory` and `UserRepository` keeps the api's entity classpath bolted to the system-tests project, which blocks the eventual strip of those dependencies from the build script.

A second issue surfaced from the recent merge of the JwtAuthFilter cookie-fallback work alongside the OIDC subtree migration: `ForwardAuthChainSystemTest.junk_bearer_plus_cookie_still_authenticates` was added back into the file still referencing `Role.BOARD` and `userFactory`, which the rest of the class had already shed. The branch did not compile until that method matched the new pattern.

## What this achieves

`AddressPageSystemTest` runs entirely through HTTP and JDBC via `TestHelper`. Spring still hosts the api in-process from the standard four-annotation bootstrap, and the test body never injects a bean. `ForwardAuthChainSystemTest` compiles again, with its newer test method using the same `TestHelper`-driven shape as its siblings.

## How

- **`TestHelper.attachAddress(user, country, city, street, houseNumber, zipCode): Long`** — logs the user in via `TestHelper.login(...)`, looks up their id via `findUser`, and `POST`s to `/addresses` with the CSRF round-trip the other state-changing calls already use. Returns the new address id, parsed out of the response body, so callers can navigate to `/account/addresses/<id>`. An earlier draft tried to bypass the controller with a JDBC `INSERT INTO addresses`, which guessed at the audit column names (`last_updated_at` is not a column; the entity carries `updated_at` plus `created_by_id` / `updated_by_id` foreign keys this code was not filling). Routing through the controller eliminates the schema guess.

- **`TestHelper.findAddress(username): AddressRow?`** — JOIN `addresses` on `users.address_id`, soft-delete predicate on both sides, returns a small read-only `AddressRow(id, country, city, street, houseNumber, zipCode)`. Used by the post-condition assertions that previously poked at `user.address?.field`.

- **`AddressPageSystemTest`** — extends `PlaywrightTestBase`, drops `@Autowired UserFactory` / `userRepository`, uses `TestHelper.registerActivateAndPromote("GUEST")` for both tests. The update test pre-seeds the address through `attachAddress(...)` and navigates by the returned id. A short `pollForAddress(username, predicate)` helper bridges the gap between the Playwright form response and the eventual JDBC row write.

- **`ForwardAuthChainSystemTest.junk_bearer_plus_cookie_still_authenticates`** — same swap as the surrounding parametrized methods: `userFactory.createUserWithRole(Role.BOARD)` becomes `TestHelper.registerActivateAndPromote("BOARD")`, `sessionTokenFor(b.username)` becomes `sessionTokenFor(b)`, and the unused-suppressed `required: Role` parameter drops with the rest.