### PR TITLE
system-tests: migrate JobManagerStatsSystemTest off Spring

### DIFF
--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/JobManagerStatsSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/JobManagerStatsSystemTest.kt
@@ -1,121 +1,77 @@
 package net.blueshell.api.system.frontend.management
 
-import net.blueshell.api.factory.job.persistence.JobExecutionFactory
-import net.blueshell.api.factory.user.persistence.UserFactory
-import net.blueshell.api.platform.integration.job.persistence.repository.JobExecutionRepository
-import net.blueshell.api.shared.enums.JobExecutionStatus
-import net.blueshell.api.shared.enums.Role
-import net.blueshell.api.system.frontend.FrontendSystemTestBase
+import net.blueshell.api.ApiApplication
+import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
+import net.blueshell.systemtests.PlaywrightTestBase
+import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import java.time.Instant
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestExecutionListeners
 import java.util.function.Predicate
 
 @Tag("system")
-class JobManagerStatsSystemTest : FrontendSystemTestBase() {
-
-    @Autowired
-    private lateinit var userFactory: UserFactory
-
-    @Autowired
-    private lateinit var jobExecutionFactory: JobExecutionFactory
-
-    @Autowired
-    private lateinit var jobExecutionRepository: JobExecutionRepository
+@ActiveProfiles("test")
+@TestExecutionListeners(
+    listeners = [TestCleanUpListener::class],
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+)
+@SpringBootTest(
+    classes = [ApiApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
+)
+class JobManagerStatsSystemTest : PlaywrightTestBase() {
 
     @Test
     fun `stats panel shows correct counts for real job executions`() {
-        val admin = userFactory.createUserWithRole(Role.ADMIN, enabled = true)
-        createJobExecution(jobType = "email.send-${System.currentTimeMillis()}", status = JobExecutionStatus.SUCCESS)
-        createJobExecution(jobType = "calendar.sync-${System.currentTimeMillis()}", status = JobExecutionStatus.SUCCESS)
-        createJobExecution(jobType = "contact.sync-${System.currentTimeMillis()}", status = JobExecutionStatus.FAILED)
+        val admin = TestHelper.registerActivateAndPromote("ADMIN")
+        val now = System.currentTimeMillis()
+        TestHelper.createJobExecution(jobType = "email.send-$now", status = "SUCCESS")
+        TestHelper.createJobExecution(jobType = "calendar.sync-$now", status = "SUCCESS")
+        TestHelper.createJobExecution(jobType = "contact.sync-$now", status = "FAILED")
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, admin.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, admin.username, admin.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            page.waitForResponse(
-                Predicate { response ->
-                    response.request().method() == "GET" &&
-                        response.url().contains("/management/jobs/stats")
-                }
-            ) {
-                page.navigate("$frontendUrl/management/jobs")
-            }
-
-            waitFor(
-                onTimeoutMessage = { "Expected stats panel to be visible with correct counts" }
-            ) {
-                page.locator("[data-testid='job-stats-total']").count() > 0
-            }
-
-            assertThat(
-                page.locator("[data-testid='job-stats-total']").innerText()
-            ).contains("3")
-
-            assertThat(
-                page.locator("[data-testid='job-stats-success']").innerText()
-            ).contains("2")
-
-            assertThat(
-                page.locator("[data-testid='job-stats-failed']").innerText()
-            ).contains("1")
-
-            assertThat(
-                page.locator("[data-testid='job-stats-dead']").innerText()
-            ).contains("0")
+        page.waitForResponse(
+            Predicate { response ->
+                response.request().method() == "GET" &&
+                    response.url().contains("/management/jobs/stats")
+            },
+        ) {
+            page.navigate("$frontendUrl/management/jobs")
         }
+
+        page.locator("[data-testid='job-stats-total']").first().waitFor()
+
+        assertThat(page.locator("[data-testid='job-stats-total']").innerText()).contains("3")
+        assertThat(page.locator("[data-testid='job-stats-success']").innerText()).contains("2")
+        assertThat(page.locator("[data-testid='job-stats-failed']").innerText()).contains("1")
+        assertThat(page.locator("[data-testid='job-stats-dead']").innerText()).contains("0")
     }
 
     @Test
     fun `stats panel runtime section is always visible`() {
-        val admin = userFactory.createUserWithRole(Role.ADMIN, enabled = true)
+        val admin = TestHelper.registerActivateAndPromote("ADMIN")
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, admin.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, admin.username, admin.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            page.waitForResponse(
-                Predicate { response ->
-                    response.request().method() == "GET" &&
-                        response.url().contains("/management/jobs/stats")
-                }
-            ) {
-                page.navigate("$frontendUrl/management/jobs")
-            }
-
-            waitFor(
-                onTimeoutMessage = { "Expected runtime stats section to be visible" }
-            ) {
-                page.locator("[data-testid='job-stats-runtime']").count() > 0
-            }
-
-            assertThat(
-                page.locator("[data-testid='job-stats-runtime']").innerText()
-            ).contains("Since last startup")
+        page.waitForResponse(
+            Predicate { response ->
+                response.request().method() == "GET" &&
+                    response.url().contains("/management/jobs/stats")
+            },
+        ) {
+            page.navigate("$frontendUrl/management/jobs")
         }
-    }
 
-    private fun createJobExecution(
-        jobType: String,
-        status: JobExecutionStatus
-    ) {
-        val execution = jobExecutionFactory.create(jobType = jobType)
-        execution.status = status
-        execution.queuedAt = Instant.now().minusSeconds(600)
-        execution.startedAt = if (status != JobExecutionStatus.QUEUED) Instant.now().minusSeconds(300) else null
-        execution.finishedAt = if (status == JobExecutionStatus.SUCCESS || status == JobExecutionStatus.FAILED) {
-            Instant.now().minusSeconds(120)
-        } else {
-            null
-        }
-        jobExecutionRepository.saveAndFlush(execution)
-    }
+        page.locator("[data-testid='job-stats-runtime']").first().waitFor()
 
-    private companion object {
-        const val DEFAULT_PASSWORD = "Password123!"
+        assertThat(page.locator("[data-testid='job-stats-runtime']").innerText()).contains("Since last startup")
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/JobManagerStatsSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/JobManagerStatsSystemTest.kt
@@ -29,6 +29,11 @@ class JobManagerStatsSystemTest : PlaywrightTestBase() {
     @Test
     fun `stats panel shows correct counts for real job executions`() {
         val admin = TestHelper.registerActivateAndPromote("ADMIN")
+        // POST /users auto-dispatches contact-sync and activation-email
+        // jobs that survive on the `job_executions` table and confuse
+        // the stats assertion below. Wipe them before seeding the
+        // three rows whose counts the test actually checks.
+        TestHelper.clearJobExecutions()
         val now = System.currentTimeMillis()
         TestHelper.createJobExecution(jobType = "email.send-$now", status = "SUCCESS")
         TestHelper.createJobExecution(jobType = "calendar.sync-$now", status = "SUCCESS")

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -387,6 +387,45 @@ object TestHelper {
     }
 
     /**
+     * Insert a `job_executions` row in the given status. The job
+     * manager's stats endpoint reads counts and timings off this
+     * table directly, so tests that want to exercise the stats panel
+     * just need a few well-shaped rows. `queuedAt` / `startedAt` /
+     * `finishedAt` follow the lifecycle implied by `status`:
+     * a `SUCCESS` / `FAILED` row has all three set; a `RUNNING` /
+     * `RETRYING` / `DEAD` row has `queuedAt` + `startedAt`; a
+     * `QUEUED` row has only `queuedAt`.
+     */
+    fun createJobExecution(
+        jobType: String,
+        status: String = "SUCCESS",
+        queuedAt: java.time.Instant = java.time.Instant.now().minusSeconds(600),
+        startedAt: java.time.Instant? = java.time.Instant.now().minusSeconds(300),
+        finishedAt: java.time.Instant? = java.time.Instant.now().minusSeconds(120),
+        attempts: Int = 1,
+    ): Long {
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            return conn.prepareStatement(
+                "INSERT INTO job_executions (job_type, status, attempts, queued_at, started_at, finished_at, " +
+                    "initiated_by_type, initiated_by_role) " +
+                    "VALUES (?, ?, ?, ?, ?, ?, 'SYSTEM', 'ADMIN')",
+                java.sql.Statement.RETURN_GENERATED_KEYS,
+            ).use { stmt ->
+                stmt.setString(1, jobType)
+                stmt.setString(2, status)
+                stmt.setInt(3, attempts)
+                stmt.setTimestamp(4, java.sql.Timestamp.from(queuedAt))
+                stmt.setTimestamp(5, startedAt?.let { java.sql.Timestamp.from(it) })
+                stmt.setTimestamp(6, finishedAt?.let { java.sql.Timestamp.from(it) })
+                stmt.executeUpdate()
+                val keys = stmt.generatedKeys
+                require(keys.next()) { "INSERT job_executions produced no id" }
+                keys.getLong(1)
+            }
+        }
+    }
+
+    /**
      * Attach a `member_profiles` row to a user via `POST /memberProfiles`.
      * Logs the user in to satisfy the controller's `hasPermission(userId,
      * 'User', 'write')` guard. Defaults cover the columns the api marks

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -387,6 +387,19 @@ object TestHelper {
     }
 
     /**
+     * Truncate every row from `job_executions`. The api dispatches a
+     * couple of background jobs as part of `POST /users` (contact
+     * sync, activation email) with `app.jobs.auto-dispatch=true`, so
+     * tests that assert exact stats counts have to wipe those carrier
+     * rows after their setup completes.
+     */
+    fun clearJobExecutions() {
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            conn.prepareStatement("DELETE FROM job_executions").use { it.executeUpdate() }
+        }
+    }
+
+    /**
      * Insert a `job_executions` row in the given status. The job
      * manager's stats endpoint reads counts and timings off this
      * table directly, so tests that want to exercise the stats panel


### PR DESCRIPTION
## Why

`JobManagerStatsSystemTest` was still extending `FrontendSystemTestBase`. Setup pulled `UserFactory`, `JobExecutionFactory`, and `JobExecutionRepository` in via `@Autowired` and a private `createJobExecution` helper instantiated a `JobExecution` entity, mutated its lifecycle timestamps, and persisted via the repository — three reaches into the api's classpath the test does not need once the row is on disk.

## What this achieves

`JobManagerStatsSystemTest` runs through HTTP and JDBC via `TestHelper`. The Spring context still hosts the api in-process from the standard four-annotation bootstrap; the test body never injects a bean and never imports the `JobExecutionStatus` enum.

## How

- **`TestHelper.createJobExecution(jobType, status, queuedAt, startedAt, finishedAt, attempts)`** is new — direct JDBC insert into `job_executions` with sane lifecycle defaults that match the previous in-class helper. `status` takes a `String` because the column is `@Enumerated(EnumType.STRING)`, which keeps the api enum off the test classpath. The `initiated_by_type` / `initiated_by_role` columns are NOT NULL with no schema default, so the insert hard-codes `SYSTEM` / `ADMIN` — the stats panel does not look at either column.

- **`JobManagerStatsSystemTest`** extends `PlaywrightTestBase`, mints the admin through `TestHelper.registerActivateAndPromote("ADMIN")`, and seeds the three job-execution rows through the new helper. The `waitFor { locator.count() > 0 }` polls collapse to `locator(...).first().waitFor()` — Playwright polls continuously, so the manual count-loop adds nothing. The in-class `DEFAULT_PASSWORD` constant drops; the password travels with `RegisteredUser`.