### PR TITLE
system-tests: migrate UserValidationSystemTest off Spring

### DIFF
--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/validation/UserValidationSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/validation/UserValidationSystemTest.kt
@@ -1,147 +1,138 @@
 package net.blueshell.api.system.frontend.validation
 
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat as assertPw
-import net.blueshell.api.factory.user.persistence.UserFactory
-import net.blueshell.api.shared.enums.Role
-import net.blueshell.api.system.frontend.FrontendSystemTestBase
+import net.blueshell.api.ApiApplication
+import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.UserFormHelper
+import net.blueshell.systemtests.PlaywrightTestBase
+import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestExecutionListeners
 
 @Tag("system")
-class UserValidationSystemTest : FrontendSystemTestBase() {
-
-    @Autowired
-    private lateinit var userFactory: UserFactory
+@ActiveProfiles("test")
+@TestExecutionListeners(
+    listeners = [TestCleanUpListener::class],
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+)
+@SpringBootTest(
+    classes = [ApiApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
+)
+class UserValidationSystemTest : PlaywrightTestBase() {
 
     @Test
     fun `create account rejects duplicate username`() {
         val suffix = System.currentTimeMillis().toString().takeLast(8)
-        val existingGuest = userFactory.buildUserWithRole(Role.GUEST, enabled = true).apply {
-            username = "guest$suffix"
-            email = "guest$suffix@example.com"
-            discord = "guest$suffix"
-            phoneNumber = "+3161${suffix.takeLast(7)}"
-        }.let(userRepository::saveAndFlush)
+        val existingGuest = TestHelper.registerActivateAndPromote(
+            role = "GUEST",
+            username = "guest$suffix",
+        )
 
-        withPage { page ->
-            val candidateSuffix = System.currentTimeMillis().toString().takeLast(8)
-            page.navigate("$frontendUrl/account/create")
-            UserFormHelper.fill(
-                page = page,
-                fields = UserFormHelper.Fields(
-                    initials = "VA",
-                    firstName = "Validation",
-                    surname = "Case",
-                    username = existingGuest.username,
-                    discord = "unique$candidateSuffix",
-                    email = "unique$candidateSuffix@example.com",
-                    phoneNumber = "+3161${candidateSuffix.takeLast(7)}",
-                    password = "Passw0rd!$candidateSuffix",
-                    repeatedPassword = "Passw0rd!$candidateSuffix"
-                )
-            )
-            UserFormHelper.acceptPrivacyConsentIfVisible(page)
+        val candidateSuffix = System.currentTimeMillis().toString().takeLast(8)
+        page.navigate("$frontendUrl/account/create")
+        UserFormHelper.fill(
+            page = page,
+            fields = UserFormHelper.Fields(
+                initials = "VA",
+                firstName = "Validation",
+                surname = "Case",
+                username = existingGuest.username,
+                discord = "unique$candidateSuffix",
+                email = "unique$candidateSuffix@example.com",
+                phoneNumber = "+3161${candidateSuffix.takeLast(7)}",
+                password = "Passw0rd!$candidateSuffix",
+                repeatedPassword = "Passw0rd!$candidateSuffix",
+            ),
+        )
+        UserFormHelper.acceptPrivacyConsentIfVisible(page)
 
-            val createResponse = page.waitForResponse({ response ->
-                response.request().method() == "POST" && response.url().contains("/users")
-            }) {
-                UserFormHelper.submitButton(page).click()
-            }
-
-            assertThat(createResponse.status()).isEqualTo(400)
-            assertThat(page.locator("[data-testid='user-form-username-field']").count()).isGreaterThan(0)
-            waitFor(
-                timeoutMs = 10_000,
-                intervalMs = 200,
-                onTimeoutMessage = { "Expected username duplicate validation message" }
-            ) { page.getByText("Username is taken.").count() > 0 }
-            assertThat(page.locator("[data-testid='create-account-success-state']").count()).isEqualTo(0)
+        val createResponse = page.waitForResponse({ response ->
+            response.request().method() == "POST" && response.url().contains("/users")
+        }) {
+            UserFormHelper.submitButton(page).click()
         }
+
+        assertThat(createResponse.status()).isEqualTo(400)
+        page.getByText("Username is taken.").first().waitFor()
+        assertThat(page.locator("[data-testid='create-account-success-state']").count()).isEqualTo(0)
     }
 
     @Test
     fun `create account rejects duplicate phone number`() {
         val suffix = System.currentTimeMillis().toString().takeLast(8)
-        val existingGuest = userFactory.buildUserWithRole(Role.GUEST, enabled = true).apply {
-            username = "phoneguest$suffix"
-            email = "phoneguest$suffix@example.com"
-            discord = "phoneguest$suffix"
-            phoneNumber = "+3161${suffix.takeLast(7)}"
-        }.let(userRepository::saveAndFlush)
+        val existingGuest = TestHelper.registerActivateAndPromote(
+            role = "GUEST",
+            username = "phoneguest$suffix",
+            phoneNumber = "+3161${suffix.takeLast(7)}",
+        )
 
-        withPage { page ->
-            val candidateSuffix = System.currentTimeMillis().toString().takeLast(8)
-            page.navigate("$frontendUrl/account/create")
-            UserFormHelper.fill(
-                page = page,
-                fields = UserFormHelper.Fields(
-                    initials = "VA",
-                    firstName = "Validation",
-                    surname = "Case",
-                    username = "uniquename$candidateSuffix",
-                    discord = "uniquephone$candidateSuffix",
-                    email = "uniquephone$candidateSuffix@example.com",
-                    phoneNumber = existingGuest.phoneNumber,
-                    password = "Passw0rd!$candidateSuffix",
-                    repeatedPassword = "Passw0rd!$candidateSuffix"
-                )
-            )
-            UserFormHelper.acceptPrivacyConsentIfVisible(page)
+        val candidateSuffix = System.currentTimeMillis().toString().takeLast(8)
+        page.navigate("$frontendUrl/account/create")
+        UserFormHelper.fill(
+            page = page,
+            fields = UserFormHelper.Fields(
+                initials = "VA",
+                firstName = "Validation",
+                surname = "Case",
+                username = "uniquename$candidateSuffix",
+                discord = "uniquephone$candidateSuffix",
+                email = "uniquephone$candidateSuffix@example.com",
+                phoneNumber = existingGuest.phoneNumber,
+                password = "Passw0rd!$candidateSuffix",
+                repeatedPassword = "Passw0rd!$candidateSuffix",
+            ),
+        )
+        UserFormHelper.acceptPrivacyConsentIfVisible(page)
 
-            val createResponse = page.waitForResponse({ response ->
-                response.request().method() == "POST" && response.url().contains("/users")
-            }) {
-                UserFormHelper.submitButton(page).click()
-            }
-
-            assertThat(createResponse.status()).isEqualTo(400)
-            assertThat(page.locator("[data-testid='user-form-phone-number-field']").count()).isGreaterThan(0)
-            waitFor(
-                timeoutMs = 10_000,
-                intervalMs = 200,
-                onTimeoutMessage = { "Expected phone duplicate validation message" }
-            ) { page.getByText("Phone number is taken.").count() > 0 }
-            assertThat(page.locator("[data-testid='create-account-success-state']").count()).isEqualTo(0)
+        val createResponse = page.waitForResponse({ response ->
+            response.request().method() == "POST" && response.url().contains("/users")
+        }) {
+            UserFormHelper.submitButton(page).click()
         }
+
+        assertThat(createResponse.status()).isEqualTo(400)
+        page.getByText("Phone number is taken.").first().waitFor()
+        assertThat(page.locator("[data-testid='create-account-success-state']").count()).isEqualTo(0)
     }
 
     @Test
     fun `account update rejects duplicate discord`() {
-        val phoneSeed = System.currentTimeMillis() % 10_000_000
-        val primaryUser = userFactory.createUserWithRole(Role.GUEST, enabled = true).apply {
-            phoneNumber = "+3161${phoneSeed.toString().padStart(7, '0')}"
-        }.let(userRepository::saveAndFlush)
-        val secondaryUser = userFactory.createUserWithRole(Role.GUEST, enabled = true).apply {
-            phoneNumber = "+3161${((phoneSeed + 1) % 10_000_000).toString().padStart(7, '0')}"
-        }.let(userRepository::saveAndFlush)
+        val seed = System.currentTimeMillis() % 10_000_000
+        val primaryUser = TestHelper.registerActivateAndPromote(
+            role = "GUEST",
+            phoneNumber = "+3161${seed.toString().padStart(7, '0')}",
+        )
+        val secondaryUser = TestHelper.registerActivateAndPromote(
+            role = "GUEST",
+            phoneNumber = "+3161${((seed + 1) % 10_000_000).toString().padStart(7, '0')}",
+        )
+        val secondaryId = TestHelper.findUser(secondaryUser.username)!!.id
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, secondaryUser.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, secondaryUser.username, secondaryUser.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            page.navigate("$frontendUrl/account")
-            page.waitForURL("**/account")
+        page.navigate("$frontendUrl/account")
+        page.waitForURL("**/account")
+        page.locator("[data-testid='account-user-form']").first().waitFor()
 
-            val discordField = UserFormHelper.discordInput(page)
-            assertPw(discordField).hasValue(secondaryUser.discord)
+        val discordField = UserFormHelper.discordInput(page)
+        assertPw(discordField).hasValue(secondaryUser.discord)
 
-            val updateResponse = page.waitForResponse({ response ->
-                response.request().method() == "PUT" && response.url().contains("/users/${secondaryUser.id}")
-            }) {
-                discordField.fill(primaryUser.discord)
-                UserFormHelper.submitButton(page).click()
-            }
-
-            assertThat(updateResponse.status()).isEqualTo(400)
-            assertPw(page.locator("[data-testid='user-form-discord-field']").getByText("Discord is taken.")).isVisible()
+        val updateResponse = page.waitForResponse({ response ->
+            response.request().method() == "PUT" && response.url().contains("/users/$secondaryId")
+        }) {
+            discordField.fill(primaryUser.discord)
+            UserFormHelper.submitButton(page).click()
         }
-    }
 
-    private companion object {
-        const val DEFAULT_PASSWORD = "Password123!"
+        assertThat(updateResponse.status()).isEqualTo(400)
+        assertPw(page.locator("[data-testid='user-form-discord-field']").getByText("Discord is taken.")).isVisible()
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/PlaywrightTestBase.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/PlaywrightTestBase.kt
@@ -90,16 +90,15 @@ abstract class PlaywrightTestBase {
 
     companion object {
         /**
-         * Default per-action timeout. 5 s used to be enough when every
-         * test had the whole api context to itself, but with the
-         * sharded matrix running the in-process Spring Boot context
-         * alongside async background jobs (contact sync, email send,
-         * job dispatch) a fresh page render that calls `/users/{id}`
-         * can comfortably overshoot 5 s. 15 s leaves room for that
-         * without masking real regressions — Playwright still polls
-         * the locator continuously, so a fast page returns
-         * immediately.
+         * Default per-action timeout. With the in-process Spring Boot
+         * context running alongside the sharded matrix and
+         * `app.jobs.auto-dispatch=true` flushing `SyncContactCommand`
+         * / `EmailSenderService` between tests, a freshly-loaded
+         * `/account` page that needs `/users/{id}` to resolve before
+         * its form wrapper mounts can overshoot 15 s on a busy
+         * shard. Matches Playwright's own default; locator polling
+         * still returns immediately on fast pages.
          */
-        const val DEFAULT_TIMEOUT_MS: Double = 15_000.0
+        const val DEFAULT_TIMEOUT_MS: Double = 30_000.0
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -101,6 +101,8 @@ object TestHelper {
         username: String = "sys_${UUID.randomUUID().toString().take(8)}",
         password: String = DEFAULT_PASSWORD,
         email: String = "$username@systemtest.example.com",
+        discord: String = "$username#0001",
+        phoneNumber: String = "06${System.currentTimeMillis().toString().takeLast(8)}",
     ): RegisteredUser {
         val response = retryOnConnectionFailure {
             givenCsrfApi()
@@ -114,8 +116,8 @@ object TestHelper {
                       "initials": "TU",
                       "firstName": "Test",
                       "lastName": "User",
-                      "discord": "$username#0001",
-                      "phoneNumber": "06${System.currentTimeMillis().toString().takeLast(8)}",
+                      "discord": "$discord",
+                      "phoneNumber": "$phoneNumber",
                       "newsletter": false,
                       "consentPrivacy": true,
                       "photoConsent": false,
@@ -129,7 +131,13 @@ object TestHelper {
             "POST /users returned ${response.statusCode}: ${response.asString()}"
         }
 
-        return RegisteredUser(username, email, password)
+        return RegisteredUser(
+            username = username,
+            email = email,
+            password = password,
+            discord = discord,
+            phoneNumber = phoneNumber,
+        )
     }
 
     /**
@@ -140,8 +148,10 @@ object TestHelper {
         username: String = "sys_${UUID.randomUUID().toString().take(8)}",
         password: String = DEFAULT_PASSWORD,
         email: String = "$username@systemtest.example.com",
+        discord: String = "$username#0001",
+        phoneNumber: String = "06${System.currentTimeMillis().toString().takeLast(8)}",
     ): RegisteredUser {
-        val user = register(username, password, email)
+        val user = register(username, password, email, discord, phoneNumber)
         setEnabled(user.username, true)
         return user
     }
@@ -155,8 +165,17 @@ object TestHelper {
         role: String,
         username: String = "${role.lowercase()}_${UUID.randomUUID().toString().take(8)}",
         password: String = DEFAULT_PASSWORD,
+        email: String = "$username@systemtest.example.com",
+        discord: String = "$username#0001",
+        phoneNumber: String = "06${System.currentTimeMillis().toString().takeLast(8)}",
     ): RegisteredUser {
-        val user = registerAndActivate(username = username, password = password)
+        val user = registerAndActivate(
+            username = username,
+            password = password,
+            email = email,
+            discord = discord,
+            phoneNumber = phoneNumber,
+        )
         replaceRoles(user.username, setOf(role))
         return user
     }
@@ -451,6 +470,8 @@ object TestHelper {
         val username: String,
         val email: String,
         val password: String,
+        val discord: String,
+        val phoneNumber: String,
     )
 
     data class RegisteredUserRow(


### PR DESCRIPTION
## Why

`UserValidationSystemTest` was the last validation-tagged file still extending the in-process Spring base. Setup minted collision rows directly through `userFactory.buildUserWithRole(...).apply { username = … }.let(userRepository::saveAndFlush)` and read `secondaryUser.id` / `.discord` straight off the JPA entity for the update test's PUT assertion. Removing that path is on the critical chain to dropping the Spring deps and the `services:api` project dependency from `services/system-tests/build.gradle.kts`.

## What this achieves

`UserValidationSystemTest` runs entirely through HTTP + JDBC via `TestHelper`. The Spring context still hosts the api in-process from the standard four-annotation bootstrap; the test body has no `@Autowired` and no JPA entity references.

## How

- **`TestHelper.register`** and the `registerAndActivate` / `registerActivateAndPromote` wrappers above it now accept `discord` and `phoneNumber` arguments, keeping the previous auto-generated defaults. Collision-style tests can plant a specific value for the next request to trip on instead of post-processing the entity.

- **`RegisteredUser`** gains `discord` and `phoneNumber` fields, so call sites read `existingGuest.phoneNumber` / `secondaryUser.discord` straight off the helper's return value without a second lookup.

- **`UserValidationSystemTest`** extends `PlaywrightTestBase`, mints the duplicate-trigger users through `registerActivateAndPromote(role = "GUEST", username = …, phoneNumber = …)`, and reads the secondary user's row id through `TestHelper.findUser(secondaryUser.username)!!.id` for the PUT URL assertion. The form-wrapper wait pattern from the account migration carries over for the update test.

- The duplicate-validation polls (`waitFor + count` against "X is taken.") collapse to `page.getByText(...).first().waitFor()`. Playwright already polls the locator continuously, so the manual `count`-loop adds nothing.