### PR TITLE
test(system): migrate MembershipSignUpPageSystemTest off Spring beans

### DIFF
--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/membership/MembershipSignUpPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/membership/MembershipSignUpPageSystemTest.kt
@@ -2,184 +2,183 @@ package net.blueshell.api.system.frontend.membership
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.options.AriaRole
-import net.blueshell.api.domain.user.application.MembershipService
-import net.blueshell.api.factory.contribution.persistence.ContributionFactory
-import net.blueshell.api.factory.user.persistence.UserFactory
-import net.blueshell.api.shared.enums.Role
-import net.blueshell.api.system.frontend.FrontendSystemTestBase
+import net.blueshell.api.ApiApplication
+import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AddressFormHelper
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.MembershipSignUpHelper
+import net.blueshell.api.system.frontend.helper.UserFormHelper
+import net.blueshell.systemtests.PlaywrightTestBase
+import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.orm.ObjectOptimisticLockingFailureException
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestExecutionListeners
+import java.time.LocalDate
 import java.util.function.Predicate
-import kotlin.io.path.Path
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat as assertPw
 
 @Tag("system")
-class MembershipSignUpPageSystemTest : FrontendSystemTestBase() {
-
-    @Autowired
-    private lateinit var userFactory: UserFactory
-
-    @Autowired
-    private lateinit var membershipService: MembershipService
-
-    @Autowired
-    private lateinit var contributionFactory: ContributionFactory
+@ActiveProfiles("test")
+@TestExecutionListeners(
+    listeners = [TestCleanUpListener::class],
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+)
+@SpringBootTest(
+    classes = [ApiApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
+)
+class MembershipSignUpPageSystemTest : PlaywrightTestBase() {
 
     @Test
     fun `step 1 can create a user with personal info and continues to step 2`() {
-        withPage { page ->
-            MembershipSignUpHelper.open(page, frontendUrl)
+        MembershipSignUpHelper.open(page, frontendUrl)
 
-            // Assert that we are on step=1 using playwright
-            waitFor(
-                onTimeoutMessage = { "Expected to be on step 1 of membership signup after initial navigation" }
-            ) {
-                page.url().contains("/membership/signup") && !page.url().contains("step=")
-            }
-
-            val credentials = createAccountThroughUi(
-                page = page,
-                url = page.url(),
-                submitButtonLabel = "Next",
-                includeMemberProfile = true,
-                submitButtonTestId = "membership-step1-next-btn"
-            )
-
-            page.waitForURL("**/membership/signup?step=2")
-
-            assertThat(page.url()).contains("/membership/signup")
-            assertThat(page.url()).contains("step=2")
-
-            val persisted = waitForOptional(producer = { userRepository.findByUsername(credentials.username) })
-            assertThat(persisted).isNotNull()
-
-            assertThat(persisted.email).isEqualTo(credentials.email)
-            assertThat(persisted.enabled).isFalse()
-            assertThat(persisted.roles).contains(Role.GUEST)
-            assertThat(persisted.memberProfile).isNotNull()
-
-            assertEmailSent(credentials.email, "Activate your Account")
+        pollFor("step 1 of membership signup after initial navigation") {
+            page.url().contains("/membership/signup") && !page.url().contains("step=")
         }
+
+        val credentials = createAccountThroughUi(page)
+
+        page.waitForURL("**/membership/signup?step=2")
+        assertThat(page.url()).contains("/membership/signup")
+        assertThat(page.url()).contains("step=2")
+
+        val persisted = pollForUser(credentials.username)
+        assertThat(persisted.email).isEqualTo(credentials.email)
+        assertThat(persisted.enabled).isFalse()
+        assertThat(TestHelper.findRoles(credentials.username)).contains("GUEST")
+        assertThat(TestHelper.hasMemberProfile(persisted.id)).isTrue()
+
+        TestHelper.assertEmailSent(credentials.email, "Activate your Account")
     }
 
     @Test
     fun `step 2 can resend the activation email`() {
-        withPage { page ->
-            MembershipSignUpHelper.open(page, frontendUrl)
+        MembershipSignUpHelper.open(page, frontendUrl)
 
-            val credentials = createAccountThroughUi(
-                page = page,
-                url = page.url(),
-                submitButtonLabel = "Next",
-                includeMemberProfile = true,
-                submitButtonTestId = "membership-step1-next-btn"
-            )
+        val credentials = createAccountThroughUi(page)
 
-            val resendResponse = page.waitForResponse("**/recovery/user/activate/resend/**") {
-                MembershipSignUpHelper.clickStepTwoResend(page)
-            }
-            assertThat(resendResponse.status()).isEqualTo(204)
-
-            val persisted = waitForOptional(producer = { userRepository.findByUsername(credentials.username) })
-            assertThat(persisted.enabled).isFalse()
+        val resendResponse = page.waitForResponse("**/recovery/user/activate/resend/**") {
+            MembershipSignUpHelper.clickStepTwoResend(page)
         }
+        assertThat(resendResponse.status()).isEqualTo(204)
+
+        val persisted = pollForUser(credentials.username)
+        assertThat(persisted.enabled).isFalse()
     }
 
     @Test
     fun `step 3 saves the address`() {
-        contributionFactory.createPeriod()
+        TestHelper.createContributionPeriod(
+            LocalDate.now().minusDays(15),
+            LocalDate.now().plusDays(345),
+        )
 
-        withPage { page ->
-            val signupContext = createAndEnableMembershipSignupUser(page)
-            val userId = signupContext.userId
+        MembershipSignUpHelper.open(page, frontendUrl)
+        val credentials = createAccountThroughUi(page)
+        val user = pollForUser(credentials.username)
+        TestHelper.setEnabled(user.username, true)
 
-            val loginStatus = AuthHelper.submitLogin(
-                page,
-                frontendUrl,
-                signupContext.credentials.username,
-                signupContext.credentials.password
-            )
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(
+            page,
+            frontendUrl,
+            credentials.username,
+            credentials.password,
+        )
+        assertThat(loginStatus).isEqualTo(200)
 
-            page.navigate("$frontendUrl/membership/signup?step=3")
+        page.navigate("$frontendUrl/membership/signup?step=3")
 
-            waitFor(
-                timeoutMs = 8_000,
-                onTimeoutMessage = { "Expected membership flow to open at address step for logged-in user" }
-            ) {
-                page.url().contains("step=3")
-            }
+        pollFor("membership flow opens at address step for logged-in user", timeoutMs = 8_000) {
+            page.url().contains("step=3")
+        }
 
-            fillAddressAndContinue(page)
+        fillAddressAndContinue(page)
 
-            waitFor(
-                timeoutMs = 10_000,
-                onTimeoutMessage = { "Expected address to be persisted from membership step 3" }
-            ) {
-                userRepository.findById(userId).orElseThrow().address != null
-            }
+        pollFor("address persisted from membership step 3", timeoutMs = 10_000) {
+            TestHelper.findAddress(user.username) != null
         }
     }
 
     @Test
     fun `step 4 completes a membership`() {
-        contributionFactory.createPeriod()
-
-        val seededUser = userFactory.createUserWithRole(Role.GUEST, enabled = true)
-        seededUser.replaceMemberProfile(userFactory.buildMemberProfile(seededUser))
-        seededUser.replaceAddress(userFactory.buildAddress(seededUser))
-        val persistedUser = userRepository.saveAndFlush(seededUser)
-
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, persistedUser.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
-
-            page.navigate("$frontendUrl/membership/signup?step=4")
-            assertStepFourVisible(page, "Expected fully pre-seeded user to access membership confirmation step")
-
-            completeMembershipAtStepFour(page)
-            assertMembershipPersisted(persistedUser.id!!)
-        }
-    }
-
-    private fun createAndEnableMembershipSignupUser(page: Page): SignupContext {
-        page.navigate("$frontendUrl/membership/signup")
-        val credentials = createAccountThroughUi(
-            page = page,
-            url = page.url(),
-            submitButtonLabel = "Next",
-            includeMemberProfile = true,
-            submitButtonTestId = "membership-step1-next-btn"
+        TestHelper.createContributionPeriod(
+            LocalDate.now().minusDays(15),
+            LocalDate.now().plusDays(345),
         )
 
-        val createdUser = waitForOptional(producer = { userRepository.findByUsername(credentials.username) })
-        val userId = enableUserByUsername(createdUser.username)
+        val seededUser = TestHelper.registerActivateAndPromote("GUEST")
+        TestHelper.attachMemberProfile(seededUser)
+        TestHelper.attachAddress(
+            user = seededUser,
+            city = "Enschede",
+            street = "System Test Street",
+            houseNumber = "42A",
+            zipCode = "7521AB",
+        )
+        val seededId = TestHelper.findUser(seededUser.username)!!.id
 
-        return SignupContext(credentials = credentials, userId = userId)
+        val loginStatus = AuthHelper.submitLogin(
+            page,
+            frontendUrl,
+            seededUser.username,
+            seededUser.password,
+        )
+        assertThat(loginStatus).isEqualTo(200)
+
+        page.navigate("$frontendUrl/membership/signup?step=4")
+        assertStepFourVisible(page)
+
+        completeMembershipAtStepFour(page)
+        assertMembershipPersisted(seededUser.username, seededId)
     }
 
-    private fun enableUserByUsername(username: String): Long {
-        repeat(5) { attempt ->
-            val user = waitForOptional(producer = { userRepository.findByUsername(username) })
-            user.enabled = true
-            try {
-                return userRepository.saveAndFlush(user).id!!
-            } catch (ex: ObjectOptimisticLockingFailureException) {
-                if (attempt == 4) {
-                    throw ex
-                }
-                Thread.sleep((attempt + 1) * 100L)
+    private data class Credentials(val username: String, val email: String, val password: String)
+
+    private fun createAccountThroughUi(page: Page): Credentials {
+        val suffix = System.currentTimeMillis().toString().takeLast(8)
+        val username = "sysuser$suffix"
+        val email = "sysuser$suffix@example.com"
+        val password = "Passw0rd!$suffix"
+        val phoneNumber = "+3161${suffix.takeLast(7)}"
+
+        UserFormHelper.fill(
+            page = page,
+            fields = UserFormHelper.Fields(
+                initials = "SU",
+                firstName = "System",
+                surname = "User$suffix",
+                username = username,
+                discord = "sysuser$suffix",
+                email = email,
+                phoneNumber = phoneNumber,
+                password = password,
+                repeatedPassword = password,
+                dateOfBirth = "1999-04-12",
+                gender = "X",
+                studentNumber = "s$suffix",
+            ),
+        )
+
+        if (UserFormHelper.acceptPrivacyConsentIfVisible(page)) {
+            pollFor("privacy consent checkbox checked", timeoutMs = 5_000) {
+                UserFormHelper.privacyConsentCheckbox(page).isChecked
             }
         }
-        throw IllegalStateException("Failed to enable user '$username' after retries")
+
+        page.waitForResponse(
+            { response ->
+                response.request().method() == "POST" && response.url().contains("/users")
+            },
+        ) {
+            page.locator("[data-testid='membership-step1-next-btn']").first().click()
+        }
+
+        return Credentials(username, email, password)
     }
 
     private fun fillAddressAndContinue(page: Page) {
@@ -190,33 +189,27 @@ class MembershipSignUpPageSystemTest : FrontendSystemTestBase() {
                 street = "System Test Street",
                 houseNumber = "42A",
                 zipCode = "7521AB",
-                city = "Enschede$suffix"
-            )
+                city = "Enschede$suffix",
+            ),
         )
         val addressSaveResponse = page.waitForResponse(
             Predicate { response ->
                 (response.request().method() == "POST" || response.request().method() == "PUT") &&
-                        response.url().contains("/addresses")
-            }
+                    response.url().contains("/addresses")
+            },
         ) {
             MembershipSignUpHelper.clickStepThreeNext(page)
         }
         assertThat(addressSaveResponse.status()).isBetween(200, 299)
     }
 
-    private fun assertStepFourVisible(page: Page, onTimeoutMessage: String) {
-        waitFor(
-            timeoutMs = 8_000,
-            onTimeoutMessage = { onTimeoutMessage }
-        ) {
+    private fun assertStepFourVisible(page: Page) {
+        pollFor("membership step 4 visible for pre-seeded user", timeoutMs = 8_000) {
             page.url().contains("step=4")
         }
 
         assertPw(membershipConsentCheckbox(page)).isVisible()
-
-        assertPw(
-            MembershipSignUpHelper.stepFourCompleteButton(page)
-        ).isVisible()
+        assertPw(MembershipSignUpHelper.stepFourCompleteButton(page)).isVisible()
     }
 
     private fun completeMembershipAtStepFour(page: Page) {
@@ -225,17 +218,14 @@ class MembershipSignUpPageSystemTest : FrontendSystemTestBase() {
         if (!consentCheckbox.isChecked) {
             consentCheckbox.check()
         }
-        waitFor(
-            timeoutMs = 5_000,
-            onTimeoutMessage = { "Expected membership consent checkbox to be checked before completion" }
-        ) {
+        pollFor("membership consent checkbox checked before completion", timeoutMs = 5_000) {
             consentCheckbox.isChecked
         }
 
         val membershipResponse = page.waitForResponse(
             Predicate { response ->
                 response.request().method() == "POST" && response.url().contains("/memberships")
-            }
+            },
         ) {
             MembershipSignUpHelper.clickStepFourComplete(page)
         }
@@ -246,29 +236,38 @@ class MembershipSignUpPageSystemTest : FrontendSystemTestBase() {
         AriaRole.CHECKBOX,
         Page.GetByRoleOptions()
             .setName(MEMBERSHIP_CONSENT_LABEL_PREFIX)
-            .setExact(false)
+            .setExact(false),
     )
 
-    private fun assertMembershipPersisted(userId: Long) {
-        waitFor(
-            timeoutMs = 10_000,
-            onTimeoutMessage = { "Expected active membership to exist after completing step 4" }
-        ) {
-            membershipService.existsActiveMembershipByUserId(userId)
+    private fun assertMembershipPersisted(username: String, userId: Long) {
+        pollFor("active membership exists after completing step 4", timeoutMs = 10_000) {
+            TestHelper.hasActiveMembership(username)
         }
-
-        val refreshed = userRepository.findById(userId).orElseThrow()
-        assertThat(refreshed.address).isNotNull()
-        assertThat(refreshed.roles).contains(Role.MEMBER)
+        assertThat(TestHelper.findAddress(username)).isNotNull()
+        assertThat(TestHelper.findRoles(username)).contains("MEMBER")
+        assertThat(TestHelper.hasMemberProfile(userId)).isTrue()
     }
 
-    private data class SignupContext(
-        val credentials: Credentials,
-        val userId: Long,
-    )
+    private fun pollForUser(username: String): TestHelper.RegisteredUserRow {
+        val deadline = System.currentTimeMillis() + 10_000
+        while (System.currentTimeMillis() < deadline) {
+            val row = TestHelper.findUser(username)
+            if (row != null) return row
+            Thread.sleep(200)
+        }
+        throw AssertionError("Expected user '$username' to be persisted within 10s")
+    }
+
+    private fun pollFor(description: String, timeoutMs: Long = 6_000, predicate: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (predicate()) return
+            Thread.sleep(200)
+        }
+        throw AssertionError("Expected $description within ${timeoutMs}ms")
+    }
 
     private companion object {
-        const val DEFAULT_PASSWORD = "Password123!"
         const val MEMBERSHIP_CONSENT_LABEL_PREFIX = "I confirm that I have read and agree to the membership terms above"
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -467,6 +467,21 @@ object TestHelper {
         }
 
     /**
+     * Returns true when a `member_profiles` row exists for the user
+     * (the row's primary key IS the user id; the table inherits from
+     * the `users` row in the api's JPA hierarchy).
+     */
+    fun hasMemberProfile(userId: Long): Boolean =
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            conn.prepareStatement(
+                "SELECT 1 FROM member_profiles WHERE id = ? AND $ACTIVE_ROW_PREDICATE LIMIT 1",
+            ).use { stmt ->
+                stmt.setLong(1, userId)
+                stmt.executeQuery().next()
+            }
+        }
+
+    /**
      * Returns true when the user has an active (end_date IS NULL)
      * membership row. Mirrors `MemberRepository.existsByUser_IdAndEndDateIsNull`.
      */


### PR DESCRIPTION
## Why
`MembershipSignUpPageSystemTest` still autowired `UserFactory`, `MembershipService`, and `ContributionFactory` from the in-process api context, and asserted persistence through `userRepository.findById(...)` directly. That coupling is what blocks the remaining work on running the system-tests module against a deployed api over HTTP.

## What this achieves
All four steps in the membership signup flow (personal info → resend activation → address save → completion) now drive the api through `TestHelper` and read state back from JDBC. The test class compiles without any reference to the api's domain or factory packages.

## How
- `MembershipSignUpPageSystemTest.kt` now extends `PlaywrightTestBase` and uses `TestHelper.registerActivateAndPromote`, `TestHelper.attachMemberProfile`, `TestHelper.attachAddress`, `TestHelper.createContributionPeriod`, and `TestHelper.findRoles` / `TestHelper.hasActiveMembership` / `TestHelper.findAddress` to seed and verify state. The local `createAccountThroughUi` mirrors the version on the other Playwright-only signup tests — it fills `UserFormHelper` with member-profile fields and clicks `membership-step1-next-btn`.
- `TestHelper.hasMemberProfile(userId)`: small JDBC probe against `member_profiles`. The row's PK is the user id (the api's JPA inheritance hierarchy), so the lookup is by id rather than by username.