### PR TITLE
system-tests: migrate CsrfSystemTest off Spring

### DIFF
--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/security/CsrfSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/security/CsrfSystemTest.kt
@@ -1,43 +1,50 @@
 package net.blueshell.api.system.frontend.security
 
-import tools.jackson.databind.ObjectMapper
-import net.blueshell.api.factory.user.persistence.UserFactory
-import net.blueshell.api.shared.enums.Role
-import net.blueshell.api.system.frontend.FrontendSystemTestBase
+import net.blueshell.api.ApiApplication
+import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.LoginDomainHelper
+import net.blueshell.systemtests.PlaywrightTestBase
+import net.blueshell.systemtests.TestEnvironment
+import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestExecutionListeners
+import tools.jackson.databind.ObjectMapper
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 
 @Tag("system")
-class CsrfSystemTest : FrontendSystemTestBase() {
-
-    @Autowired
-    private lateinit var userFactory: UserFactory
-
-    @Value("\${server.port}")
-    private var serverPort: Int = 8080
+@ActiveProfiles("test")
+@TestExecutionListeners(
+    listeners = [TestCleanUpListener::class],
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+)
+@SpringBootTest(
+    classes = [ApiApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
+)
+class CsrfSystemTest : PlaywrightTestBase() {
 
     @Test
     fun `cross-origin state changing request without csrf token is rejected`() {
         val response = HttpClient.newHttpClient().send(
-            HttpRequest.newBuilder(URI.create("http://127.0.0.1:$serverPort/auth"))
+            HttpRequest.newBuilder(URI.create("${TestEnvironment.apiUrl}/auth"))
                 .header("Origin", frontendUrl)
                 .header("Content-Type", "application/json")
                 .POST(
                     HttpRequest.BodyPublishers.ofString(
-                        """{"username":"does-not-exist","password":"invalid-password"}"""
-                    )
+                        """{"username":"does-not-exist","password":"invalid-password"}""",
+                    ),
                 )
                 .build(),
-            HttpResponse.BodyHandlers.ofString()
+            HttpResponse.BodyHandlers.ofString(),
         )
 
         assertThat(response.statusCode()).isEqualTo(403)
@@ -45,68 +52,63 @@ class CsrfSystemTest : FrontendSystemTestBase() {
 
     @Test
     fun `frontend login flow succeeds and stores csrf cookie`() {
-        val user = userFactory.createUserWithRole(Role.MEMBER, enabled = true)
+        val user = TestHelper.registerActivateAndPromote("MEMBER")
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, user.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, user.username, user.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            assertThat(
-                page.context().cookies().any { cookie ->
-                    cookie.name == "XSRF-TOKEN" && cookie.value.isNotBlank()
-                }
-            ).isTrue()
-        }
+        assertThat(
+            page.context().cookies().any { cookie ->
+                cookie.name == "XSRF-TOKEN" && cookie.value.isNotBlank()
+            },
+        ).isTrue()
     }
 
     @Test
     fun `login page flow uses csrf body token and succeeds`() {
-        val user = userFactory.createUserWithRole(Role.MEMBER, enabled = true)
+        val user = TestHelper.registerActivateAndPromote("MEMBER")
 
-        withPage { page ->
-            var csrfBodyToken: String? = null
-            var csrfCookieToken: String? = null
-            page.onResponse { response ->
-                if (response.request().method() == "GET" && response.url().contains("/csrf")) {
-                    csrfBodyToken = objectMapper.readTree(response.text())["token"].asText()
-                    val setCookie = response.headerValue("set-cookie") ?: ""
-                    csrfCookieToken = CSRF_COOKIE_PATTERN.find(setCookie)?.groupValues?.get(1)
-                }
+        var csrfBodyToken: String? = null
+        var csrfCookieToken: String? = null
+        page.onResponse { response ->
+            if (response.request().method() == "GET" && response.url().contains("/csrf")) {
+                csrfBodyToken = objectMapper.readTree(response.text())["token"].asText()
+                val setCookie = response.headerValue("set-cookie") ?: ""
+                csrfCookieToken = CSRF_COOKIE_PATTERN.find(setCookie)?.groupValues?.get(1)
             }
-
-            page.navigate("$frontendUrl/login/")
-            LoginDomainHelper.fillLoginCredentials(page, user.username, DEFAULT_PASSWORD)
-
-            val authResponse = page.waitForResponse({ response ->
-                response.request().method() == "POST" && response.url().contains("/auth")
-            }) {
-                LoginDomainHelper.clickLoginSubmit(page)
-            }
-
-            val csrfBody = csrfBodyToken ?: "<missing>"
-            val csrfCookie = csrfCookieToken ?: "<missing>"
-            val csrfHeaderOnAuth = authResponse.request().headers()["x-xsrf-token"] ?: "<missing>"
-
-            assertThat(csrfBody).isNotBlank()
-            assertThat(csrfCookie).isNotBlank()
-            assertThat(csrfHeaderOnAuth).isNotBlank()
-            assertThat(csrfBody).isNotEqualTo(csrfCookie)
-            assertThat(csrfHeaderOnAuth).isEqualTo(csrfBody)
-
-            assertThat(authResponse.status())
-                .withFailMessage(
-                    "Expected /auth status 200 from login flow. Got %s (csrfBody=%s, csrfCookie=%s, authHeader=%s)",
-                    authResponse.status(),
-                    csrfBody,
-                    csrfCookie,
-                    csrfHeaderOnAuth
-                )
-                .isEqualTo(200)
         }
+
+        page.navigate("$frontendUrl/login/")
+        LoginDomainHelper.fillLoginCredentials(page, user.username, user.password)
+
+        val authResponse = page.waitForResponse({ response ->
+            response.request().method() == "POST" && response.url().contains("/auth")
+        }) {
+            LoginDomainHelper.clickLoginSubmit(page)
+        }
+
+        val csrfBody = csrfBodyToken ?: "<missing>"
+        val csrfCookie = csrfCookieToken ?: "<missing>"
+        val csrfHeaderOnAuth = authResponse.request().headers()["x-xsrf-token"] ?: "<missing>"
+
+        assertThat(csrfBody).isNotBlank()
+        assertThat(csrfCookie).isNotBlank()
+        assertThat(csrfHeaderOnAuth).isNotBlank()
+        assertThat(csrfBody).isNotEqualTo(csrfCookie)
+        assertThat(csrfHeaderOnAuth).isEqualTo(csrfBody)
+
+        assertThat(authResponse.status())
+            .withFailMessage(
+                "Expected /auth status 200 from login flow. Got %s (csrfBody=%s, csrfCookie=%s, authHeader=%s)",
+                authResponse.status(),
+                csrfBody,
+                csrfCookie,
+                csrfHeaderOnAuth,
+            )
+            .isEqualTo(200)
     }
 
     private companion object {
-        const val DEFAULT_PASSWORD = "Password123!"
         val CSRF_COOKIE_PATTERN = Regex("""XSRF-TOKEN=([^;]+)""")
         val objectMapper = ObjectMapper()
     }


### PR DESCRIPTION
## Why

`CsrfSystemTest` was the last `security`-tagged file still extending `FrontendSystemTestBase`. It pulled a member in via `@Autowired UserFactory` and built the cross-origin POST URL out of `@Value("\${server.port}")`. Both keep the test reaching into the in-process Spring context, blocking the eventual strip of those deps from the system-tests build script.

## What this achieves

`CsrfSystemTest` runs entirely through HTTP and `TestHelper`. The Spring context still hosts the api in-process from the standard four-annotation bootstrap; the test body has no `@Autowired` and no `@Value`.

## How

- **User setup** — `userFactory.createUserWithRole(Role.MEMBER, enabled = true)` becomes `TestHelper.registerActivateAndPromote("MEMBER")`. The two login-flow tests pick up the new `RegisteredUser.password` so the in-class `DEFAULT_PASSWORD` constant drops.

- **Base URL** — the cross-origin POST now reads `TestEnvironment.apiUrl` instead of injecting `server.port`. Same value (8080), single source of truth.

- **Test class** — extends `PlaywrightTestBase`, picks up the standard four-annotation Spring host, and inlines the `withPage` blocks against the per-test `page` field that `PlaywrightTestBase` already owns. No behaviour changes — the assertions on the BREACH-protected CSRF round-trip (body token vs cookie token, header echoes body) stay byte-for-byte the same.