### PR TITLE
test(system): migrate EventPageSystemTest off Spring beans

### DIFF
--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventPageSystemTest.kt
@@ -2,301 +2,258 @@ package net.blueshell.api.system.frontend.events
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.options.AriaRole
-import net.blueshell.api.domain.event.persistence.Event
-import net.blueshell.api.domain.event.persistence.repository.EventRepository
-import net.blueshell.api.domain.event.persistence.repository.EventSignUpRepository
-import net.blueshell.api.factory.committee.persistence.CommitteeFactory
-import net.blueshell.api.factory.event.persistence.EventFactory
-import net.blueshell.api.factory.user.persistence.UserFactory
-import net.blueshell.api.shared.enums.Role
-import net.blueshell.api.system.frontend.FrontendSystemTestBase
+import net.blueshell.api.ApiApplication
+import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.EventPageHelper
+import net.blueshell.systemtests.PlaywrightTestBase
+import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestExecutionListeners
 import java.time.Instant
 import java.util.function.Predicate
 
 @Tag("system")
-class EventPageSystemTest : FrontendSystemTestBase() {
-
-    @Autowired
-    private lateinit var userFactory: UserFactory
-
-    @Autowired
-    private lateinit var committeeFactory: CommitteeFactory
-
-    @Autowired
-    private lateinit var eventFactory: EventFactory
-
-    @Autowired
-    private lateinit var eventRepository: EventRepository
-
-    @Autowired
-    private lateinit var eventSignUpRepository: EventSignUpRepository
+@ActiveProfiles("test")
+@TestExecutionListeners(
+    listeners = [TestCleanUpListener::class],
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+)
+@SpringBootTest(
+    classes = [ApiApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
+)
+class EventPageSystemTest : PlaywrightTestBase() {
 
     @Test
     fun `board can approve event from event card`() {
-        val board = userFactory.createUserWithRole(Role.BOARD, enabled = true)
-        val committee = committeeFactory.create(name = "Approval Committee ${System.currentTimeMillis()}")
-        val event = createCurrentMonthEvent(
-            committee = committee,
+        val board = TestHelper.registerActivateAndPromote("BOARD")
+        val committeeId = TestHelper.createCommittee(name = "Approval Committee ${System.currentTimeMillis()}")
+        val eventId = createCurrentMonthEvent(
+            committeeId = committeeId,
             approved = false,
             signUp = false,
-            title = "Card Approval Event ${System.currentTimeMillis()}"
+            title = "Card Approval Event ${System.currentTimeMillis()}",
         )
-        val eventId = checkNotNull(event.id) { "Expected event id" }
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, board.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, board.username, board.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            EventPageHelper.open(page, frontendUrl)
-            EventPageHelper.waitForEventCardVisible(page, eventId)
+        EventPageHelper.open(page, frontendUrl)
+        EventPageHelper.waitForEventCardVisible(page, eventId)
 
-            val response = page.waitForResponse(
-                { r ->
-                    r.request().method() == "PUT" &&
-                            r.url().contains("/events/$eventId/approve") &&
-                            r.url().contains("approved=true")
-                }
-            ) {
-                EventPageHelper.clickApproveButton(page, eventId)
-            }
-            assertThat(response.status()).isEqualTo(200)
-        }
-
-        waitFor(
-            onTimeoutMessage = { "Expected event $eventId to become approved from event card action" }
+        val response = page.waitForResponse(
+            { r ->
+                r.request().method() == "PUT" &&
+                    r.url().contains("/events/$eventId/approve") &&
+                    r.url().contains("approved=true")
+            },
         ) {
-            eventRepository.findById(eventId).orElseThrow().approved
+            EventPageHelper.clickApproveButton(page, eventId)
+        }
+        assertThat(response.status()).isEqualTo(200)
+
+        pollFor("event $eventId becomes approved from event card action") {
+            TestHelper.findEvent(eventId)?.approved == true
         }
     }
 
     @Test
     fun `committee member can delete event from event card`() {
-        val member = userFactory.createUserWithRole(Role.COMMITTEE, enabled = true)
-        val committee = committeeFactory.create(name = "Delete Card Committee ${System.currentTimeMillis()}")
-        committeeFactory.createMember(committee, member)
-        val event = createCurrentMonthEvent(
-            committee = committee,
+        val member = TestHelper.registerActivateAndPromote("COMMITTEE")
+        val committeeId = TestHelper.createCommittee(name = "Delete Card Committee ${System.currentTimeMillis()}")
+        TestHelper.addCommitteeMember(committeeId, member.username)
+        val eventId = createCurrentMonthEvent(
+            committeeId = committeeId,
             approved = true,
             signUp = false,
-            title = "Delete Card Event ${System.currentTimeMillis()}"
+            title = "Delete Card Event ${System.currentTimeMillis()}",
         )
-        val eventId = checkNotNull(event.id) { "Expected event id" }
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, member.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, member.username, member.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            EventPageHelper.open(page, frontendUrl)
-            EventPageHelper.waitForEventCardVisible(page, eventId)
+        EventPageHelper.open(page, frontendUrl)
+        EventPageHelper.waitForEventCardVisible(page, eventId)
 
-            val response = page.waitForResponse(
-                { r -> r.request().method() == "DELETE" && r.url().contains("/events/$eventId") }
-            ) {
-                EventPageHelper.clickDeleteEventButton(page, eventId)
-                page.getByRole(
-                    AriaRole.BUTTON,
-                    Page.GetByRoleOptions().setName("Delete").setExact(true)
-                ).click()
-            }
-            assertThat(response.status()).isEqualTo(204)
-        }
-
-        waitFor(
-            onTimeoutMessage = { "Expected event $eventId to be deleted from event card action" }
+        val response = page.waitForResponse(
+            { r -> r.request().method() == "DELETE" && r.url().contains("/events/$eventId") },
         ) {
-            eventRepository.findById(eventId).isEmpty
+            EventPageHelper.clickDeleteEventButton(page, eventId)
+            page.getByRole(
+                AriaRole.BUTTON,
+                Page.GetByRoleOptions().setName("Delete").setExact(true),
+            ).click()
+        }
+        assertThat(response.status()).isEqualTo(204)
+
+        pollFor("event $eventId soft-deleted from event card action") {
+            TestHelper.findEvent(eventId) == null
         }
     }
 
     @Test
     fun `logged-in user can create event sign-up`() {
-        val member = userFactory.createUserWithRole(Role.MEMBER, enabled = true)
-        val committee = committeeFactory.create(name = "Signup Member Create Committee ${System.currentTimeMillis()}")
-        val event = createCurrentMonthEvent(
-            committee = committee,
+        val member = TestHelper.registerActivateAndPromote("MEMBER")
+        val memberId = TestHelper.findUser(member.username)!!.id
+        val committeeId = TestHelper.createCommittee(name = "Signup Member Create Committee ${System.currentTimeMillis()}")
+        val eventId = createCurrentMonthEvent(
+            committeeId = committeeId,
             approved = true,
             signUp = true,
-            title = "Member Signup Create Event ${System.currentTimeMillis()}"
+            title = "Member Signup Create Event ${System.currentTimeMillis()}",
         )
-        val eventId = checkNotNull(event.id) { "Expected event id" }
-        val memberId = checkNotNull(member.id) { "Expected member id" }
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, member.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, member.username, member.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            EventPageHelper.open(page, frontendUrl)
-            EventPageHelper.waitForEventCardVisible(page, eventId)
-            openSignUpForm(page, eventId)
+        EventPageHelper.open(page, frontendUrl)
+        EventPageHelper.waitForEventCardVisible(page, eventId)
+        openSignUpForm(page, eventId)
 
-            val createResponse = page.waitForResponse(
-                Predicate { r ->
-                    r.request().method() == "POST" &&
-                            r.url().contains("/events/$eventId/signups")
-                }
-            ) {
-                EventPageHelper.clickSubmitSignUpButton(page, eventId)
-            }
-            assertThat(createResponse.status()).isEqualTo(201)
-        }
-
-        waitFor(
-            onTimeoutMessage = { "Expected user sign-up to be persisted for user=$memberId event=$eventId" }
+        val createResponse = page.waitForResponse(
+            Predicate { r ->
+                r.request().method() == "POST" &&
+                    r.url().contains("/events/$eventId/signups")
+            },
         ) {
-            eventSignUpRepository.findByUser_IdAndEvent_Id(memberId, eventId).isPresent
+            EventPageHelper.clickSubmitSignUpButton(page, eventId)
+        }
+        assertThat(createResponse.status()).isEqualTo(201)
+
+        pollFor("user sign-up persisted for user=$memberId event=$eventId") {
+            TestHelper.findUserEventSignUp(eventId, memberId) != null
         }
     }
 
     @Test
     fun `logged-in user can update existing event sign-up`() {
-        val member = userFactory.createUserWithRole(Role.MEMBER, enabled = true)
-        val committee = committeeFactory.create(name = "Signup Member Update Committee ${System.currentTimeMillis()}")
-        val event = createCurrentMonthEvent(
-            committee = committee,
+        val member = TestHelper.registerActivateAndPromote("MEMBER")
+        val memberId = TestHelper.findUser(member.username)!!.id
+        val committeeId = TestHelper.createCommittee(name = "Signup Member Update Committee ${System.currentTimeMillis()}")
+        val eventId = createCurrentMonthEvent(
+            committeeId = committeeId,
             approved = true,
             signUp = true,
-            title = "Member Signup Update Event ${System.currentTimeMillis()}"
+            title = "Member Signup Update Event ${System.currentTimeMillis()}",
         )
-        val eventId = checkNotNull(event.id) { "Expected event id" }
-        val memberId = checkNotNull(member.id) { "Expected member id" }
-        val existingSignUp = eventFactory.createSignUp(event = event, user = member)
-        val existingSignUpId = checkNotNull(existingSignUp.id) { "Expected existing member sign-up id" }
+        val existingSignUpId = TestHelper.createUserEventSignUp(eventId, memberId)
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, member.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, member.username, member.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            EventPageHelper.open(page, frontendUrl)
-            EventPageHelper.waitForEventCardVisible(page, eventId)
-            openSignUpForm(page, eventId)
-            EventPageHelper.waitForSignUpMode(page, eventId, "update")
+        EventPageHelper.open(page, frontendUrl)
+        EventPageHelper.waitForEventCardVisible(page, eventId)
+        openSignUpForm(page, eventId)
+        EventPageHelper.waitForSignUpMode(page, eventId, "update")
 
-            val updateResponse = page.waitForResponse(
-                Predicate { r ->
-                    r.request().method() == "PUT" &&
-                            r.url().contains("/events/$eventId/signups")
-                }
-            ) {
-                EventPageHelper.clickSubmitSignUpButton(page, eventId)
-            }
-            assertThat(updateResponse.status()).isEqualTo(200)
-        }
-
-        waitFor(
-            onTimeoutMessage = {
-                "Expected updated user sign-up to remain persisted for user=$memberId event=$eventId signUp=$existingSignUpId"
-            }
+        val updateResponse = page.waitForResponse(
+            Predicate { r ->
+                r.request().method() == "PUT" &&
+                    r.url().contains("/events/$eventId/signups")
+            },
         ) {
-            eventSignUpRepository.findByUser_IdAndEvent_Id(memberId, eventId)
-                .map { it.id == existingSignUpId }
-                .orElse(false)
+            EventPageHelper.clickSubmitSignUpButton(page, eventId)
+        }
+        assertThat(updateResponse.status()).isEqualTo(200)
+
+        pollFor("user sign-up id $existingSignUpId persists after update for user=$memberId event=$eventId") {
+            TestHelper.findUserEventSignUp(eventId, memberId) == existingSignUpId
         }
     }
 
     @Test
     fun `logged-in user can delete existing event sign-up`() {
-        val member = userFactory.createUserWithRole(Role.MEMBER, enabled = true)
-        val committee = committeeFactory.create(name = "Signup Member Delete Committee ${System.currentTimeMillis()}")
-        val event = createCurrentMonthEvent(
-            committee = committee,
+        val member = TestHelper.registerActivateAndPromote("MEMBER")
+        val memberId = TestHelper.findUser(member.username)!!.id
+        val committeeId = TestHelper.createCommittee(name = "Signup Member Delete Committee ${System.currentTimeMillis()}")
+        val eventId = createCurrentMonthEvent(
+            committeeId = committeeId,
             approved = true,
             signUp = true,
-            title = "Member Signup Delete Event ${System.currentTimeMillis()}"
+            title = "Member Signup Delete Event ${System.currentTimeMillis()}",
         )
-        val eventId = checkNotNull(event.id) { "Expected event id" }
-        val existingSignUp = eventFactory.createSignUp(event = event, user = member)
-        val existingSignUpId = checkNotNull(existingSignUp.id) { "Expected existing member sign-up id" }
+        val existingSignUpId = TestHelper.createUserEventSignUp(eventId, memberId)
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, member.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, member.username, member.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            EventPageHelper.open(page, frontendUrl)
-            EventPageHelper.waitForEventCardVisible(page, eventId)
-            openSignUpForm(page, eventId)
-            EventPageHelper.waitForSignUpMode(page, eventId, "update")
-            EventPageHelper.deleteSignUpButton(page, eventId).waitFor()
+        EventPageHelper.open(page, frontendUrl)
+        EventPageHelper.waitForEventCardVisible(page, eventId)
+        openSignUpForm(page, eventId)
+        EventPageHelper.waitForSignUpMode(page, eventId, "update")
+        EventPageHelper.deleteSignUpButton(page, eventId).waitFor()
 
-            val deleteResponse = page.waitForResponse(
-                Predicate { r ->
-                    r.request().method() == "DELETE" &&
-                            r.url().contains("/events/signups/$existingSignUpId")
-                }
-            ) {
-                EventPageHelper.clickDeleteSignUpButton(page, eventId)
-            }
-            assertThat(deleteResponse.status()).isEqualTo(204)
-        }
-
-        waitFor(
-            onTimeoutMessage = { "Expected user sign-up to be deleted for signUp=$existingSignUpId" }
+        val deleteResponse = page.waitForResponse(
+            Predicate { r ->
+                r.request().method() == "DELETE" &&
+                    r.url().contains("/events/signups/$existingSignUpId")
+            },
         ) {
-            eventSignUpRepository.findById(existingSignUpId).isEmpty
+            EventPageHelper.clickDeleteSignUpButton(page, eventId)
+        }
+        assertThat(deleteResponse.status()).isEqualTo(204)
+
+        pollFor("user sign-up $existingSignUpId removed for event=$eventId") {
+            TestHelper.findUserEventSignUp(eventId, memberId) == null
         }
     }
 
     @Test
     fun `guest can create event sign-up`() {
-        val committee = committeeFactory.create(name = "Signup Guest Create Committee ${System.currentTimeMillis()}")
-        val event = createCurrentMonthEvent(
-            committee = committee,
+        val committeeId = TestHelper.createCommittee(name = "Signup Guest Create Committee ${System.currentTimeMillis()}")
+        val eventId = createCurrentMonthEvent(
+            committeeId = committeeId,
             approved = true,
             signUp = true,
-            title = "Guest Signup Create Event ${System.currentTimeMillis()}"
+            title = "Guest Signup Create Event ${System.currentTimeMillis()}",
         )
-        val eventId = checkNotNull(event.id) { "Expected event id" }
         val guestName = "Guest Original"
         val guestDiscord = "guest_original"
 
-        withPage { page ->
-            EventPageHelper.open(page, frontendUrl)
-            EventPageHelper.waitForEventCardVisible(page, eventId)
-            openSignUpForm(page, eventId)
+        EventPageHelper.open(page, frontendUrl)
+        EventPageHelper.waitForEventCardVisible(page, eventId)
+        openSignUpForm(page, eventId)
 
-            page.getByLabel("Full name*", Page.GetByLabelOptions().setExact(true)).fill(guestName)
-            page.getByLabel("Discord username*", Page.GetByLabelOptions().setExact(true)).fill(guestDiscord)
-            page.getByLabel("Email*", Page.GetByLabelOptions().setExact(true))
-                .fill("guest${System.currentTimeMillis()}@example.com")
-            page.getByLabel("Phone Number*", Page.GetByLabelOptions().setExact(true)).fill("+31612345678")
+        page.getByLabel("Full name*", Page.GetByLabelOptions().setExact(true)).fill(guestName)
+        page.getByLabel("Discord username*", Page.GetByLabelOptions().setExact(true)).fill(guestDiscord)
+        page.getByLabel("Email*", Page.GetByLabelOptions().setExact(true))
+            .fill("guest${System.currentTimeMillis()}@example.com")
+        page.getByLabel("Phone Number*", Page.GetByLabelOptions().setExact(true)).fill("+31612345678")
 
-            val createResponse = page.waitForResponse(
-                Predicate { r ->
-                    r.request().method() == "POST" &&
-                            r.url().contains("/events/$eventId/signups")
-                }
-            ) {
-                EventPageHelper.clickSubmitSignUpButton(page, eventId)
-            }
-            assertThat(createResponse.status()).isEqualTo(201)
-            checkNotNull(createResponse.headerValue("x-guest-access-token")) {
-                "Expected guest access token header after guest sign-up create"
-            }
+        val createResponse = page.waitForResponse(
+            Predicate { r ->
+                r.request().method() == "POST" &&
+                    r.url().contains("/events/$eventId/signups")
+            },
+        ) {
+            EventPageHelper.clickSubmitSignUpButton(page, eventId)
+        }
+        assertThat(createResponse.status()).isEqualTo(201)
+        checkNotNull(createResponse.headerValue("x-guest-access-token")) {
+            "Expected guest access token header after guest sign-up create"
         }
 
-        waitFor(
-            onTimeoutMessage = { "Expected at least one guest sign-up for event=$eventId" }
-        ) {
-            val signUp = eventSignUpRepository.findByEvent_Id(eventId).stream().findFirst()
-            signUp.isPresent && signUp.get().guest?.name == guestName && signUp.get().guest?.discord == guestDiscord
+        pollFor("guest sign-up for event=$eventId reflects submitted name/discord") {
+            val signUp = TestHelper.findGuestEventSignUp(eventId)
+            signUp != null && signUp.name == guestName && signUp.discord == guestDiscord
         }
     }
 
     @Test
     fun `guest can update existing event sign-up`() {
-        val committee = committeeFactory.create(name = "Signup Guest Update Committee ${System.currentTimeMillis()}")
-        val event = createCurrentMonthEvent(
-            committee = committee,
+        val committeeId = TestHelper.createCommittee(name = "Signup Guest Update Committee ${System.currentTimeMillis()}")
+        val eventId = createCurrentMonthEvent(
+            committeeId = committeeId,
             approved = true,
             signUp = true,
-            title = "Guest Signup Update Event ${System.currentTimeMillis()}"
+            title = "Guest Signup Update Event ${System.currentTimeMillis()}",
         )
-        val eventId = checkNotNull(event.id) { "Expected event id" }
         val originalGuestName = "Guest Original"
         val originalGuestDiscord = "guest_original"
         val originalGuestEmail = "guest-original-${System.currentTimeMillis()}@example.com"
@@ -306,138 +263,127 @@ class EventPageSystemTest : FrontendSystemTestBase() {
         val updatedGuestEmail = "guest-updated-${System.currentTimeMillis()}@example.com"
         val updatedGuestPhone = "+31687654321"
 
-        withPage { page ->
-            EventPageHelper.open(page, frontendUrl)
-            EventPageHelper.waitForEventCardVisible(page, eventId)
-            openSignUpForm(page, eventId)
-            fillGuestDetails(
-                page = page,
-                name = originalGuestName,
-                discord = originalGuestDiscord,
-                email = originalGuestEmail,
-                phoneNumber = originalGuestPhone
-            )
+        EventPageHelper.open(page, frontendUrl)
+        EventPageHelper.waitForEventCardVisible(page, eventId)
+        openSignUpForm(page, eventId)
+        fillGuestDetails(
+            page = page,
+            name = originalGuestName,
+            discord = originalGuestDiscord,
+            email = originalGuestEmail,
+            phoneNumber = originalGuestPhone,
+        )
 
-            val createResponse = page.waitForResponse(
-                Predicate { r ->
-                    r.request().method() == "POST" &&
-                            r.url().contains("/events/$eventId/signups")
-                }
-            ) {
-                EventPageHelper.clickSubmitSignUpButton(page, eventId)
-            }
-            assertThat(createResponse.status()).isEqualTo(201)
-            checkNotNull(createResponse.headerValue("x-guest-access-token")) {
-                "Expected guest access token header after guest sign-up create"
-            }
-
-            openSignUpForm(page, eventId)
-            EventPageHelper.waitForSignUpMode(page, eventId, "update")
-            fillGuestDetails(
-                page = page,
-                name = updatedGuestName,
-                discord = updatedGuestDiscord,
-                email = updatedGuestEmail,
-                phoneNumber = updatedGuestPhone
-            )
-
-            val updateResponse = page.waitForResponse(
-                Predicate { r ->
-                    r.request().method() == "PUT" &&
-                            r.url().contains("/events/$eventId/signups")
-                }
-            ) {
-                EventPageHelper.clickSubmitSignUpButton(page, eventId)
-            }
-            assertThat(updateResponse.status()).isEqualTo(200)
+        val createResponse = page.waitForResponse(
+            Predicate { r ->
+                r.request().method() == "POST" &&
+                    r.url().contains("/events/$eventId/signups")
+            },
+        ) {
+            EventPageHelper.clickSubmitSignUpButton(page, eventId)
+        }
+        assertThat(createResponse.status()).isEqualTo(201)
+        checkNotNull(createResponse.headerValue("x-guest-access-token")) {
+            "Expected guest access token header after guest sign-up create"
         }
 
-        waitFor(
-            onTimeoutMessage = { "Expected guest sign-up name update to be persisted for event=$eventId" }
+        openSignUpForm(page, eventId)
+        EventPageHelper.waitForSignUpMode(page, eventId, "update")
+        fillGuestDetails(
+            page = page,
+            name = updatedGuestName,
+            discord = updatedGuestDiscord,
+            email = updatedGuestEmail,
+            phoneNumber = updatedGuestPhone,
+        )
+
+        val updateResponse = page.waitForResponse(
+            Predicate { r ->
+                r.request().method() == "PUT" &&
+                    r.url().contains("/events/$eventId/signups")
+            },
         ) {
-            eventSignUpRepository.findByEvent_Id(eventId).stream().findFirst()
-                .map { signUp ->
-                    signUp.guest?.name == updatedGuestName &&
-                            signUp.guest?.discord == updatedGuestDiscord &&
-                            signUp.guest?.email == updatedGuestEmail &&
-                            signUp.guest?.phoneNumber == updatedGuestPhone
-                }
-                .orElse(false)
+            EventPageHelper.clickSubmitSignUpButton(page, eventId)
+        }
+        assertThat(updateResponse.status()).isEqualTo(200)
+
+        pollFor("guest sign-up reflects updated name/discord/email/phone for event=$eventId") {
+            val signUp = TestHelper.findGuestEventSignUp(eventId)
+            signUp != null &&
+                signUp.name == updatedGuestName &&
+                signUp.discord == updatedGuestDiscord &&
+                signUp.email == updatedGuestEmail &&
+                signUp.phoneNumber == updatedGuestPhone
         }
     }
 
     @Test
     fun `guest can delete existing event sign-up`() {
-        val committee = committeeFactory.create(name = "Signup Guest Delete Committee ${System.currentTimeMillis()}")
-        val event = createCurrentMonthEvent(
-            committee = committee,
+        val committeeId = TestHelper.createCommittee(name = "Signup Guest Delete Committee ${System.currentTimeMillis()}")
+        val eventId = createCurrentMonthEvent(
+            committeeId = committeeId,
             approved = true,
             signUp = true,
-            title = "Guest Signup Delete Event ${System.currentTimeMillis()}"
+            title = "Guest Signup Delete Event ${System.currentTimeMillis()}",
         )
-        val eventId = checkNotNull(event.id) { "Expected event id" }
         val originalGuestName = "Guest Delete"
         val originalGuestDiscord = "guest_delete"
         val originalGuestEmail = "guest-delete-${System.currentTimeMillis()}@example.com"
-        var existingSignUpId: Long? = null
 
-        withPage { page ->
-            EventPageHelper.open(page, frontendUrl)
-            EventPageHelper.waitForEventCardVisible(page, eventId)
-            openSignUpForm(page, eventId)
-            fillGuestDetails(
-                page = page,
-                name = originalGuestName,
-                discord = originalGuestDiscord,
-                email = originalGuestEmail,
-                phoneNumber = "+31612345678"
-            )
+        EventPageHelper.open(page, frontendUrl)
+        EventPageHelper.waitForEventCardVisible(page, eventId)
+        openSignUpForm(page, eventId)
+        fillGuestDetails(
+            page = page,
+            name = originalGuestName,
+            discord = originalGuestDiscord,
+            email = originalGuestEmail,
+            phoneNumber = "+31612345678",
+        )
 
-            val createResponse = page.waitForResponse(
-                Predicate { r ->
-                    r.request().method() == "POST" &&
-                            r.url().contains("/events/$eventId/signups")
-                }
-            ) {
-                EventPageHelper.clickSubmitSignUpButton(page, eventId)
-            }
-            assertThat(createResponse.status()).isEqualTo(201)
-            checkNotNull(createResponse.headerValue("x-guest-access-token")) {
-                "Expected guest access token header after guest sign-up create"
-            }
-            existingSignUpId = waitForOptional(
-                producer = { eventSignUpRepository.findByEvent_Id(eventId).stream().findFirst() },
-                onTimeoutMessage = { "Expected persisted guest sign-up for event=$eventId before delete" }
-            ).id
-
-            openSignUpForm(page, eventId)
-            EventPageHelper.waitForSignUpMode(page, eventId, "update")
-            EventPageHelper.deleteSignUpButton(page, eventId).waitFor()
-            EventPageHelper.clickDeleteSignUpButton(page, eventId)
+        val createResponse = page.waitForResponse(
+            Predicate { r ->
+                r.request().method() == "POST" &&
+                    r.url().contains("/events/$eventId/signups")
+            },
+        ) {
+            EventPageHelper.clickSubmitSignUpButton(page, eventId)
+        }
+        assertThat(createResponse.status()).isEqualTo(201)
+        checkNotNull(createResponse.headerValue("x-guest-access-token")) {
+            "Expected guest access token header after guest sign-up create"
         }
 
-        waitFor(
-            onTimeoutMessage = { "Expected guest sign-up to be deleted for signUp=$existingSignUpId" }
-        ) {
-            eventSignUpRepository.findById(checkNotNull(existingSignUpId)).isEmpty
+        val existingSignUpId = pollForValue("persisted guest sign-up for event=$eventId before delete") {
+            TestHelper.findGuestEventSignUp(eventId)?.id
+        }
+
+        openSignUpForm(page, eventId)
+        EventPageHelper.waitForSignUpMode(page, eventId, "update")
+        EventPageHelper.deleteSignUpButton(page, eventId).waitFor()
+        EventPageHelper.clickDeleteSignUpButton(page, eventId)
+
+        pollFor("guest sign-up $existingSignUpId removed for event=$eventId") {
+            TestHelper.findGuestEventSignUp(eventId) == null
         }
     }
 
     private fun createCurrentMonthEvent(
-        committee: net.blueshell.api.domain.committee.persistence.Committee,
+        committeeId: Long,
         approved: Boolean,
         signUp: Boolean,
-        title: String
-    ): Event {
-        val event = eventFactory.create(
-            committee = committee,
+        title: String,
+    ): Long {
+        val startTime = Instant.now().plusSeconds(2 * 3600)
+        val endTime = Instant.now().plusSeconds(3 * 3600)
+        return TestHelper.createEvent(
+            committeeId = committeeId,
+            title = title,
+            startTime = startTime,
+            endTime = endTime,
             approved = approved,
             signUp = signUp,
-            title = title
         )
-        event.startTime = Instant.now().plusSeconds(2 * 3600)
-        event.endTime = Instant.now().plusSeconds(3 * 3600)
-        return eventRepository.saveAndFlush(event)
     }
 
     private fun openSignUpForm(page: Page, eventId: Long) {
@@ -450,7 +396,7 @@ class EventPageSystemTest : FrontendSystemTestBase() {
         name: String,
         discord: String,
         email: String,
-        phoneNumber: String
+        phoneNumber: String,
     ) {
         page.getByLabel("Full name*", Page.GetByLabelOptions().setExact(true)).fill(name)
         page.getByLabel("Discord username*", Page.GetByLabelOptions().setExact(true)).fill(discord)
@@ -458,7 +404,26 @@ class EventPageSystemTest : FrontendSystemTestBase() {
         page.getByLabel("Phone Number*", Page.GetByLabelOptions().setExact(true)).fill(phoneNumber)
     }
 
-    private companion object {
-        const val DEFAULT_PASSWORD = "Password123!"
+    private fun pollFor(description: String, timeoutMs: Long = 10_000, predicate: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (predicate()) return
+            Thread.sleep(200)
+        }
+        throw AssertionError("Expected $description within ${timeoutMs}ms")
+    }
+
+    private fun <T : Any> pollForValue(
+        description: String,
+        timeoutMs: Long = 10_000,
+        producer: () -> T?,
+    ): T {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            val value = producer()
+            if (value != null) return value
+            Thread.sleep(200)
+        }
+        throw AssertionError("Expected $description within ${timeoutMs}ms")
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -917,6 +917,76 @@ object TestHelper {
             }
         }
 
+    /**
+     * Insert an `event_signups` row tying the given user to an event.
+     * Skipping the controller because the membership-only/active
+     * checks are evaluated against the *current* logged-in principal;
+     * the tests that need a pre-existing signup just want a row to
+     * exist so the UI flips into "update" mode.
+     */
+    fun createUserEventSignUp(eventId: Long, userId: Long): Long {
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            return conn.prepareStatement(
+                "INSERT INTO event_signups (event_id, user_id) VALUES (?, ?)",
+                java.sql.Statement.RETURN_GENERATED_KEYS,
+            ).use { stmt ->
+                stmt.setLong(1, eventId)
+                stmt.setLong(2, userId)
+                stmt.executeUpdate()
+                val keys = stmt.generatedKeys
+                require(keys.next()) { "INSERT event_signups produced no id" }
+                keys.getLong(1)
+            }
+        }
+    }
+
+    /**
+     * Read the active `event_signups` row for (event, user). Returns
+     * null when the user never signed up or the row was soft-deleted.
+     */
+    fun findUserEventSignUp(eventId: Long, userId: Long): Long? =
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            conn.prepareStatement(
+                "SELECT id FROM event_signups " +
+                    "WHERE event_id = ? AND user_id = ? AND $ACTIVE_ROW_PREDICATE",
+            ).use { stmt ->
+                stmt.setLong(1, eventId)
+                stmt.setLong(2, userId)
+                val rs = stmt.executeQuery()
+                if (rs.next()) rs.getLong("id") else null
+            }
+        }
+
+    /**
+     * Read the first active guest-backed `event_signups` row for a
+     * given event, joined with the `guests` row so callers can assert
+     * the guest details that the api persisted from the form payload.
+     */
+    fun findGuestEventSignUp(eventId: Long): GuestSignUpRow? =
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            conn.prepareStatement(
+                "SELECT es.id AS signup_id, g.name, g.discord, g.email, g.phone_number " +
+                    "FROM event_signups es JOIN guests g ON es.guest_id = g.id " +
+                    "WHERE es.event_id = ? AND es.$ACTIVE_ROW_PREDICATE " +
+                    "AND g.$ACTIVE_ROW_PREDICATE " +
+                    "ORDER BY es.id DESC LIMIT 1",
+            ).use { stmt ->
+                stmt.setLong(1, eventId)
+                val rs = stmt.executeQuery()
+                if (rs.next()) {
+                    GuestSignUpRow(
+                        id = rs.getLong("signup_id"),
+                        name = rs.getString("name"),
+                        discord = rs.getString("discord"),
+                        email = rs.getString("email"),
+                        phoneNumber = rs.getString("phone_number"),
+                    )
+                } else {
+                    null
+                }
+            }
+        }
+
     private fun java.sql.ResultSet.toEventRow(): EventRow = EventRow(
         id = getLong("id"),
         title = getString("title"),
@@ -1077,6 +1147,14 @@ object TestHelper {
         val membersOnly: Boolean,
         val committeeId: Long?,
         val signUpLimit: Int?,
+    )
+
+    data class GuestSignUpRow(
+        val id: Long,
+        val name: String,
+        val discord: String,
+        val email: String,
+        val phoneNumber: String?,
     )
 
     data class AddressRow(


### PR DESCRIPTION
## Why
`EventPageSystemTest` still autowired `UserFactory`, `CommitteeFactory`, `EventFactory`, `EventRepository`, and `EventSignUpRepository` from the in-process api context. With eight scenarios depending on those beans, the test class blocked the next step of running the system-tests module against a deployed api over HTTP.

## What this achieves
All eight scenarios in the event card surface (board approval, committee-member delete, member create/update/delete signup, guest create/update/delete signup) now drive setup through `TestHelper` and read persistence state back via JDBC. The test class compiles without any reference to the api's domain or factory packages.

## How
- `EventPageSystemTest.kt` now extends `PlaywrightTestBase` and seeds state through `TestHelper.registerActivateAndPromote`, `TestHelper.createCommittee`, `TestHelper.addCommitteeMember`, and `TestHelper.createEvent`. Assertions read state via `TestHelper.findEvent` (approval / soft-delete), `TestHelper.findUserEventSignUp` (member signup id), and `TestHelper.findGuestEventSignUp` (guest signup details). Guest tests still drive the UI form to mint guest rows; only the persistence-side checks moved to JDBC.
- `TestHelper.createUserEventSignUp(eventId, userId)`: JDBC INSERT against `event_signups`. The "update" and "delete" member tests need a pre-existing signup; going through `POST /events/{id}/signups` would require logging in as the target user and is heavier than is warranted for a setup-only row.
- `TestHelper.findUserEventSignUp(eventId, userId)`: returns the active signup id (or null) so the update test can assert the same row was kept rather than re-created.
- `TestHelper.findGuestEventSignUp(eventId)`: joins `event_signups` with `guests` and returns the latest row's id + name/discord/email/phone, mirroring what the assertion side previously read off the entity.