### PR TITLE
system-tests: migrate AccountPageSystemTest off Spring

### DIFF
--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AccountPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AccountPageSystemTest.kt
@@ -31,6 +31,7 @@ class AccountPageSystemTest : PlaywrightTestBase() {
     fun `member can update editable account fields`() {
         val member = TestHelper.registerActivateAndPromote("MEMBER")
         TestHelper.attachMemberProfile(member)
+        TestHelper.attachMembership(member.username)
 
         val suffix = System.currentTimeMillis().toString().takeLast(8)
         val updatedDiscord = "account$suffix"

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AccountPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AccountPageSystemTest.kt
@@ -42,6 +42,11 @@ class AccountPageSystemTest : PlaywrightTestBase() {
 
         page.navigate("$frontendUrl/account")
         page.waitForURL("**/account")
+        // The form wrapper mounts after the page's `/users/{id}` fetch
+        // resolves; without waiting for it explicitly, `fill` can race
+        // the still-loading VeeValidate setup that briefly leaves the
+        // inputs non-editable.
+        page.locator("[data-testid='account-user-form']").first().waitFor()
 
         page.getByLabel("Discord*", Page.GetByLabelOptions().setExact(true)).fill(updatedDiscord)
         page.getByLabel("Phone Number*", Page.GetByLabelOptions().setExact(true)).fill(updatedPhone)

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AccountPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AccountPageSystemTest.kt
@@ -1,61 +1,70 @@
 package net.blueshell.api.system.frontend.login
 
 import com.microsoft.playwright.Page
-import net.blueshell.api.factory.user.persistence.UserFactory
-import net.blueshell.api.shared.enums.Role
-import net.blueshell.api.system.frontend.FrontendSystemTestBase
+import net.blueshell.api.ApiApplication
+import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.LoginDomainHelper
+import net.blueshell.systemtests.PlaywrightTestBase
+import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestExecutionListeners
 
 @Tag("system")
-class AccountPageSystemTest : FrontendSystemTestBase() {
-
-    @Autowired
-    private lateinit var userFactory: UserFactory
+@ActiveProfiles("test")
+@TestExecutionListeners(
+    listeners = [TestCleanUpListener::class],
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+)
+@SpringBootTest(
+    classes = [ApiApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
+)
+class AccountPageSystemTest : PlaywrightTestBase() {
 
     @Test
     fun `member can update editable account fields`() {
-        val member = userFactory.createUserWithRole(Role.MEMBER, enabled = true)
-        member.replaceMemberProfile(userFactory.buildMemberProfile(member))
-        userRepository.saveAndFlush(member)
-        userFactory.createMembership(member)
+        val member = TestHelper.registerActivateAndPromote("MEMBER")
+        TestHelper.attachMemberProfile(member)
 
         val suffix = System.currentTimeMillis().toString().takeLast(8)
         val updatedDiscord = "account$suffix"
         val updatedPhone = "+3161${suffix.takeLast(7)}"
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, member.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, member.username, member.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            page.navigate("$frontendUrl/account")
-            page.waitForURL("**/account")
+        page.navigate("$frontendUrl/account")
+        page.waitForURL("**/account")
 
-            page.getByLabel("Discord*", Page.GetByLabelOptions().setExact(true)).fill(updatedDiscord)
-            page.getByLabel("Phone Number*", Page.GetByLabelOptions().setExact(true)).fill(updatedPhone)
-            LoginDomainHelper.clickAccountSubmit(page)
+        page.getByLabel("Discord*", Page.GetByLabelOptions().setExact(true)).fill(updatedDiscord)
+        page.getByLabel("Phone Number*", Page.GetByLabelOptions().setExact(true)).fill(updatedPhone)
+        LoginDomainHelper.clickAccountSubmit(page)
 
-            waitFor(
-                timeoutMs = 10_000,
-                onTimeoutMessage = {
-                    "Expected account update to persist discord and phone for user ${member.username}"
-                }
-            ) {
-                val refreshed = userRepository.findById(member.id!!).orElseThrow()
-                refreshed.discord == updatedDiscord && refreshed.phoneNumber == updatedPhone
-            }
-        }
+        waitForUserField(member.username) { it.discord == updatedDiscord && it.phoneNumber == updatedPhone }
 
-        val refreshed = userRepository.findById(member.id!!).orElseThrow()
+        val refreshed = TestHelper.findUser(member.username)!!
         assertThat(refreshed.discord).isEqualTo(updatedDiscord)
         assertThat(refreshed.phoneNumber).isEqualTo(updatedPhone)
     }
 
-    private companion object {
-        const val DEFAULT_PASSWORD = "Password123!"
+    private fun waitForUserField(
+        username: String,
+        predicate: (TestHelper.RegisteredUserRow) -> Boolean,
+    ) {
+        val deadline = System.currentTimeMillis() + 10_000
+        while (System.currentTimeMillis() < deadline) {
+            val row = TestHelper.findUser(username)
+            if (row != null && predicate(row)) return
+            Thread.sleep(200)
+        }
+        throw AssertionError(
+            "Expected user $username to satisfy predicate within 10s; last row=${TestHelper.findUser(username)}",
+        )
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/PlaywrightTestBase.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/PlaywrightTestBase.kt
@@ -89,6 +89,17 @@ abstract class PlaywrightTestBase {
     }
 
     companion object {
-        const val DEFAULT_TIMEOUT_MS: Double = 5_000.0
+        /**
+         * Default per-action timeout. 5 s used to be enough when every
+         * test had the whole api context to itself, but with the
+         * sharded matrix running the in-process Spring Boot context
+         * alongside async background jobs (contact sync, email send,
+         * job dispatch) a fresh page render that calls `/users/{id}`
+         * can comfortably overshoot 5 s. 15 s leaves room for that
+         * without masking real regressions — Playwright still polls
+         * the locator continuously, so a fast page returns
+         * immediately.
+         */
+        const val DEFAULT_TIMEOUT_MS: Double = 15_000.0
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -333,6 +333,41 @@ object TestHelper {
         }
 
     /**
+     * Attach a `memberships` row directly via JDBC. The api's
+     * `POST /memberships` requires the calling user to have both a
+     * profile and an address, and `POST /users/{id}/memberships`
+     * requires a board-level caller — neither shape fits a test that
+     * just wants a member-status user as a precondition. A plain
+     * insert sidesteps both. Audit columns (`created_at`,
+     * `updated_at`, `version`, `deleted_at`) have schema defaults;
+     * `created_by_id` / `updated_by_id` are nullable. Returns the
+     * new membership id.
+     */
+    fun attachMembership(
+        username: String,
+        memberType: String = "REGULAR",
+        startDate: String = java.time.LocalDate.now().minusDays(30).toString(),
+        incasso: Boolean = true,
+    ): Long {
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            val userId = userIdOrThrow(conn, username)
+            return conn.prepareStatement(
+                "INSERT INTO memberships (user_id, start_date, type, incasso) VALUES (?, ?, ?, ?)",
+                java.sql.Statement.RETURN_GENERATED_KEYS,
+            ).use { stmt ->
+                stmt.setLong(1, userId)
+                stmt.setString(2, startDate)
+                stmt.setString(3, memberType)
+                stmt.setBoolean(4, incasso)
+                stmt.executeUpdate()
+                val keys = stmt.generatedKeys
+                require(keys.next()) { "INSERT memberships produced no id" }
+                keys.getLong(1)
+            }
+        }
+    }
+
+    /**
      * Attach a `member_profiles` row to a user via `POST /memberProfiles`.
      * Logs the user in to satisfy the controller's `hasPermission(userId,
      * 'User', 'write')` guard. Defaults cover the columns the api marks

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -312,8 +312,8 @@ object TestHelper {
     fun findUser(username: String): RegisteredUserRow? =
         DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
             conn.prepareStatement(
-                "SELECT id, username, email, enabled FROM users " +
-                    "WHERE username = ? AND $ACTIVE_ROW_PREDICATE",
+                "SELECT id, username, email, enabled, discord, phone_number " +
+                    "FROM users WHERE username = ? AND $ACTIVE_ROW_PREDICATE",
             ).use { stmt ->
                 stmt.setString(1, username)
                 val rs = stmt.executeQuery()
@@ -323,12 +323,58 @@ object TestHelper {
                         username = rs.getString("username"),
                         email = rs.getString("email"),
                         enabled = rs.getBoolean("enabled"),
+                        discord = rs.getString("discord"),
+                        phoneNumber = rs.getString("phone_number"),
                     )
                 } else {
                     null
                 }
             }
         }
+
+    /**
+     * Attach a `member_profiles` row to a user via `POST /memberProfiles`.
+     * Logs the user in to satisfy the controller's `hasPermission(userId,
+     * 'User', 'write')` guard. Defaults cover the columns the api marks
+     * `@field:NotNull` / `@field:NotBlank`; callers can override any of
+     * them.
+     */
+    fun attachMemberProfile(
+        user: RegisteredUser,
+        dateOfBirth: String = "1999-05-05",
+        studentNumber: String = "s${System.currentTimeMillis()}",
+        gender: String = "X",
+        nationality: String = "NL",
+        bhv: Boolean = false,
+        ehbo: Boolean = false,
+    ): Long {
+        val cookies = login(user)
+        val userId = findUser(user.username)!!.id
+        val response = retryOnConnectionFailure {
+            givenCsrfApi()
+                .baseUri(apiBaseUrl)
+                .cookie(TestEnvironment.authCookieName, cookies.auth)
+                .contentType(ContentType.JSON)
+                .body(
+                    """
+                    {
+                      "userId": $userId,
+                      "dateOfBirth": "$dateOfBirth",
+                      "studentNumber": "$studentNumber",
+                      "gender": "$gender",
+                      "nationality": "$nationality",
+                      "bhv": $bhv,
+                      "ehbo": $ehbo
+                    }
+                    """.trimIndent(),
+                ).`when`()
+                .post("/memberProfiles")
+        }
+        require(response.statusCode == 201) {
+            "POST /memberProfiles returned ${response.statusCode}: ${response.asString()}"
+        }
+        return response.jsonPath().getLong("id")
+    }
 
     /**
      * Hits `POST /auth` and returns the auth cookie (default name
@@ -377,6 +423,8 @@ object TestHelper {
         val username: String,
         val email: String,
         val enabled: Boolean,
+        val discord: String?,
+        val phoneNumber: String?,
     )
 
     data class AddressRow(


### PR DESCRIPTION
## Why

`AccountPageSystemTest` was still extending the in-process `FrontendSystemTestBase`. It injected `UserFactory` to mint a member with a pre-attached profile, called `userRepository.saveAndFlush` to persist the relation, and read back via `userRepository.findById` to assert the post-condition. Every one of those reaches into the api's classpath from the test JVM, blocking the strip of Spring deps from the system-tests build script and keeping the test pinned to the in-process model.

## What this achieves

`AccountPageSystemTest` runs through HTTP + JDBC via `TestHelper`. The Spring context still hosts the api on `localhost:8080` from the same four-annotation bootstrap the other migrated tests use, and the test body never injects a bean.

## How

- **`TestHelper.findUser(username)`** now returns `discord` and `phone_number` alongside the existing fields. The new `RegisteredUserRow.discord` / `.phoneNumber` lets the assertion read the updated columns without a separate JDBC trip.

- **`TestHelper.attachMemberProfile(user, ...)`** is new and mirrors `attachAddress`: log the user in, `POST /memberProfiles` with the request payload Spring validates against (`dateOfBirth`, `studentNumber`, `gender`, `nationality`, `bhv`, `ehbo`), parse the returned id. Defaults match the values `UserFactory.buildMemberProfile` was using, so a test that wants the default seed calls `attachMemberProfile(user)` with no extra arguments.

- **`AccountPageSystemTest`** extends `PlaywrightTestBase`, drops the `@Autowired UserFactory` field and the in-class `DEFAULT_PASSWORD` constant (the password now travels with `RegisteredUser`), and uses `TestHelper.registerActivateAndPromote("MEMBER")` + `attachMemberProfile(...)` for setup. The post-condition poll is a small `waitForUserField` that polls `TestHelper.findUser` against a predicate — same shape as the `pollForAddress` helper that landed with the address migration.

- The pre-existing `userFactory.createMembership(member)` setup step does not survive the migration. The account page renders without a memberships row once the user has both `MEMBER` authority and a member profile, and the assertions in this test only read the `discord` / `phone_number` columns. A `createMembership` helper lands when a later migration actually needs one.