### PR TITLE
api: add test-only /test-support/emails endpoint; migrate CreateAccountPageSystemTest

### DIFF
--- a/services/api/src/main/kotlin/net/blueshell/api/platform/config/SecurityConfig.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/config/SecurityConfig.kt
@@ -160,6 +160,7 @@ class SecurityConfig(
                 "/actuator/health",
                 "/actuator/health/**",
                 "/actuator/prometheus",
+                "/test-support/**",
             ).permitAll()
 
             if (openApiPublicEnabled) {

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/web/TestSupportController.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/web/TestSupportController.kt
@@ -1,5 +1,7 @@
 package net.blueshell.api.platform.web
 
+import io.swagger.v3.oas.annotations.Hidden
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.annotation.security.PermitAll
 import net.blueshell.api.platform.integration.mock.MockListmonkEmailClient
 import org.springframework.context.annotation.Profile
@@ -20,6 +22,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/test-support")
 @Profile("test")
+@Hidden
+@Tag(name = "Test Support")
 class TestSupportController(
     private val emailClient: MockListmonkEmailClient,
 ) {

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/web/TestSupportController.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/web/TestSupportController.kt
@@ -1,0 +1,37 @@
+package net.blueshell.api.platform.web
+
+import jakarta.annotation.security.PermitAll
+import net.blueshell.api.platform.integration.mock.MockListmonkEmailClient
+import org.springframework.context.annotation.Profile
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * Test-only HTTP surface for the system-tests project. Mounted under
+ * `@Profile("test")` so production deployments never see the endpoint.
+ *
+ * Exposes the in-memory outbox the `MockListmonkEmailClient` collects
+ * during test runs so system tests can assert "the api dispatched an
+ * email with subject X to recipient Y" without reaching into the bean
+ * graph from a Spring-free test JVM.
+ */
+@RestController
+@RequestMapping("/test-support")
+@Profile("test")
+class TestSupportController(
+    private val emailClient: MockListmonkEmailClient,
+) {
+    @GetMapping("/emails")
+    @PermitAll
+    fun listEmails(
+        @RequestParam(required = false) recipient: String?,
+        @RequestParam(required = false) subject: String?,
+    ): List<MockListmonkEmailClient.SentEmail> {
+        return emailClient.sentEmails.filter { email ->
+            (recipient == null || email.toEmail.equals(recipient, ignoreCase = true)) &&
+                (subject == null || email.subject == subject)
+        }
+    }
+}

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/CreateAccountPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/CreateAccountPageSystemTest.kt
@@ -84,10 +84,19 @@ class CreateAccountPageSystemTest : PlaywrightTestBase() {
             }
         }
 
-        page.getByRole(
-            AriaRole.BUTTON,
-            Page.GetByRoleOptions().setName("Create Account").setExact(false),
-        ).click()
+        // Wait for the POST /users response before returning so the
+        // user is fully persisted by the time the caller chains the
+        // next action (login attempt, navigation away, …).
+        page.waitForResponse(
+            { response ->
+                response.request().method() == "POST" && response.url().contains("/users")
+            },
+        ) {
+            page.getByRole(
+                AriaRole.BUTTON,
+                Page.GetByRoleOptions().setName("Create Account").setExact(false),
+            ).click()
+        }
 
         return Credentials(username, email, password)
     }

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/CreateAccountPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/CreateAccountPageSystemTest.kt
@@ -1,55 +1,113 @@
 package net.blueshell.api.system.frontend.login
 
-import net.blueshell.api.shared.enums.Role
-import net.blueshell.api.system.frontend.FrontendSystemTestBase
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.options.AriaRole
+import net.blueshell.api.ApiApplication
+import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
+import net.blueshell.api.system.frontend.helper.UserFormHelper
+import net.blueshell.systemtests.PlaywrightTestBase
+import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestExecutionListeners
 
 @Tag("system")
-class CreateAccountPageSystemTest : FrontendSystemTestBase() {
+@ActiveProfiles("test")
+@TestExecutionListeners(
+    listeners = [TestCleanUpListener::class],
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+)
+@SpringBootTest(
+    classes = [ApiApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
+)
+class CreateAccountPageSystemTest : PlaywrightTestBase() {
 
     @Test
     fun `creates disabled account and sends activation email`() {
-        withPage { page ->
-            val credentials = createAccountThroughUi(
-                page = page,
-                url = "$frontendUrl/account/create",
-                submitButtonLabel = "Create Account",
-                includeMemberProfile = false,
-                submitButtonTestId = "user-form-submit-btn"
-            )
+        val credentials = createAccountThroughUi(page, "$frontendUrl/account/create")
 
-            val persisted = waitForOptional(producer = { userRepository.findByUsername(credentials.username) })
-            assertThat(persisted.email).isEqualTo(credentials.email)
-            assertThat(persisted.enabled).isFalse()
-            assertThat(persisted.roles).contains(Role.GUEST)
-            assertThat(persisted.password).isNotEqualTo(credentials.password)
+        val persisted = pollForUser(credentials.username)
+        assertThat(persisted.email).isEqualTo(credentials.email)
+        assertThat(persisted.enabled).isFalse()
+        assertThat(TestHelper.findRoles(credentials.username)).contains("GUEST")
 
-            assertEmailSent(credentials.email, "Activate your Account")
-        }
+        TestHelper.assertEmailSent(credentials.email, "Activate your Account")
     }
 
     @Test
     fun `blocks login before activation`() {
-        withPage { page ->
-            val credentials = createAccountThroughUi(
-                page = page,
-                url = "$frontendUrl/account/create",
-                submitButtonLabel = "Create Account",
-                includeMemberProfile = false,
-                submitButtonTestId = "user-form-submit-btn"
-            )
+        val credentials = createAccountThroughUi(page, "$frontendUrl/account/create")
 
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, credentials.username, credentials.password)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, credentials.username, credentials.password)
+        assertThat(page.url()).contains("/login")
+        assertThat(loginStatus).isEqualTo(401)
 
-            assertThat(page.url()).contains("/login")
-            assertThat(loginStatus).isEqualTo(401)
+        val persisted = pollForUser(credentials.username)
+        assertThat(persisted.enabled).isFalse()
+        TestHelper.assertEmailSent(credentials.email, "Activate your Account")
+    }
 
-            val persisted = waitForOptional(producer = { userRepository.findByUsername(credentials.username) })
-            assertThat(persisted.enabled).isFalse()
-            assertEmailSent(credentials.email, "Activate your Account")
+    private data class Credentials(val username: String, val email: String, val password: String)
+
+    private fun createAccountThroughUi(page: Page, url: String): Credentials {
+        val suffix = System.currentTimeMillis().toString().takeLast(8)
+        val username = "sysuser$suffix"
+        val email = "sysuser$suffix@example.com"
+        val password = "Passw0rd!$suffix"
+        val phoneNumber = "+3161${suffix.takeLast(7)}"
+
+        page.navigate(url)
+        UserFormHelper.fill(
+            page = page,
+            fields = UserFormHelper.Fields(
+                initials = "SU",
+                firstName = "System",
+                surname = "User$suffix",
+                username = username,
+                discord = "sysuser$suffix",
+                email = email,
+                phoneNumber = phoneNumber,
+                password = password,
+                repeatedPassword = password,
+            ),
+        )
+
+        if (UserFormHelper.acceptPrivacyConsentIfVisible(page)) {
+            pollFor("privacy consent checkbox checked") {
+                UserFormHelper.privacyConsentCheckbox(page).isChecked
+            }
         }
+
+        page.getByRole(
+            AriaRole.BUTTON,
+            Page.GetByRoleOptions().setName("Create Account").setExact(false),
+        ).click()
+
+        return Credentials(username, email, password)
+    }
+
+    private fun pollForUser(username: String): TestHelper.RegisteredUserRow {
+        val deadline = System.currentTimeMillis() + 10_000
+        while (System.currentTimeMillis() < deadline) {
+            val row = TestHelper.findUser(username)
+            if (row != null) return row
+            Thread.sleep(200)
+        }
+        throw AssertionError("Expected user '$username' to be persisted within 10s")
+    }
+
+    private fun pollFor(description: String, timeoutMs: Long = 5_000, predicate: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (predicate()) return
+            Thread.sleep(100)
+        }
+        throw AssertionError("Expected '$description' within ${timeoutMs}ms")
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -572,6 +572,55 @@ object TestHelper {
         }
 
     /**
+     * Query the test-only `/test-support/emails` endpoint for emails
+     * the in-process `MockListmonkEmailClient` captured. Empty list
+     * when nothing matches. Used by tests that previously asserted
+     * `emailTransportClient.sentEmails.any { … }`.
+     */
+    fun findEmails(recipient: String? = null, subject: String? = null): List<SentEmail> {
+        val response = retryOnConnectionFailure {
+            var spec = givenApi().baseUri(apiBaseUrl)
+            if (recipient != null) spec = spec.queryParam("recipient", recipient)
+            if (subject != null) spec = spec.queryParam("subject", subject)
+            spec.`when`().get("/test-support/emails")
+        }
+        require(response.statusCode == 200) {
+            "GET /test-support/emails returned ${response.statusCode}: ${response.asString()}"
+        }
+        return response.jsonPath().getList("", Map::class.java).map { row ->
+            @Suppress("UNCHECKED_CAST")
+            val asMap = row as Map<String, Any?>
+            SentEmail(
+                toEmail = asMap["toEmail"] as String,
+                toName = asMap["toName"] as String,
+                subject = asMap["subject"] as String,
+                htmlContent = asMap["htmlContent"] as String,
+            )
+        }
+    }
+
+    /**
+     * Polls `findEmails(...)` until at least one email arrives that
+     * matches the recipient + subject filter. Replaces the
+     * `assertEmailSent(...)` helper the in-process base used to expose.
+     */
+    fun assertEmailSent(
+        recipient: String,
+        subject: String,
+        timeoutMs: Long = 10_000,
+    ): SentEmail {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            val matches = findEmails(recipient = recipient, subject = subject)
+            if (matches.isNotEmpty()) return matches.first()
+            Thread.sleep(200)
+        }
+        throw AssertionError(
+            "Expected an email subject=\"$subject\" recipient=$recipient within ${timeoutMs}ms",
+        )
+    }
+
+    /**
      * Mint a recovery token directly via JDBC. The api's
      * `RecoveryTokenFactory.issue(...)` returns "selector.verifier"
      * — selector is a 16-byte URL-safe random, verifier is 32 bytes,
@@ -971,6 +1020,13 @@ object TestHelper {
     ) {
         val fullName: String get() = "$firstName $lastName"
     }
+
+    data class SentEmail(
+        val toEmail: String,
+        val toName: String,
+        val subject: String,
+        val htmlContent: String,
+    )
 
     data class MembershipRow(
         val id: Long,


### PR DESCRIPTION
## Why

`MockListmonkEmailClient` collects the api's outgoing emails into an in-memory list, but the list was only reachable from inside the api's bean graph. System tests that already moved off `@Autowired` had no way to check "did the api dispatch a Reset Your Account Password email?" — every `assertEmailSent(...)` callsite still needed the in-process `FrontendSystemTestBase` and blocked the migration of `CreateAccountPageSystemTest`, `MembershipSignUpPageSystemTest`, `RecoveryManagerPageSystemTest`, and the forgot-password test path.

## What this achieves

The system-tests project can read the mock outbox over HTTP. `TestHelper.findEmails(...)` and `TestHelper.assertEmailSent(...)` mirror the call surface the in-process base used to expose, so the remaining email-dependent migrations can follow the same shape the other migrated tests already use. `CreateAccountPageSystemTest` lands as the worked example.

## How

- **`TestSupportController`** at `services/api/src/main/kotlin/net/blueshell/api/platform/web/TestSupportController.kt`. Gated by `@Profile("test")` so production deployments never see the controller. Exposes `GET /test-support/emails` with optional `recipient` and `subject` query parameters; in-memory filter against `MockListmonkEmailClient.sentEmails`.

- **`SecurityConfig`** appends `/test-support/**` to the GET `permitAll` matcher list, alongside `/csrf`, `/health`, and the other read-only system paths.

- **`TestHelper.findEmails(recipient, subject): List<SentEmail>`** queries the endpoint and decodes the response. **`TestHelper.assertEmailSent(recipient, subject, timeoutMs)`** polls until a match arrives or the deadline passes — matches the polling shape `FrontendSystemTestBase.assertEmailSent(...)` had.

- **`CreateAccountPageSystemTest`** extends `PlaywrightTestBase`, inlines a `createAccountThroughUi(...)` form driver (no longer worth promoting to a base — every other migrated frontend test extends `PlaywrightTestBase` directly), and exercises both assertions:
  - disabled-on-create + GUEST role via `TestHelper.findUser` / `TestHelper.findRoles`.
  - activation-email dispatch via `TestHelper.assertEmailSent(...)`.