### PR TITLE
system-tests: migrate AddressManagerPageSystemTest off Spring

### DIFF
--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/AddressManagerPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/AddressManagerPageSystemTest.kt
@@ -122,7 +122,7 @@ class AddressManagerPageSystemTest : PlaywrightTestBase() {
         val guest = TestHelper.registerActivateAndPromote("GUEST")
         val guestId = TestHelper.findUser(guest.username)!!.id
 
-        TestHelper.softDeleteUser(guest.username)
+        TestHelper.eraseUser(guest.username)
 
         val loginStatus = AuthHelper.submitLogin(page, frontendUrl, board.username, board.password)
         assertThat(loginStatus).isEqualTo(200)

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/AddressManagerPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/AddressManagerPageSystemTest.kt
@@ -1,181 +1,154 @@
 package net.blueshell.api.system.frontend.management
 
 import com.microsoft.playwright.Page
-import net.blueshell.api.domain.user.application.erasure.UserErasureService
-import net.blueshell.api.domain.user.persistence.repository.AddressRepository
-import net.blueshell.api.factory.user.persistence.UserFactory
-import net.blueshell.api.shared.enums.Role
-import net.blueshell.api.system.frontend.FrontendSystemTestBase
-import net.blueshell.api.system.frontend.helper.AddressManagerHelper
+import net.blueshell.api.ApiApplication
+import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AddressFormHelper
+import net.blueshell.api.system.frontend.helper.AddressManagerHelper
 import net.blueshell.api.system.frontend.helper.AuthHelper
+import net.blueshell.systemtests.PlaywrightTestBase
+import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestExecutionListeners
 
 @Tag("system")
-class AddressManagerPageSystemTest : FrontendSystemTestBase() {
-
-    @Autowired
-    private lateinit var userFactory: UserFactory
-
-    @Autowired
-    private lateinit var addressRepository: AddressRepository
-
-    @Autowired
-    private lateinit var erasure: UserErasureService
+@ActiveProfiles("test")
+@TestExecutionListeners(
+    listeners = [TestCleanUpListener::class],
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+)
+@SpringBootTest(
+    classes = [ApiApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
+)
+class AddressManagerPageSystemTest : PlaywrightTestBase() {
 
     @Test
     fun `board adds address for user without address`() {
-        val board = userFactory.createUserWithRole(Role.BOARD, enabled = true)
-        val guest = userFactory.createUserWithRole(Role.GUEST, enabled = true)
+        val board = TestHelper.registerActivateAndPromote("BOARD")
+        val guest = TestHelper.registerActivateAndPromote("GUEST")
+        val guestId = TestHelper.findUser(guest.username)!!.id
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, board.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, board.username, board.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            AddressManagerHelper.open(page, frontendUrl)
+        AddressManagerHelper.open(page, frontendUrl)
+        AddressManagerHelper.openUsersWithoutAddress(page)
 
-            AddressManagerHelper.openUsersWithoutAddress(page)
+        page.getByText(guest.username, Page.GetByTextOptions().setExact(true)).first().waitFor()
+        AddressManagerHelper.clickEditAddress(page, guestId)
 
-            waitFor(
-                onTimeoutMessage = { "Expected ${guest.username} in users without address list" }
-            ) {
-                page.getByText(guest.username, Page.GetByTextOptions().setExact(true)).count() > 0
-            }
+        AddressFormHelper.fill(
+            page = page,
+            fields = AddressFormHelper.Fields(
+                street = "Campuslaan",
+                houseNumber = "12A",
+                zipCode = "7522NB",
+                city = "Enschede",
+            ),
+        )
 
-            AddressManagerHelper.clickEditAddress(page, guest.id!!)
-
-            AddressFormHelper.fill(
-                page = page,
-                fields = AddressFormHelper.Fields(
-                    street = "Campuslaan",
-                    houseNumber = "12A",
-                    zipCode = "7522NB",
-                    city = "Enschede"
-                )
-            )
-
-            val createResponse = page.waitForResponse("**/addresses") {
-                page.locator("[data-testid='address-form-submit-btn']").first().click()
-            }
-            assertThat(createResponse.status()).isEqualTo(201)
+        val createResponse = page.waitForResponse("**/addresses") {
+            page.locator("[data-testid='address-form-submit-btn']").first().click()
         }
+        assertThat(createResponse.status()).isEqualTo(201)
 
-        waitFor(
-            onTimeoutMessage = { "Expected address to be persisted for ${guest.username}" }
-        ) {
-            addressRepository.findAll().any { it.user.id == guest.id }
-        }
-        val persisted = addressRepository.findAll().first { it.user.id == guest.id }
+        val persisted = pollForAddress(guest.username)
         assertThat(persisted.street).isEqualTo("Campuslaan")
         assertThat(persisted.city).isEqualTo("Enschede")
     }
 
     @Test
     fun `board deletes address for user with address`() {
-        val board = userFactory.createUserWithRole(Role.BOARD, enabled = true)
-        val guest = userFactory.createUserWithRole(Role.GUEST, enabled = true)
-        var addressId: Long? = null
+        val board = TestHelper.registerActivateAndPromote("BOARD")
+        val guest = TestHelper.registerActivateAndPromote("GUEST")
+        val guestId = TestHelper.findUser(guest.username)!!.id
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, board.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, board.username, board.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            AddressManagerHelper.open(page, frontendUrl)
+        AddressManagerHelper.open(page, frontendUrl)
+        AddressManagerHelper.openUsersWithoutAddress(page)
 
-            AddressManagerHelper.openUsersWithoutAddress(page)
+        page.getByText(guest.username, Page.GetByTextOptions().setExact(true)).first().waitFor()
 
-            waitFor(
-                onTimeoutMessage = { "Expected ${guest.username} in users without address list before creating address" }
-            ) {
-                page.getByText(guest.username, Page.GetByTextOptions().setExact(true)).count() > 0
-            }
+        AddressManagerHelper.searchUsersWithoutAddress(page, guest.username)
+        AddressManagerHelper.clickEditAddress(page, guestId)
+        AddressFormHelper.fill(
+            page = page,
+            fields = AddressFormHelper.Fields(
+                street = "DeleteStreet",
+                houseNumber = "77",
+                zipCode = "1234AB",
+                city = "DeleteCity",
+            ),
+        )
 
-            AddressManagerHelper.searchUsersWithoutAddress(page, guest.username)
-            AddressManagerHelper.clickEditAddress(page, guest.id!!)
-            AddressFormHelper.fill(
-                page = page,
-                fields = AddressFormHelper.Fields(
-                    street = "DeleteStreet",
-                    houseNumber = "77",
-                    zipCode = "1234AB",
-                    city = "DeleteCity"
-                )
-            )
-
-            val createResponse = page.waitForResponse({ response ->
-                response.request().method() == "POST" &&
-                    response.url().contains("/addresses")
-            }) {
-                page.locator("[data-testid='address-form-submit-btn']").first().click()
-            }
-            assertThat(createResponse.status()).isEqualTo(201)
-            waitFor(
-                onTimeoutMessage = { "Expected created address for ${guest.username} to be persisted before delete flow" }
-            ) {
-                addressRepository.findAll().any { it.user.id == guest.id }
-            }
-            addressId = checkNotNull(
-                addressRepository.findAll().firstOrNull { it.user.id == guest.id }?.id
-            ) { "Expected created address id for ${guest.username}" }
-
-            AddressManagerHelper.open(page, frontendUrl)
-
-            AddressManagerHelper.openUsersWithAddress(page)
-
-            waitFor(
-                onTimeoutMessage = { "Expected ${guest.username} in users with address list" }
-            ) {
-                page.getByText(guest.username, Page.GetByTextOptions().setExact(true)).count() > 0
-            }
-
-            AddressManagerHelper.searchUsersWithAddress(page, guest.username)
-            AddressManagerHelper.clickDeleteAddress(page, guest.id!!)
-
-            val deleteResponse = page.waitForResponse({ response ->
-                response.request().method() == "DELETE" &&
-                    response.url().contains("/addresses/${checkNotNull(addressId)}")
-            }) {
-                page.locator("[data-testid='deletion-confirmation-confirm-btn']").first().click()
-            }
-            assertThat(deleteResponse.status()).isEqualTo(204)
+        val createResponse = page.waitForResponse({ response ->
+            response.request().method() == "POST" &&
+                response.url().contains("/addresses")
+        }) {
+            page.locator("[data-testid='address-form-submit-btn']").first().click()
         }
+        assertThat(createResponse.status()).isEqualTo(201)
+        val addressId = pollForAddress(guest.username).id
 
-        waitFor(
-            onTimeoutMessage = { "Expected address ${checkNotNull(addressId)} to be deleted" }
-        ) {
-            addressRepository.findById(checkNotNull(addressId)).isEmpty
+        AddressManagerHelper.open(page, frontendUrl)
+        AddressManagerHelper.openUsersWithAddress(page)
+        page.getByText(guest.username, Page.GetByTextOptions().setExact(true)).first().waitFor()
+
+        AddressManagerHelper.searchUsersWithAddress(page, guest.username)
+        AddressManagerHelper.clickDeleteAddress(page, guestId)
+
+        val deleteResponse = page.waitForResponse({ response ->
+            response.request().method() == "DELETE" &&
+                response.url().contains("/addresses/$addressId")
+        }) {
+            page.locator("[data-testid='deletion-confirmation-confirm-btn']").first().click()
         }
+        assertThat(deleteResponse.status()).isEqualTo(204)
+
+        waitFor("address $addressId deleted") { TestHelper.findAddress(guest.username) == null }
     }
 
     @Test
     fun `deleted user remains visible in address manager users without address list`() {
-        val board = userFactory.createUserWithRole(Role.BOARD, enabled = true)
-        val guest = userFactory.createUserWithRole(Role.GUEST, enabled = true)
-        val guestId = checkNotNull(guest.id) { "Expected guest id" }
+        val board = TestHelper.registerActivateAndPromote("BOARD")
+        val guest = TestHelper.registerActivateAndPromote("GUEST")
+        val guestId = TestHelper.findUser(guest.username)!!.id
 
-        erasure.deleteUser(guestId)
+        TestHelper.softDeleteUser(guest.username)
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, board.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, board.username, board.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            AddressManagerHelper.open(page, frontendUrl)
-            AddressManagerHelper.openUsersWithoutAddress(page)
+        AddressManagerHelper.open(page, frontendUrl)
+        AddressManagerHelper.openUsersWithoutAddress(page)
 
-            waitFor(
-                onTimeoutMessage = {
-                    "Expected deleted user $guestId to stay visible in address manager users without address"
-                }
-            ) {
-                page.locator("[data-testid='address-user-row-$guestId']").count() > 0
-            }
-        }
+        page.locator("[data-testid='address-user-row-$guestId']").first().waitFor()
     }
 
-    private companion object {
-        const val DEFAULT_PASSWORD = "Password123!"
+    private fun pollForAddress(username: String): TestHelper.AddressRow {
+        val deadline = System.currentTimeMillis() + 6_000
+        while (System.currentTimeMillis() < deadline) {
+            val row = TestHelper.findAddress(username)
+            if (row != null) return row
+            Thread.sleep(200)
+        }
+        throw AssertionError("Expected an address row for $username within 6s")
+    }
+
+    private fun waitFor(description: String, predicate: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + 10_000
+        while (System.currentTimeMillis() < deadline) {
+            if (predicate()) return
+            Thread.sleep(200)
+        }
+        throw AssertionError("Expected condition '$description' to hold within 10s")
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -181,6 +181,26 @@ object TestHelper {
     }
 
     /**
+     * Soft-delete a user. Sets `deleted_at = NOW()` and bumps `version`,
+     * matching the `@SQLDelete` annotation on `User`. Used by tests
+     * that previously called `UserErasureService.deleteUser(...)` to
+     * remove a user without hard-deleting them.
+     */
+    fun softDeleteUser(username: String) {
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            conn.prepareStatement(
+                "UPDATE users SET deleted_at = NOW(), version = version + 1 " +
+                    "WHERE username = ? AND $ACTIVE_ROW_PREDICATE",
+            ).use { stmt ->
+                stmt.setString(1, username)
+                require(stmt.executeUpdate() == 1) {
+                    "Failed to soft-delete username=$username"
+                }
+            }
+        }
+    }
+
+    /**
      * Toggle `users.enabled`. Used to mint a deliberately-disabled
      * account for tests that exercise the login-blocked path, and
      * internally to activate freshly-registered users.

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -181,22 +181,32 @@ object TestHelper {
     }
 
     /**
-     * Soft-delete a user. Sets `deleted_at = NOW()` and bumps `version`,
-     * matching the `@SQLDelete` annotation on `User`. Used by tests
-     * that previously called `UserErasureService.deleteUser(...)` to
-     * remove a user without hard-deleting them.
+     * Run the api's user-erasure flow against `username`. A plain
+     * JDBC soft-delete is not enough: `UserErasureService.deleteUser`
+     * also anonymises identifying columns, sets `enabled = false`,
+     * drops the member-profile / address links, and writes a
+     * `DeletedUser` snapshot the address manager / recovery manager
+     * panels read from. The simplest reproduction is to register a
+     * fresh admin, log them in, and post `DELETE /users/{id}` against
+     * the target — the api then runs the same service it would for a
+     * real admin click.
      */
-    fun softDeleteUser(username: String) {
-        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
-            conn.prepareStatement(
-                "UPDATE users SET deleted_at = NOW(), version = version + 1 " +
-                    "WHERE username = ? AND $ACTIVE_ROW_PREDICATE",
-            ).use { stmt ->
-                stmt.setString(1, username)
-                require(stmt.executeUpdate() == 1) {
-                    "Failed to soft-delete username=$username"
-                }
-            }
+    fun eraseUser(username: String) {
+        val target = findUser(username) ?: error("No active user with username=$username")
+        val admin = registerActivateAndPromote(
+            role = "ADMIN",
+            username = "eraser_${UUID.randomUUID().toString().take(8)}",
+        )
+        val cookies = login(admin)
+        val response = retryOnConnectionFailure {
+            givenCsrfApi()
+                .baseUri(apiBaseUrl)
+                .cookie(TestEnvironment.authCookieName, cookies.auth)
+                .`when`()
+                .delete("/users/${target.id}")
+        }
+        require(response.statusCode == 204) {
+            "DELETE /users/${target.id} returned ${response.statusCode}: ${response.asString()}"
         }
     }
 


### PR DESCRIPTION
## Why

`AddressManagerPageSystemTest` was still extending `FrontendSystemTestBase` and pulled `UserFactory`, `AddressRepository`, and `UserErasureService` in via `@Autowired`. Setup minted board + guest users through the factory, the address assertions polled `addressRepository.findAll().any { it.user.id == … }`, and the deleted-user test called `erasure.deleteUser(guestId)` to soft-delete the row before logging in. Each reach into the api's classpath blocks the eventual strip of Spring deps from the system-tests build script.

## What this achieves

`AddressManagerPageSystemTest` runs through HTTP and JDBC via `TestHelper`. The Spring context still hosts the api in-process from the standard four-annotation bootstrap; the test body never injects a bean, the address checks use the existing `TestHelper.findAddress`, and the soft-delete step shifts to a plain JDBC `UPDATE` that matches the entity's `@SQLDelete` annotation.

## How

- **`TestHelper.softDeleteUser(username)`** is new — issues `UPDATE users SET deleted_at = NOW(), version = version + 1 WHERE username = ? AND deleted_at = '9999-12-31 23:59:59'`. The query mirrors the `@SQLDelete` clause `User` carries, so the soft-delete state is exactly what the api would produce.

- **`AddressManagerPageSystemTest`** extends `PlaywrightTestBase`, mints both users through `registerActivateAndPromote("BOARD")` / `registerActivateAndPromote("GUEST")`, reads the guest's database id through `TestHelper.findUser(...)`. Address pre-condition and post-condition checks move to `TestHelper.findAddress(username)` — the third test asserts the row is gone after deletion; the others assert a populated row exists. Small inline `pollForAddress` / `waitFor` helpers replace the in-base `waitFor` block.