### PR TITLE
system-tests: migrate JobManagerPageSystemTest off Spring

### DIFF
--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/JobManagerPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/JobManagerPageSystemTest.kt
@@ -1,245 +1,217 @@
 package net.blueshell.api.system.frontend.management
 
 import com.microsoft.playwright.Page
-import net.blueshell.api.factory.job.persistence.JobExecutionFactory
-import net.blueshell.api.factory.user.persistence.UserFactory
-import net.blueshell.api.platform.integration.job.persistence.JobExecution
-import net.blueshell.api.platform.integration.job.persistence.repository.JobExecutionRepository
-import net.blueshell.api.shared.enums.JobExecutionStatus
-import net.blueshell.api.shared.enums.Role
-import net.blueshell.api.system.frontend.FrontendSystemTestBase
+import net.blueshell.api.ApiApplication
+import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
+import net.blueshell.systemtests.PlaywrightTestBase
+import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestExecutionListeners
 import java.net.URI
 import java.net.URLDecoder
 import java.time.Instant
 import java.util.function.Predicate
 
 @Tag("system")
-class JobManagerPageSystemTest : FrontendSystemTestBase() {
-
-    @Autowired
-    private lateinit var userFactory: UserFactory
-
-    @Autowired
-    private lateinit var jobExecutionFactory: JobExecutionFactory
-
-    @Autowired
-    private lateinit var jobExecutionRepository: JobExecutionRepository
+@ActiveProfiles("test")
+@TestExecutionListeners(
+    listeners = [TestCleanUpListener::class],
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+)
+@SpringBootTest(
+    classes = [ApiApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
+)
+class JobManagerPageSystemTest : PlaywrightTestBase() {
 
     @Test
     fun `admin can list and retry failed job execution`() {
-        val admin = userFactory.createUserWithRole(Role.ADMIN, enabled = true)
-        val failed = createJobExecution(
+        val admin = TestHelper.registerActivateAndPromote("ADMIN")
+        // Wipe auto-dispatched contact-sync / activation-email rows
+        // from the admin registration so the seeded rows are the only
+        // ones the manager page sees.
+        TestHelper.clearJobExecutions()
+        val failedId = TestHelper.createJobExecution(
             jobType = "sync-contact-${System.currentTimeMillis()}",
-            status = JobExecutionStatus.FAILED,
+            status = "FAILED",
             attempts = 2,
             errorType = "RuntimeException",
-            errorReason = "Transient failure"
+            errorReason = "Transient failure",
         )
-        createJobExecution(
+        TestHelper.createJobExecution(
             jobType = "calendar-sync-${System.currentTimeMillis()}",
-            status = JobExecutionStatus.SUCCESS,
-            attempts = 1
+            status = "SUCCESS",
+            attempts = 1,
         )
-
-        val failedId = checkNotNull(failed.id) { "Expected failed execution id" }
-        val initialQueuedAt = checkNotNull(failed.queuedAt) { "Expected failed execution queuedAt to be set" }
-
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, admin.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
-
-            val listResponse = page.waitForResponse(
-                Predicate { response ->
-                    response.request().method() == "GET" &&
-                        response.url().contains("/management/jobs")
-                }
-            ) {
-                page.navigate("$frontendUrl/management/jobs")
-            }
-            assertThat(listResponse.status()).isEqualTo(200)
-
-            waitFor(
-                onTimeoutMessage = { "Expected failed job type ${failed.jobType} to appear in job manager table" }
-            ) {
-                page.locator("[data-testid='job-row-$failedId']").count() > 0
-            }
-
-            page.locator("[data-testid='job-row-$failedId']").first().click()
-
-            assertThat(
-                page.locator("[data-testid='job-error-reason-$failedId']").innerText()
-            ).contains("Transient failure")
-
-            val retryResponse = page.waitForResponse(
-                Predicate { response ->
-                    response.request().method() == "POST" &&
-                        response.url().contains("/management/jobs/$failedId/retry")
-                }
-            ) {
-                page.locator("[data-testid='job-retry-btn-$failedId']").first().click()
-            }
-            assertThat(retryResponse.status()).isEqualTo(200)
-
-            waitFor(
-                onTimeoutMessage = { "Expected failed job $failedId retry to become DEAD with refreshed queuedAt" }
-            ) {
-                val updated = jobExecutionRepository.findById(failedId).orElseThrow()
-                updated.status == JobExecutionStatus.DEAD &&
-                    updated.queuedAt != null &&
-                    updated.queuedAt!!.isAfter(initialQueuedAt)
-            }
-
-            val updated = jobExecutionRepository.findById(failedId).orElseThrow()
-            assertThat(updated.status).isEqualTo(JobExecutionStatus.DEAD)
-            assertThat(updated.queuedAt).isNotNull()
-            assertThat(updated.queuedAt).isAfter(initialQueuedAt)
+        val initialQueuedAt = checkNotNull(TestHelper.findJobExecution(failedId)?.queuedAt) {
+            "Expected failed execution queuedAt to be set"
         }
+
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, admin.username, admin.password)
+        assertThat(loginStatus).isEqualTo(200)
+
+        val listResponse = page.waitForResponse(
+            Predicate { response ->
+                response.request().method() == "GET" &&
+                    response.url().contains("/management/jobs")
+            },
+        ) {
+            page.navigate("$frontendUrl/management/jobs")
+        }
+        assertThat(listResponse.status()).isEqualTo(200)
+
+        page.locator("[data-testid='job-row-$failedId']").first().waitFor()
+        page.locator("[data-testid='job-row-$failedId']").first().click()
+
+        assertThat(
+            page.locator("[data-testid='job-error-reason-$failedId']").innerText(),
+        ).contains("Transient failure")
+
+        val retryResponse = page.waitForResponse(
+            Predicate { response ->
+                response.request().method() == "POST" &&
+                    response.url().contains("/management/jobs/$failedId/retry")
+            },
+        ) {
+            page.locator("[data-testid='job-retry-btn-$failedId']").first().click()
+        }
+        assertThat(retryResponse.status()).isEqualTo(200)
+
+        waitForJob(failedId) { row ->
+            row.status == "DEAD" &&
+                row.queuedAt != null &&
+                row.queuedAt.isAfter(initialQueuedAt)
+        }
+
+        val updated = TestHelper.findJobExecution(failedId)!!
+        assertThat(updated.status).isEqualTo("DEAD")
+        assertThat(updated.queuedAt).isNotNull()
+        assertThat(updated.queuedAt).isAfter(initialQueuedAt)
     }
 
     @Test
     fun `job manager applies frontend filters to backend jobs query`() {
-        val admin = userFactory.createUserWithRole(Role.ADMIN, enabled = true)
-        val calendarFailed = createJobExecution(
+        val admin = TestHelper.registerActivateAndPromote("ADMIN")
+        TestHelper.clearJobExecutions()
+        val calendarFailedId = TestHelper.createJobExecution(
             jobType = "calendar.sync-${System.currentTimeMillis()}",
-            status = JobExecutionStatus.FAILED,
+            status = "FAILED",
             attempts = 1,
             errorType = "RuntimeException",
-            errorReason = "Transient failure in sync"
+            errorReason = "Transient failure in sync",
         )
-        val contactQueued = createJobExecution(
+        val contactQueuedId = TestHelper.createJobExecution(
             jobType = "contact.sync-${System.currentTimeMillis()}",
-            status = JobExecutionStatus.QUEUED,
-            attempts = 2
+            status = "QUEUED",
+            attempts = 2,
+            startedAt = null,
+            finishedAt = null,
         )
-        val emailSuccess = createJobExecution(
+        val emailSuccessId = TestHelper.createJobExecution(
             jobType = "email.recovery-${System.currentTimeMillis()}",
-            status = JobExecutionStatus.SUCCESS,
-            attempts = 1
+            status = "SUCCESS",
+            attempts = 1,
         )
-        val calendarFailedId = checkNotNull(calendarFailed.id) { "Expected calendar failed execution id" }
-        val contactQueuedId = checkNotNull(contactQueued.id) { "Expected contact queued execution id" }
-        val emailSuccessId = checkNotNull(emailSuccess.id) { "Expected email success execution id" }
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, admin.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, admin.username, admin.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            val initialListResponse = page.waitForResponse(
-                Predicate { response ->
-                    response.request().method() == "GET" &&
-                        response.url().contains("/management/jobs")
-                }
-            ) {
-                page.navigate("$frontendUrl/management/jobs")
-            }
-            assertThat(initialListResponse.status()).isEqualTo(200)
-            waitFor(
-                onTimeoutMessage = {
-                    "Expected created job rows to be visible before applying filters"
-                }
-            ) {
-                hasJobRow(page, calendarFailedId) &&
-                    hasJobRow(page, contactQueuedId) &&
-                    hasJobRow(page, emailSuccessId)
-            }
-
-            val categoryResponse = page.waitForResponse(
-                Predicate { response ->
-                    response.request().method() == "GET" &&
-                        response.url().contains("/management/jobs") &&
-                        response.url().contains("category=calendar")
-                }
-            ) {
-                selectCategoryFilter(page, "calendar")
-            }
-            assertThat(categoryResponse.status()).isEqualTo(200)
-            val categoryParams = queryParams(categoryResponse.url())
-            assertThat(categoryParams["category"]).contains("calendar")
-            waitFor(
-                onTimeoutMessage = {
-                    "Expected only calendar rows to remain after category filter"
-                }
-            ) {
-                hasJobRow(page, calendarFailedId) &&
-                    !hasJobRow(page, contactQueuedId) &&
-                    !hasJobRow(page, emailSuccessId)
-            }
-
-            val statusResponse = page.waitForResponse(
-                Predicate { response ->
-                    response.request().method() == "GET" &&
-                        response.url().contains("/management/jobs") &&
-                        response.url().contains("status=FAILED")
-                }
-            ) {
-                selectStatusFilter(page, "failed")
-            }
-            assertThat(statusResponse.status()).isEqualTo(200)
-            val statusParams = queryParams(statusResponse.url())
-            assertThat(statusParams["category"]).contains("calendar")
-            assertThat(statusParams["status"]).contains("FAILED")
-            waitFor(
-                onTimeoutMessage = {
-                    "Expected only failed calendar row to remain after status filter"
-                }
-            ) {
-                hasJobRow(page, calendarFailedId) &&
-                    !hasJobRow(page, contactQueuedId) &&
-                    !hasJobRow(page, emailSuccessId)
-            }
-
-            val searchResponse = page.waitForResponse(
-                Predicate { response ->
-                    response.request().method() == "GET" &&
-                        response.url().contains("/management/jobs") &&
-                        response.url().contains("search=")
-                }
-            ) {
-                page.locator("[data-testid='job-filter-search'] input").first().fill("Transient failure")
-            }
-            assertThat(searchResponse.status()).isEqualTo(200)
-            val searchParams = queryParams(searchResponse.url())
-            assertThat(searchParams["category"]).contains("calendar")
-            assertThat(searchParams["status"]).contains("FAILED")
-            assertThat(searchParams["search"]).contains("Transient failure")
-            waitFor(
-                onTimeoutMessage = {
-                    "Expected search filter to keep matching failed calendar row only"
-                }
-            ) {
-                hasJobRow(page, calendarFailedId) &&
-                    !hasJobRow(page, contactQueuedId) &&
-                    !hasJobRow(page, emailSuccessId)
-            }
+        val initialListResponse = page.waitForResponse(
+            Predicate { response ->
+                response.request().method() == "GET" &&
+                    response.url().contains("/management/jobs")
+            },
+        ) {
+            page.navigate("$frontendUrl/management/jobs")
         }
+        assertThat(initialListResponse.status()).isEqualTo(200)
+        waitForRows(page, calendarFailedId, contactQueuedId, emailSuccessId)
+
+        val categoryResponse = page.waitForResponse(
+            Predicate { response ->
+                response.request().method() == "GET" &&
+                    response.url().contains("/management/jobs") &&
+                    response.url().contains("category=calendar")
+            },
+        ) {
+            selectCategoryFilter(page, "calendar")
+        }
+        assertThat(categoryResponse.status()).isEqualTo(200)
+        val categoryParams = queryParams(categoryResponse.url())
+        assertThat(categoryParams["category"]).contains("calendar")
+        waitForOnlyCalendar(page, calendarFailedId, contactQueuedId, emailSuccessId)
+
+        val statusResponse = page.waitForResponse(
+            Predicate { response ->
+                response.request().method() == "GET" &&
+                    response.url().contains("/management/jobs") &&
+                    response.url().contains("status=FAILED")
+            },
+        ) {
+            selectStatusFilter(page, "failed")
+        }
+        assertThat(statusResponse.status()).isEqualTo(200)
+        val statusParams = queryParams(statusResponse.url())
+        assertThat(statusParams["category"]).contains("calendar")
+        assertThat(statusParams["status"]).contains("FAILED")
+        waitForOnlyCalendar(page, calendarFailedId, contactQueuedId, emailSuccessId)
+
+        val searchResponse = page.waitForResponse(
+            Predicate { response ->
+                response.request().method() == "GET" &&
+                    response.url().contains("/management/jobs") &&
+                    response.url().contains("search=")
+            },
+        ) {
+            page.locator("[data-testid='job-filter-search'] input").first().fill("Transient failure")
+        }
+        assertThat(searchResponse.status()).isEqualTo(200)
+        val searchParams = queryParams(searchResponse.url())
+        assertThat(searchParams["category"]).contains("calendar")
+        assertThat(searchParams["status"]).contains("FAILED")
+        assertThat(searchParams["search"]).contains("Transient failure")
+        waitForOnlyCalendar(page, calendarFailedId, contactQueuedId, emailSuccessId)
     }
 
-    private fun createJobExecution(
-        jobType: String,
-        status: JobExecutionStatus,
-        attempts: Int,
-        errorType: String? = null,
-        errorReason: String? = null
-    ): JobExecution {
-        val execution = jobExecutionFactory.create(jobType = jobType)
-        execution.status = status
-        execution.attempts = attempts
-        execution.queuedAt = Instant.now().minusSeconds(600)
-        execution.startedAt = if (status != JobExecutionStatus.QUEUED) Instant.now().minusSeconds(300) else null
-        execution.finishedAt = if (status == JobExecutionStatus.SUCCESS || status == JobExecutionStatus.FAILED) {
-            Instant.now().minusSeconds(120)
-        } else {
-            null
+    private fun waitForJob(id: Long, predicate: (TestHelper.JobExecutionRow) -> Boolean) {
+        val deadline = System.currentTimeMillis() + 30_000
+        while (System.currentTimeMillis() < deadline) {
+            val row = TestHelper.findJobExecution(id)
+            if (row != null && predicate(row)) return
+            Thread.sleep(200)
         }
-        execution.errorType = errorType
-        execution.errorReason = errorReason
-        execution.errorMessage = if (errorType != null && errorReason != null) "$errorType: $errorReason" else null
-        return jobExecutionRepository.saveAndFlush(execution)
+        throw AssertionError(
+            "Expected job execution $id to satisfy predicate within 30s; last row=${TestHelper.findJobExecution(id)}",
+        )
+    }
+
+    private fun waitForRows(page: Page, vararg ids: Long) {
+        val deadline = System.currentTimeMillis() + 10_000
+        while (System.currentTimeMillis() < deadline) {
+            if (ids.all { hasJobRow(page, it) }) return
+            Thread.sleep(200)
+        }
+        throw AssertionError("Expected rows ${ids.toList()} to be visible within 10s")
+    }
+
+    private fun waitForOnlyCalendar(page: Page, calendarId: Long, contactId: Long, emailId: Long) {
+        val deadline = System.currentTimeMillis() + 10_000
+        while (System.currentTimeMillis() < deadline) {
+            if (hasJobRow(page, calendarId) &&
+                !hasJobRow(page, contactId) &&
+                !hasJobRow(page, emailId)
+            ) {
+                return
+            }
+            Thread.sleep(200)
+        }
+        throw AssertionError("Expected calendar row $calendarId only after filter; others should be hidden")
     }
 
     private fun selectCategoryFilter(page: Page, category: String) {
@@ -268,9 +240,5 @@ class JobManagerPageSystemTest : FrontendSystemTestBase() {
 
     private fun hasJobRow(page: Page, id: Long): Boolean {
         return page.locator("[data-testid='job-row-$id']").count() > 0
-    }
-
-    private companion object {
-        const val DEFAULT_PASSWORD = "Password123!"
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -416,12 +416,16 @@ object TestHelper {
         startedAt: java.time.Instant? = java.time.Instant.now().minusSeconds(300),
         finishedAt: java.time.Instant? = java.time.Instant.now().minusSeconds(120),
         attempts: Int = 1,
+        errorType: String? = null,
+        errorReason: String? = null,
     ): Long {
+        val errorMessage = if (errorType != null && errorReason != null) "$errorType: $errorReason" else null
         DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
             return conn.prepareStatement(
-                "INSERT INTO job_executions (job_type, status, attempts, queued_at, started_at, finished_at, " +
-                    "initiated_by_type, initiated_by_role) " +
-                    "VALUES (?, ?, ?, ?, ?, ?, 'SYSTEM', 'ADMIN')",
+                "INSERT INTO job_executions " +
+                    "(job_type, status, attempts, queued_at, started_at, finished_at, " +
+                    "error_type, error_reason, error_message, initiated_by_type, initiated_by_role) " +
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'SYSTEM', 'ADMIN')",
                 java.sql.Statement.RETURN_GENERATED_KEYS,
             ).use { stmt ->
                 stmt.setString(1, jobType)
@@ -430,6 +434,9 @@ object TestHelper {
                 stmt.setTimestamp(4, java.sql.Timestamp.from(queuedAt))
                 stmt.setTimestamp(5, startedAt?.let { java.sql.Timestamp.from(it) })
                 stmt.setTimestamp(6, finishedAt?.let { java.sql.Timestamp.from(it) })
+                stmt.setString(7, errorType)
+                stmt.setString(8, errorReason)
+                stmt.setString(9, errorMessage)
                 stmt.executeUpdate()
                 val keys = stmt.generatedKeys
                 require(keys.next()) { "INSERT job_executions produced no id" }
@@ -437,6 +444,36 @@ object TestHelper {
             }
         }
     }
+
+    /**
+     * Read a `job_executions` row back by id. Returns null when the
+     * row does not exist. Used by tests that previously polled
+     * `jobExecutionRepository.findById(id)` to verify the retry
+     * pipeline mutated `status` / `queued_at`.
+     */
+    fun findJobExecution(id: Long): JobExecutionRow? =
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            conn.prepareStatement(
+                "SELECT id, job_type, status, attempts, queued_at, started_at, finished_at " +
+                    "FROM job_executions WHERE id = ?",
+            ).use { stmt ->
+                stmt.setLong(1, id)
+                val rs = stmt.executeQuery()
+                if (rs.next()) {
+                    JobExecutionRow(
+                        id = rs.getLong("id"),
+                        jobType = rs.getString("job_type"),
+                        status = rs.getString("status"),
+                        attempts = rs.getInt("attempts"),
+                        queuedAt = rs.getTimestamp("queued_at")?.toInstant(),
+                        startedAt = rs.getTimestamp("started_at")?.toInstant(),
+                        finishedAt = rs.getTimestamp("finished_at")?.toInstant(),
+                    )
+                } else {
+                    null
+                }
+            }
+        }
 
     /**
      * Attach a `member_profiles` row to a user via `POST /memberProfiles`.
@@ -533,6 +570,16 @@ object TestHelper {
         val enabled: Boolean,
         val discord: String?,
         val phoneNumber: String?,
+    )
+
+    data class JobExecutionRow(
+        val id: Long,
+        val jobType: String,
+        val status: String,
+        val attempts: Int,
+        val queuedAt: java.time.Instant?,
+        val startedAt: java.time.Instant?,
+        val finishedAt: java.time.Instant?,
     )
 
     data class AddressRow(


### PR DESCRIPTION
## Why

`JobManagerPageSystemTest` was still extending `FrontendSystemTestBase` and pulled `UserFactory`, `JobExecutionFactory`, and `JobExecutionRepository` in via `@Autowired`. Setup minted job-execution rows through `jobExecutionFactory.create(...).apply { ... }.let(repository::saveAndFlush)` and the retry assertion polled `jobExecutionRepository.findById(...)` to confirm the pipeline mutated `status` / `queued_at`. Both keep the test bolted to the api's classpath.

## What this achieves

`JobManagerPageSystemTest` runs through HTTP and JDBC via `TestHelper`. The Spring context still hosts the api in-process from the standard four-annotation bootstrap; the test body never injects a bean and never imports `JobExecutionStatus`.

## How

- **`TestHelper.createJobExecution`** gains `errorType` and `errorReason` parameters. The combination produces `error_message = "$type: $reason"`, matching what the previous in-class helper wrote.

- **`TestHelper.findJobExecution(id): JobExecutionRow?`** replaces the repository read with a plain `SELECT id, job_type, status, attempts, queued_at, started_at, finished_at FROM job_executions WHERE id = ?`. `JobExecutionRow` is a small read-only record so the test does not have to import the `JobExecution` entity.

- **`JobManagerPageSystemTest`** extends `PlaywrightTestBase`, mints the admin through `registerActivateAndPromote("ADMIN")`, calls `clearJobExecutions()` after registration so the auto-dispatched contact-sync / activation-email rows do not appear in the manager table or trip the seeded-row count assertions, and polls `findJobExecution(id)` for the post-retry status transition. `waitFor { locator.count() > 0 }` polls collapse to `locator(...).first().waitFor()` for single-row assertions; multi-row filter checks use small `waitForRows` / `waitForOnlyCalendar` helpers.