### PR TITLE
system-tests: migrate ContributionManagerPageSystemTest off Spring

### DIFF
--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/ContributionManagerPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/ContributionManagerPageSystemTest.kt
@@ -1,45 +1,41 @@
 package net.blueshell.api.system.frontend.management
 
 import com.microsoft.playwright.Page
-import net.blueshell.api.domain.contribution.persistence.Contribution
-import net.blueshell.api.domain.contribution.persistence.ContributionPeriod
-import net.blueshell.api.domain.contribution.persistence.repository.ContributionRepository
-import net.blueshell.api.domain.user.application.erasure.UserErasureService
-import net.blueshell.api.factory.contribution.persistence.ContributionFactory
-import net.blueshell.api.factory.user.persistence.UserFactory
-import net.blueshell.api.shared.enums.Role
-import net.blueshell.api.system.frontend.FrontendSystemTestBase
+import net.blueshell.api.ApiApplication
+import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.ContributionManagerHelper
 import net.blueshell.api.system.frontend.helper.ContributionPeriodHelper
+import net.blueshell.systemtests.PlaywrightTestBase
+import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestExecutionListeners
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 @Tag("system")
-class ContributionManagerPageSystemTest : FrontendSystemTestBase() {
-
-    @Autowired
-    private lateinit var userFactory: UserFactory
-
-    @Autowired
-    private lateinit var contributionFactory: ContributionFactory
-
-    @Autowired
-    private lateinit var contributionRepository: ContributionRepository
-
-    @Autowired
-    private lateinit var erasure: UserErasureService
+@ActiveProfiles("test")
+@TestExecutionListeners(
+    listeners = [TestCleanUpListener::class],
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+)
+@SpringBootTest(
+    classes = [ApiApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
+)
+class ContributionManagerPageSystemTest : PlaywrightTestBase() {
 
     @Test
     fun `board adds period and switches paid status between periods`() {
-        val board = userFactory.createUserWithRole(Role.BOARD, enabled = true)
-        val member = userFactory.createUserWithRole(Role.MEMBER, enabled = true)
-        val memberId = checkNotNull(member.id) { "Expected member id" }
-        userFactory.createMembership(member)
+        val board = TestHelper.registerActivateAndPromote("BOARD")
+        val member = TestHelper.registerActivateAndPromote("MEMBER")
+        TestHelper.attachMembership(member.username)
+        val memberId = TestHelper.findUser(member.username)!!.id
 
         val uniqueOffset = System.currentTimeMillis() % 10_000
         val initialStartDate = LocalDate.now().minusDays(300L + uniqueOffset)
@@ -47,194 +43,128 @@ class ContributionManagerPageSystemTest : FrontendSystemTestBase() {
         val addedStartDate = LocalDate.now().plusDays(300L + uniqueOffset)
         val addedEndDate = addedStartDate.plusDays(30)
 
-        val initialPeriod = contributionFactory.createPeriod(initialStartDate, initialEndDate)
-        contributionRepository.saveAndFlush(
-            Contribution(
-                user = member,
-                contributionPeriod = initialPeriod
-            )
-        )
+        val initialPeriodId = TestHelper.createContributionPeriod(initialStartDate, initialEndDate)
+        TestHelper.createContribution(initialPeriodId, member.username)
 
         val initialPeriodLabel = ContributionPeriodHelper.label(initialStartDate, initialEndDate)
         val addedPeriodLabel = ContributionPeriodHelper.label(addedStartDate, addedEndDate)
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, board.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, board.username, board.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            ContributionManagerHelper.open(page, frontendUrl)
-            waitFor(
-                onTimeoutMessage = { "Expected contribution period '$initialPeriodLabel' to be visible" }
-            ) {
-                page.getByText(initialPeriodLabel, Page.GetByTextOptions().setExact(false)).count() > 0
-            }
+        ContributionManagerHelper.open(page, frontendUrl)
+        page.getByText(initialPeriodLabel, Page.GetByTextOptions().setExact(false)).first().waitFor()
 
-            val addStatus = ContributionPeriodHelper.createPeriod(page, addedStartDate, addedEndDate)
-            assertThat(addStatus).isEqualTo(201)
-            waitFor(
-                onTimeoutMessage = { "Expected added contribution period '$addedPeriodLabel' to be visible" }
-            ) {
-                page.getByText(addedPeriodLabel, Page.GetByTextOptions().setExact(false)).count() > 0
-            }
+        val addStatus = ContributionPeriodHelper.createPeriod(page, addedStartDate, addedEndDate)
+        assertThat(addStatus).isEqualTo(201)
+        page.getByText(addedPeriodLabel, Page.GetByTextOptions().setExact(false)).first().waitFor()
 
-            ContributionManagerHelper.selectPeriod(page, initialPeriodLabel)
-            ContributionManagerHelper.openSection(page, "paid")
-            waitFor(
-                onTimeoutMessage = { "Expected ${member.username} to be paid in initial period" }
-            ) {
-                page.getByText(member.username, Page.GetByTextOptions().setExact(true)).count() > 0
-            }
-            waitFor(
-                onTimeoutMessage = { "Expected mark unpaid action for ${member.username} in initial period" }
-            ) {
-                page.locator(
-                    "[data-testid='contribution-user-toggle-paid-btn-$memberId'][data-contribution-action='mark-unpaid']"
-                ).count() > 0
-            }
+        ContributionManagerHelper.selectPeriod(page, initialPeriodLabel)
+        ContributionManagerHelper.openSection(page, "paid")
+        page.getByText(member.username, Page.GetByTextOptions().setExact(true)).first().waitFor()
+        page.locator(
+            "[data-testid='contribution-user-toggle-paid-btn-$memberId'][data-contribution-action='mark-unpaid']",
+        ).first().waitFor()
 
-            ContributionManagerHelper.selectPeriod(page, addedPeriodLabel)
-            ContributionManagerHelper.openSection(page, "unpaid")
-            waitFor(
-                onTimeoutMessage = { "Expected ${member.username} to be unpaid in added period" }
-            ) {
-                page.getByText(member.username, Page.GetByTextOptions().setExact(true)).count() > 0
-            }
-            waitFor(
-                onTimeoutMessage = { "Expected mark paid action for ${member.username} in added period" }
-            ) {
-                page.locator(
-                    "[data-testid='contribution-user-toggle-paid-btn-$memberId'][data-contribution-action='mark-paid']"
-                ).count() > 0
-            }
-        }
+        ContributionManagerHelper.selectPeriod(page, addedPeriodLabel)
+        ContributionManagerHelper.openSection(page, "unpaid")
+        page.getByText(member.username, Page.GetByTextOptions().setExact(true)).first().waitFor()
+        page.locator(
+            "[data-testid='contribution-user-toggle-paid-btn-$memberId'][data-contribution-action='mark-paid']",
+        ).first().waitFor()
     }
 
     @Test
     fun `board marks contribution paid and unpaid`() {
-        val board = userFactory.createUserWithRole(Role.BOARD, enabled = true)
-        val member = userFactory.createUserWithRole(Role.MEMBER, enabled = true)
-        userFactory.createMembership(member)
+        val board = TestHelper.registerActivateAndPromote("BOARD")
+        val member = TestHelper.registerActivateAndPromote("MEMBER")
+        TestHelper.attachMembership(member.username)
+        val memberId = TestHelper.findUser(member.username)!!.id
 
-        val (startDate, endDate, period) = createFuturePeriod()
-        val periodId = checkNotNull(period.id) { "Expected contribution period id" }
+        val (startDate, endDate, periodId) = createFuturePeriod()
         val periodLabel = "${startDate.format(FORMATTER)} - ${endDate.format(FORMATTER)}"
-        val memberId = checkNotNull(member.id) { "Expected member id" }
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, board.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, board.username, board.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            ContributionManagerHelper.open(page, frontendUrl)
+        ContributionManagerHelper.open(page, frontendUrl)
+        page.getByText(periodLabel, Page.GetByTextOptions().setExact(false)).first().waitFor()
+        ContributionManagerHelper.selectPeriod(page, periodLabel)
+        ContributionManagerHelper.openSection(page, "unpaid")
+        page.getByText(member.username, Page.GetByTextOptions().setExact(true)).first().waitFor()
 
-            waitFor(
-                onTimeoutMessage = { "Expected contribution period '$periodLabel' to be visible" }
-            ) {
-                page.getByText(periodLabel, Page.GetByTextOptions().setExact(false)).count() > 0
-            }
-            ContributionManagerHelper.selectPeriod(page, periodLabel)
+        ContributionManagerHelper.searchUser(page, "unpaid", member.username)
+        val markPaidResponse = page.waitForResponse({ response ->
+            response.request().method() == "POST" &&
+                response.url().contains("/contributions")
+        }) {
+            ContributionManagerHelper.togglePaidButton(page, memberId)
+        }
+        assertThat(markPaidResponse.status()).isEqualTo(201)
 
-            ContributionManagerHelper.openSection(page, "unpaid")
-
-            waitFor(
-                onTimeoutMessage = { "Expected ${member.username} in unpaid contribution list" }
-            ) {
-                page.getByText(member.username, Page.GetByTextOptions().setExact(true)).count() > 0
-            }
-
-            ContributionManagerHelper.searchUser(page, "unpaid", member.username)
-            val markPaidResponse = page.waitForResponse({ response ->
-                response.request().method() == "POST" &&
-                    response.url().contains("/contributions")
-            }) {
-                ContributionManagerHelper.togglePaidButton(page, memberId)
-            }
-            assertThat(markPaidResponse.status()).isEqualTo(201)
+        pollFor("contribution persisted for user=$memberId period=$periodId") {
+            memberId in TestHelper.findContributions(periodId)
         }
 
-        waitFor(
-            onTimeoutMessage = { "Expected contribution to be persisted for user $memberId and period $periodId" }
-        ) {
-            contributionRepository.findByIdContributionPeriodId(periodId).any { it.userId == memberId }
+        // Second page navigation: mark unpaid via DELETE.
+        page.navigate("$frontendUrl/")
+        AuthHelper.submitLogin(page, frontendUrl, board.username, board.password)
+        ContributionManagerHelper.open(page, frontendUrl)
+        page.getByText(periodLabel, Page.GetByTextOptions().setExact(false)).first().waitFor()
+        ContributionManagerHelper.selectPeriod(page, periodLabel)
+        ContributionManagerHelper.openSection(page, "paid")
+        page.getByText(member.username, Page.GetByTextOptions().setExact(true)).first().waitFor()
+
+        ContributionManagerHelper.searchUser(page, "paid", member.username)
+        val markUnpaidResponse = page.waitForResponse({ response ->
+            response.request().method() == "DELETE" &&
+                response.url().contains("/contributionPeriods/") &&
+                response.url().contains("/contributions")
+        }) {
+            ContributionManagerHelper.togglePaidButton(page, memberId)
         }
-
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, board.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
-
-            ContributionManagerHelper.open(page, frontendUrl)
-
-            waitFor(
-                onTimeoutMessage = { "Expected contribution period '$periodLabel' to be visible for unmark flow" }
-            ) {
-                page.getByText(periodLabel, Page.GetByTextOptions().setExact(false)).count() > 0
-            }
-            ContributionManagerHelper.selectPeriod(page, periodLabel)
-
-            ContributionManagerHelper.openSection(page, "paid")
-
-            waitFor(
-                onTimeoutMessage = { "Expected ${member.username} in paid contribution list" }
-            ) {
-                page.getByText(member.username, Page.GetByTextOptions().setExact(true)).count() > 0
-            }
-
-            ContributionManagerHelper.searchUser(page, "paid", member.username)
-            val markUnpaidResponse = page.waitForResponse({ response ->
-                response.request().method() == "DELETE" &&
-                    response.url().contains("/contributionPeriods/") &&
-                    response.url().contains("/contributions")
-            }) {
-                ContributionManagerHelper.togglePaidButton(page, memberId)
-            }
-            assertThat(markUnpaidResponse.status()).isEqualTo(204)
-        }
-
+        assertThat(markUnpaidResponse.status()).isEqualTo(204)
     }
 
     @Test
     fun `deleted member remains visible in contribution manager lists`() {
-        val board = userFactory.createUserWithRole(Role.BOARD, enabled = true)
-        val member = userFactory.createUserWithRole(Role.MEMBER, enabled = true)
-        userFactory.createMembership(member)
-        val memberId = checkNotNull(member.id) { "Expected member id" }
+        val board = TestHelper.registerActivateAndPromote("BOARD")
+        val member = TestHelper.registerActivateAndPromote("MEMBER")
+        TestHelper.attachMembership(member.username)
+        val memberId = TestHelper.findUser(member.username)!!.id
 
         val (startDate, endDate, _) = createFuturePeriod()
         val periodLabel = "${startDate.format(FORMATTER)} - ${endDate.format(FORMATTER)}"
 
-        erasure.deleteUser(memberId)
+        TestHelper.eraseUser(member.username)
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, board.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, board.username, board.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            ContributionManagerHelper.open(page, frontendUrl)
-            waitFor(
-                onTimeoutMessage = { "Expected contribution period '$periodLabel' to be visible" }
-            ) {
-                page.getByText(periodLabel, Page.GetByTextOptions().setExact(false)).count() > 0
-            }
-            ContributionManagerHelper.selectPeriod(page, periodLabel)
-            ContributionManagerHelper.openSection(page, "unpaid")
-
-            waitFor(
-                onTimeoutMessage = {
-                    "Expected deleted member $memberId to stay visible in contribution unpaid list as anonymized user"
-                }
-            ) {
-                page.locator("[data-testid='contribution-user-row-$memberId']").count() > 0
-            }
-        }
+        ContributionManagerHelper.open(page, frontendUrl)
+        page.getByText(periodLabel, Page.GetByTextOptions().setExact(false)).first().waitFor()
+        ContributionManagerHelper.selectPeriod(page, periodLabel)
+        ContributionManagerHelper.openSection(page, "unpaid")
+        page.locator("[data-testid='contribution-user-row-$memberId']").first().waitFor()
     }
 
-    private fun createFuturePeriod(): Triple<LocalDate, LocalDate, ContributionPeriod> {
+    private fun createFuturePeriod(): Triple<LocalDate, LocalDate, Long> {
         val uniqueOffset = System.currentTimeMillis() % 10_000
         val startDate = LocalDate.now().plusDays(1000L + uniqueOffset)
         val endDate = startDate.plusDays(30)
-        return Triple(startDate, endDate, contributionFactory.createPeriod(startDate, endDate))
+        return Triple(startDate, endDate, TestHelper.createContributionPeriod(startDate, endDate))
+    }
+
+    private fun pollFor(description: String, timeoutMs: Long = 10_000, predicate: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (predicate()) return
+            Thread.sleep(200)
+        }
+        throw AssertionError("Expected '$description' within ${timeoutMs}ms")
     }
 
     private companion object {
         val FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
-        const val DEFAULT_PASSWORD = "Password123!"
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -520,6 +520,73 @@ object TestHelper {
         }
 
     /**
+     * Insert a `contribution_periods` row. Returns the new id.
+     */
+    fun createContributionPeriod(
+        startDate: java.time.LocalDate,
+        endDate: java.time.LocalDate,
+        halfYearFee: Double = 0.0,
+        fullYearFee: Double = 0.0,
+        alumniFee: Double = 0.0,
+    ): Long {
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            return conn.prepareStatement(
+                "INSERT INTO contribution_periods " +
+                    "(start_date, end_date, half_year_fee, full_year_fee, alumni_fee) " +
+                    "VALUES (?, ?, ?, ?, ?)",
+                java.sql.Statement.RETURN_GENERATED_KEYS,
+            ).use { stmt ->
+                stmt.setDate(1, java.sql.Date.valueOf(startDate))
+                stmt.setDate(2, java.sql.Date.valueOf(endDate))
+                stmt.setDouble(3, halfYearFee)
+                stmt.setDouble(4, fullYearFee)
+                stmt.setDouble(5, alumniFee)
+                stmt.executeUpdate()
+                val keys = stmt.generatedKeys
+                require(keys.next()) { "INSERT contribution_periods produced no id" }
+                keys.getLong(1)
+            }
+        }
+    }
+
+    /**
+     * Mark a user as paid for a contribution period. Inserts a row in
+     * `contributions` keyed on (user_id, contribution_period_id).
+     */
+    fun createContribution(periodId: Long, username: String) {
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            val userId = userIdOrThrow(conn, username)
+            conn.prepareStatement(
+                "INSERT INTO contributions (user_id, contribution_period_id) VALUES (?, ?)",
+            ).use { stmt ->
+                stmt.setLong(1, userId)
+                stmt.setLong(2, periodId)
+                stmt.executeUpdate()
+            }
+        }
+    }
+
+    /**
+     * Return all active `contributions` rows for the given period as
+     * `(userId, periodId)` pairs.
+     */
+    fun findContributions(periodId: Long): List<Long> =
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            conn.prepareStatement(
+                "SELECT user_id FROM contributions " +
+                    "WHERE contribution_period_id = ? AND $ACTIVE_ROW_PREDICATE",
+            ).use { stmt ->
+                stmt.setLong(1, periodId)
+                val rs = stmt.executeQuery()
+                val userIds = mutableListOf<Long>()
+                while (rs.next()) {
+                    userIds += rs.getLong("user_id")
+                }
+                userIds
+            }
+        }
+
+    /**
      * Insert a `committees` row. Returns the new committee id.
      */
     fun createCommittee(


### PR DESCRIPTION
## Why

`ContributionManagerPageSystemTest` was still extending `FrontendSystemTestBase` and pulled `UserFactory`, `ContributionFactory`, `ContributionRepository`, and `UserErasureService` in via `@Autowired`. Setup seeded periods through the factory and instantiated `Contribution` entities directly; post-condition reads polled the repository.

## What this achieves

`ContributionManagerPageSystemTest` runs through HTTP and JDBC via `TestHelper`. The Spring context still hosts the api in-process; the test body has no `@Autowired` and no entity imports.

## How

- **`TestHelper.createContributionPeriod(start, end, halfYearFee, fullYearFee, alumniFee): Long`** — `INSERT INTO contribution_periods`. Fees default to 0.0, matching the factory's `Double = 0.0` defaults.
- **`TestHelper.createContribution(periodId, username)`** — `INSERT INTO contributions (user_id, contribution_period_id)`. Mirrors a member-marked-paid row.
- **`TestHelper.findContributions(periodId): List<Long>`** — soft-delete-aware `SELECT user_id FROM contributions WHERE contribution_period_id = ?`. Replaces the `contributionRepository.findByIdContributionPeriodId(...)` post-condition poll.

- **`ContributionManagerPageSystemTest`** extends `PlaywrightTestBase`. Erasure uses the existing `TestHelper.eraseUser(username)`. The "marks paid and unpaid" test re-navigates the same `page` for the unmark flow instead of opening a second `withPage` (the migration's base provides one page per test).