### PR TITLE
system-tests: migrate ActivationPageSystemTest off Spring

### DIFF
--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/ActivationPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/ActivationPageSystemTest.kt
@@ -1,146 +1,140 @@
 package net.blueshell.api.system.frontend.login
 
 import com.microsoft.playwright.Page
-import net.blueshell.api.domain.auth.application.factory.RecoveryTokenFactory
-import net.blueshell.api.factory.user.persistence.UserFactory
-import net.blueshell.api.shared.enums.ResetType
-import net.blueshell.api.shared.enums.Role
-import net.blueshell.api.system.frontend.FrontendSystemTestBase
+import net.blueshell.api.ApiApplication
+import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.LoginDomainHelper
+import net.blueshell.systemtests.PlaywrightTestBase
+import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestExecutionListeners
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.time.Duration
 
 @Tag("system")
-class ActivationPageSystemTest : FrontendSystemTestBase() {
-
-    @Autowired
-    private lateinit var userFactory: UserFactory
-
-    @Autowired
-    private lateinit var recoveryTokenFactory: RecoveryTokenFactory
+@ActiveProfiles("test")
+@TestExecutionListeners(
+    listeners = [TestCleanUpListener::class],
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+)
+@SpringBootTest(
+    classes = [ApiApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
+)
+class ActivationPageSystemTest : PlaywrightTestBase() {
 
     @Test
     fun `member activation activates account and allows sign in`() {
-        val user = userFactory.createUserWithRole(Role.MEMBER, enabled = false)
-        val rawToken = recoveryTokenFactory.issue(
-            user = user,
-            type = ResetType.MEMBER_ACTIVATION,
-            ttl = Duration.ofDays(7)
+        val user = TestHelper.register()
+        TestHelper.replaceRoles(user.username, setOf("MEMBER"))
+        // Disabled by default — the activation flow flips enabled=true.
+        val rawToken = TestHelper.mintRecoveryToken(
+            username = user.username,
+            type = "MEMBER_ACTIVATION",
+            ttl = Duration.ofDays(7),
         )
         val encodedToken = URLEncoder.encode(rawToken, StandardCharsets.UTF_8)
         val newUsername = "member${System.currentTimeMillis().toString().takeLast(8)}"
         val newPassword = "N3wMemberPass!"
 
-        withPage { page ->
-            page.navigate("$frontendUrl/account/activate/member#token=$encodedToken")
-            submitMemberActivationForm(page, username = newUsername, password = newPassword)
+        page.navigate("$frontendUrl/account/activate/member#token=$encodedToken")
+        submitMemberActivationForm(page, username = newUsername, password = newPassword)
 
-            val response = page.waitForResponse("**/recovery/member/activate") {
-                LoginDomainHelper.clickActivateMemberSubmit(page)
-            }
-            assertThat(response.status()).isEqualTo(200)
-            // The success alert mounts in Vue's `.then` block, which
-            // runs after `waitForResponse` returns. Poll with
-            // `.first().waitFor()` rather than asserting `.count()`
-            // straight away, otherwise a fast network + slow render
-            // intermittently lands on `count == 0`.
-            page.locator("[data-testid='activate-member-success-alert']").first().waitFor()
+        val response = page.waitForResponse("**/recovery/member/activate") {
+            LoginDomainHelper.clickActivateMemberSubmit(page)
+        }
+        assertThat(response.status()).isEqualTo(200)
+        page.locator("[data-testid='activate-member-success-alert']").first().waitFor()
+
+        pollFor("user ${user.username} enabled after activation") {
+            TestHelper.findUser(newUsername)?.enabled == true
         }
 
-        waitFor(
-            onTimeoutMessage = { "Expected user ${user.id} to be enabled after member activation" }
-        ) {
-            userRepository.findById(user.id!!).orElseThrow().enabled
-        }
-
-        withPage { page ->
-            val status = AuthHelper.submitLogin(page, frontendUrl, newUsername, newPassword)
-            assertThat(status).isEqualTo(200)
-        }
+        val status = AuthHelper.submitLogin(page, frontendUrl, newUsername, newPassword)
+        assertThat(status).isEqualTo(200)
     }
 
     @Test
     fun `member activation shows error for invalid token`() {
-        val user = userFactory.createUserWithRole(Role.MEMBER, enabled = false)
+        val user = TestHelper.register()
+        TestHelper.replaceRoles(user.username, setOf("MEMBER"))
         val invalidToken = URLEncoder.encode("invalid-member-token", StandardCharsets.UTF_8)
         val newUsername = "member${System.currentTimeMillis().toString().takeLast(8)}"
         val newPassword = "N3wMemberPass!"
 
-        withPage { page ->
-            page.navigate("$frontendUrl/account/activate/member#token=$invalidToken")
-            submitMemberActivationForm(page, username = newUsername, password = newPassword)
+        page.navigate("$frontendUrl/account/activate/member#token=$invalidToken")
+        submitMemberActivationForm(page, username = newUsername, password = newPassword)
 
-            val response = page.waitForResponse("**/recovery/member/activate") {
-                LoginDomainHelper.clickActivateMemberSubmit(page)
-            }
-            assertThat(response.status()).isGreaterThanOrEqualTo(400)
-            // Vue's catch block runs after waitForResponse returns and
-            // sets `errorMessage` — Playwright's `.waitFor()` polls for
-            // the locator, removing the race that produced
-            // "expected 0 to be greater than 0" intermittently.
-            page.locator("[data-testid='activate-member-error-alert']").first().waitFor()
+        val response = page.waitForResponse("**/recovery/member/activate") {
+            LoginDomainHelper.clickActivateMemberSubmit(page)
         }
+        assertThat(response.status()).isGreaterThanOrEqualTo(400)
+        page.locator("[data-testid='activate-member-error-alert']").first().waitFor()
 
-        assertThat(userRepository.findById(user.id!!).orElseThrow().enabled).isFalse()
+        assertThat(TestHelper.findUser(user.username)!!.enabled).isFalse()
     }
 
     @Test
     fun `user activation enables account and returns membership step redirect path`() {
-        val user = userFactory.createUserWithRole(Role.MEMBER, enabled = false)
-        user.replaceMemberProfile(userFactory.buildMemberProfile(user))
-        userRepository.saveAndFlush(user)
-        val rawToken = recoveryTokenFactory.issue(
-            user = user,
-            type = ResetType.USER_ACTIVATION,
-            ttl = Duration.ofHours(1)
+        // Enable briefly so `attachMemberProfile` can POST via a real
+        // login, then flip back to disabled so the activation flow has
+        // work to do.
+        val user = TestHelper.registerAndActivate()
+        TestHelper.replaceRoles(user.username, setOf("MEMBER"))
+        TestHelper.attachMemberProfile(user)
+        TestHelper.setEnabled(user.username, false)
+        val rawToken = TestHelper.mintRecoveryToken(
+            username = user.username,
+            type = "USER_ACTIVATION",
+            ttl = Duration.ofHours(1),
         )
         val encodedToken = URLEncoder.encode(rawToken, StandardCharsets.UTF_8)
 
-        withPage { page ->
-            val response = page.waitForResponse("**/recovery/user/activate") {
-                page.navigate("$frontendUrl/account/activate/user#token=$encodedToken")
-            }
-            assertThat(response.status()).isEqualTo(200)
-            assertThat(response.text()).contains("/membership/signUp?step=2")
-            // Same render race as the member-activation success path —
-            // wait for the success-state locator rather than asserting
-            // `.count()` straight after `waitForResponse` returns.
-            page.locator("[data-testid='activate-user-success-state']").first().waitFor()
+        val response = page.waitForResponse("**/recovery/user/activate") {
+            page.navigate("$frontendUrl/account/activate/user#token=$encodedToken")
         }
+        assertThat(response.status()).isEqualTo(200)
+        assertThat(response.text()).contains("/membership/signUp?step=2")
+        page.locator("[data-testid='activate-user-success-state']").first().waitFor()
 
-        waitFor(
-            onTimeoutMessage = { "Expected user ${user.id} to be enabled after user activation" }
-        ) {
-            userRepository.findById(user.id!!).orElseThrow().enabled
+        pollFor("user ${user.username} enabled after activation") {
+            TestHelper.findUser(user.username)?.enabled == true
         }
     }
 
     @Test
     fun `user activation with invalid token shows warning`() {
-        val user = userFactory.createUserWithRole(Role.GUEST, enabled = false)
+        val user = TestHelper.register()
+        TestHelper.replaceRoles(user.username, setOf("GUEST"))
         val invalidToken = URLEncoder.encode("invalid-user-token", StandardCharsets.UTF_8)
 
-        withPage { page ->
-            val response = page.waitForResponse("**/recovery/user/activate") {
-                page.navigate("$frontendUrl/account/activate/user#token=$invalidToken")
-            }
-            assertThat(response.status()).isGreaterThanOrEqualTo(400)
-            assertThat(
-                page.locator("[data-testid='activate-user-error-alert']").count()
-            ).isGreaterThan(0)
+        val response = page.waitForResponse("**/recovery/user/activate") {
+            page.navigate("$frontendUrl/account/activate/user#token=$invalidToken")
         }
+        assertThat(response.status()).isGreaterThanOrEqualTo(400)
+        page.locator("[data-testid='activate-user-error-alert']").first().waitFor()
 
-        assertThat(userRepository.findById(user.id!!).orElseThrow().enabled).isFalse()
+        assertThat(TestHelper.findUser(user.username)!!.enabled).isFalse()
     }
 
     private fun submitMemberActivationForm(page: Page, username: String, password: String) {
         LoginDomainHelper.fillActivateMemberForm(page, username, password)
         LoginDomainHelper.activateMemberRepeatPasswordInput(page).press("Tab")
+    }
+
+    private fun pollFor(description: String, timeoutMs: Long = 10_000, predicate: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (predicate()) return
+            Thread.sleep(200)
+        }
+        throw AssertionError("Expected '$description' within ${timeoutMs}ms")
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -28,6 +28,8 @@ object TestHelper {
     private const val API_RETRY_ATTEMPTS = 3
     private const val API_RETRY_DELAY_MS = 2_000L
     private const val ACTIVE_ROW_PREDICATE = "deleted_at = '9999-12-31 23:59:59'"
+    private const val SELECTOR_BYTES = 16
+    private const val VERIFIER_BYTES = 32
     private const val EVENT_SELECT =
         "SELECT id, title, description, location, approved, sign_up, members_only, " +
             "committee_id, sign_up_limit FROM events "
@@ -568,6 +570,63 @@ object TestHelper {
                 }
             }
         }
+
+    /**
+     * Mint a recovery token directly via JDBC. The api's
+     * `RecoveryTokenFactory.issue(...)` returns "selector.verifier"
+     * — selector is a 16-byte URL-safe random, verifier is 32 bytes,
+     * and only the BCrypt hash of the verifier lands in the table.
+     * This helper reproduces all three steps so tests that exercise
+     * the activation / password-reset flows can plant a known
+     * plaintext token without going through the in-process factory.
+     *
+     * `type` accepts the `ResetType` enum names:
+     * `USER_ACTIVATION`, `MEMBER_ACTIVATION`, `PASSWORD_RESET`.
+     */
+    fun mintRecoveryToken(
+        username: String,
+        type: String,
+        ttl: java.time.Duration = java.time.Duration.ofDays(7),
+    ): String {
+        val selector = randomUrlSafe(SELECTOR_BYTES)
+        val verifier = randomUrlSafe(VERIFIER_BYTES)
+        val verifierHash = org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder()
+            .encode(verifier)
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            val userId = userIdOrThrow(conn, username)
+            // Remove any prior unconsumed token of the same type for
+            // this user — `RecoveryTokenFactory.issue(...)` deletes
+            // those before inserting the new row.
+            conn.prepareStatement(
+                "DELETE FROM recovery_tokens " +
+                    "WHERE user_id = ? AND type = ? AND consumed_at IS NULL " +
+                    "AND $ACTIVE_ROW_PREDICATE",
+            ).use { stmt ->
+                stmt.setLong(1, userId)
+                stmt.setString(2, type)
+                stmt.executeUpdate()
+            }
+            conn.prepareStatement(
+                "INSERT INTO recovery_tokens " +
+                    "(user_id, type, selector, verifier_hash, expires_at, created_at, updated_at, version) " +
+                    "VALUES (?, ?, ?, ?, ?, NOW(), NOW(), 0)",
+            ).use { stmt ->
+                stmt.setLong(1, userId)
+                stmt.setString(2, type)
+                stmt.setString(3, selector)
+                stmt.setString(4, verifierHash)
+                stmt.setTimestamp(5, java.sql.Timestamp.from(java.time.Instant.now().plus(ttl)))
+                stmt.executeUpdate()
+            }
+        }
+        return "$selector.$verifier"
+    }
+
+    private fun randomUrlSafe(byteCount: Int): String {
+        val bytes = ByteArray(byteCount)
+        java.security.SecureRandom().nextBytes(bytes)
+        return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
 
     /**
      * Insert a `contribution_periods` row. Returns the new id.


### PR DESCRIPTION
## Why

`ActivationPageSystemTest` was the last login-subtree file still extending `FrontendSystemTestBase`. It depended on `RecoveryTokenFactory.issue(user, type, ttl)` — the in-process factory that generates `selector + verifier`, BCrypt-hashes the verifier, persists the row, and returns the plaintext token in `"selector.verifier"` format. Without a Spring-free way to mint that pair, every recovery-flow test stays pinned to the in-process api.

## What this achieves

The full member-activation, user-activation, and invalid-token paths run through HTTP + JDBC via `TestHelper`. The Spring context still hosts the api in-process; the test body has no `@Autowired` and no entity imports.

## How

- **`TestHelper.mintRecoveryToken(username, type, ttl)`** reproduces `RecoveryTokenFactory.issue(...)` over JDBC:
  - Generates a 16-byte URL-safe selector and a 32-byte URL-safe verifier (matching the factory's `randomUrlSafe(16)` / `randomUrlSafe(32)`).
  - BCrypt-hashes the verifier via `BCryptPasswordEncoder.encode(verifier)`.
  - Deletes any prior unconsumed token of the same type for this user (matching the factory's `findAllUnconsumedByTypeAndUserId(...).forEach { delete }` step).
  - Inserts the new row with `expires_at = now + ttl`, audit columns filled to keep MariaDB happy on NOT-NULL fields that lack defaults at this point in the schema.
  - Returns `"$selector.$verifier"`.

- **`ActivationPageSystemTest`** extends `PlaywrightTestBase` and runs all four tests:
  - Member activation success: register → MEMBER role → mint `MEMBER_ACTIVATION` token → drive form → assert success alert + login.
  - Member activation invalid token: same setup with an unencoded random string.
  - User activation success: briefly enable so `attachMemberProfile` can POST through the api, then disable so the activation flow has work; navigate to the activation URL with the minted `USER_ACTIVATION` token.
  - User activation invalid token: drive the URL with an unencoded random string.

  Post-condition reads use `TestHelper.findUser(...)?.enabled`. Success-state locators use `.first().waitFor()` — matches the pattern this file already used for the error-alert locators.