### PR TITLE
test(system): migrate EventSignUpsPageSystemTest off Spring beans

### DIFF
--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventSignUpsPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventSignUpsPageSystemTest.kt
@@ -1,279 +1,218 @@
 package net.blueshell.api.system.frontend.events
 
 import com.microsoft.playwright.Page
-import net.blueshell.api.domain.user.application.erasure.UserErasureService
-import net.blueshell.api.domain.event.persistence.Event
-import net.blueshell.api.domain.event.persistence.EventSignUpAnswer
-import net.blueshell.api.domain.event.persistence.repository.EventRepository
-import net.blueshell.api.domain.survey.persistence.Answer
-import net.blueshell.api.domain.survey.persistence.Question
-import net.blueshell.api.domain.survey.persistence.Survey
-import net.blueshell.api.domain.survey.persistence.repository.AnswerRepository
-import net.blueshell.api.factory.committee.persistence.CommitteeFactory
-import net.blueshell.api.factory.event.persistence.EventFactory
-import net.blueshell.api.factory.support.FactoryPersistenceSupport
-import net.blueshell.api.factory.user.persistence.UserFactory
-import net.blueshell.api.shared.enums.QuestionType
-import net.blueshell.api.shared.enums.Role
-import net.blueshell.api.system.frontend.FrontendSystemTestBase
+import net.blueshell.api.ApiApplication
+import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
+import net.blueshell.systemtests.PlaywrightTestBase
+import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestExecutionListeners
+import java.time.Instant
 import java.util.function.Predicate
 
 @Tag("system")
-class EventSignUpsPageSystemTest : FrontendSystemTestBase() {
-
-    @Autowired
-    private lateinit var userFactory: UserFactory
-
-    @Autowired
-    private lateinit var committeeFactory: CommitteeFactory
-
-    @Autowired
-    private lateinit var eventFactory: EventFactory
-
-    @Autowired
-    private lateinit var eventRepository: EventRepository
-
-    @Autowired
-    private lateinit var answerRepository: AnswerRepository
-
-    @Autowired
-    private lateinit var persistence: FactoryPersistenceSupport
-
-    @Autowired
-    private lateinit var erasure: UserErasureService
+@ActiveProfiles("test")
+@TestExecutionListeners(
+    listeners = [TestCleanUpListener::class],
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+)
+@SpringBootTest(
+    classes = [ApiApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
+)
+class EventSignUpsPageSystemTest : PlaywrightTestBase() {
 
     @Test
     fun `committee member sees sign-up respondents answers and totals`() {
         val seeded = seedEventSignUpsData()
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, seeded.viewer.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, seeded.viewer.username, seeded.viewer.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            val signupsResponse = page.waitForResponse(
-                Predicate { response ->
-                    response.request().method() == "GET" &&
-                        response.url().contains("/events/${seeded.eventId}/signups")
-                }
-            ) {
-                page.navigate("$frontendUrl/events/signups/${seeded.eventId}")
-            }
-            assertThat(signupsResponse.status()).isEqualTo(200)
-
-            waitFor(
-                onTimeoutMessage = { "Expected respondent rows on sign-ups page for event=${seeded.eventId}" }
-            ) {
-                page.locator(".attendees-table tbody tr").count() >= 2
-            }
-
-            assertThat(
-                page.getByText(seeded.guestName, Page.GetByTextOptions().setExact(true)).count()
-            ).isGreaterThan(0)
-
-            assertThat(
-                page.getByText(seeded.memberOpenAnswer, Page.GetByTextOptions().setExact(true)).count()
-            ).isGreaterThan(0)
-            assertThat(
-                page.getByText(seeded.guestOpenAnswer, Page.GetByTextOptions().setExact(true)).count()
-            ).isGreaterThan(0)
-
-            assertThat(questionTotals(page, seeded.radioQuestionLabel)).containsExactly("1", "1")
-            assertThat(questionTotals(page, seeded.checkboxQuestionLabel)).containsExactly("1", "1", "1")
+        val signupsResponse = page.waitForResponse(
+            Predicate { response ->
+                response.request().method() == "GET" &&
+                    response.url().contains("/events/${seeded.eventId}/signups")
+            },
+        ) {
+            page.navigate("$frontendUrl/events/signups/${seeded.eventId}")
         }
+        assertThat(signupsResponse.status()).isEqualTo(200)
+
+        pollFor("respondent rows on sign-ups page for event=${seeded.eventId}") {
+            page.locator(".attendees-table tbody tr").count() >= 2
+        }
+
+        assertThat(
+            page.getByText(seeded.guestName, Page.GetByTextOptions().setExact(true)).count(),
+        ).isGreaterThan(0)
+
+        assertThat(
+            page.getByText(seeded.memberOpenAnswer, Page.GetByTextOptions().setExact(true)).count(),
+        ).isGreaterThan(0)
+        assertThat(
+            page.getByText(seeded.guestOpenAnswer, Page.GetByTextOptions().setExact(true)).count(),
+        ).isGreaterThan(0)
+
+        assertThat(questionTotals(page, seeded.radioQuestionLabel)).containsExactly("1", "1")
+        assertThat(questionTotals(page, seeded.checkboxQuestionLabel)).containsExactly("1", "1", "1")
     }
 
     @Test
     fun `non committee user gets forbidden response on sign-up list`() {
         val seeded = seedEventSignUpsData()
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, seeded.outsider.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, seeded.outsider.username, seeded.outsider.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            val signupsResponse = page.waitForResponse(
-                Predicate { response ->
-                    response.request().method() == "GET" &&
-                        response.url().contains("/events/${seeded.eventId}/signups")
-                }
-            ) {
-                page.navigate("$frontendUrl/events/signups/${seeded.eventId}")
-            }
-            assertThat(signupsResponse.status()).isIn(401, 403)
-
-            assertThat(
-                page.getByText(seeded.guestName, Page.GetByTextOptions().setExact(true)).count()
-            ).isEqualTo(0)
+        val signupsResponse = page.waitForResponse(
+            Predicate { response ->
+                response.request().method() == "GET" &&
+                    response.url().contains("/events/${seeded.eventId}/signups")
+            },
+        ) {
+            page.navigate("$frontendUrl/events/signups/${seeded.eventId}")
         }
+        assertThat(signupsResponse.status()).isIn(401, 403)
+
+        assertThat(
+            page.getByText(seeded.guestName, Page.GetByTextOptions().setExact(true)).count(),
+        ).isEqualTo(0)
     }
 
     @Test
     fun `deleted signup user remains visible on sign-up page as anonymized identity`() {
         val seeded = seedEventSignUpsData()
-        val deletedUserId = checkNotNull(seeded.memberRespondent.id) { "Expected member respondent id" }
-        erasure.deleteUser(deletedUserId)
+        TestHelper.eraseUser(seeded.memberRespondent.username)
 
-        withPage { page ->
-            val loginStatus = AuthHelper.submitLogin(page, frontendUrl, seeded.viewer.username, DEFAULT_PASSWORD)
-            assertThat(loginStatus).isEqualTo(200)
+        val loginStatus = AuthHelper.submitLogin(page, frontendUrl, seeded.viewer.username, seeded.viewer.password)
+        assertThat(loginStatus).isEqualTo(200)
 
-            val signupsResponse = page.waitForResponse(
-                Predicate { response ->
-                    response.request().method() == "GET" &&
-                        response.url().contains("/events/${seeded.eventId}/signups")
-                }
-            ) {
-                page.navigate("$frontendUrl/events/signups/${seeded.eventId}")
-            }
-            assertThat(signupsResponse.status()).isEqualTo(200)
-
-            waitFor(
-                onTimeoutMessage = { "Expected respondent rows on sign-ups page for event=${seeded.eventId}" }
-            ) {
-                page.locator(".attendees-table tbody tr").count() >= 2
-            }
-
-            waitFor(
-                onTimeoutMessage = {
-                    "Expected deleted signup user to remain visible as anonymized identity 'Deleted User'"
-                }
-            ) {
-                page.getByText("Deleted User", Page.GetByTextOptions().setExact(true)).count() > 0
-            }
-
-            assertThat(
-                page.getByText(seeded.memberOpenAnswer, Page.GetByTextOptions().setExact(true)).count()
-            ).isGreaterThan(0)
+        val signupsResponse = page.waitForResponse(
+            Predicate { response ->
+                response.request().method() == "GET" &&
+                    response.url().contains("/events/${seeded.eventId}/signups")
+            },
+        ) {
+            page.navigate("$frontendUrl/events/signups/${seeded.eventId}")
         }
+        assertThat(signupsResponse.status()).isEqualTo(200)
+
+        pollFor("respondent rows on sign-ups page for event=${seeded.eventId}") {
+            page.locator(".attendees-table tbody tr").count() >= 2
+        }
+
+        pollFor("deleted signup user appears as anonymized identity 'Deleted User'") {
+            page.getByText("Deleted User", Page.GetByTextOptions().setExact(true)).count() > 0
+        }
+
+        assertThat(
+            page.getByText(seeded.memberOpenAnswer, Page.GetByTextOptions().setExact(true)).count(),
+        ).isGreaterThan(0)
     }
 
     private fun seedEventSignUpsData(): SeededSignUpsData {
         val marker = System.currentTimeMillis()
 
-        val viewer = userFactory.createUserWithRole(Role.COMMITTEE, enabled = true)
-        val outsider = userFactory.createUserWithRole(Role.MEMBER, enabled = true)
-        val memberRespondent = userFactory.createUserWithRole(Role.MEMBER, enabled = true)
-        val committee = committeeFactory.create(name = "Signups Committee $marker")
-        committeeFactory.createMember(committee, viewer)
+        val viewer = TestHelper.registerActivateAndPromote("COMMITTEE")
+        val outsider = TestHelper.registerActivateAndPromote("MEMBER")
+        val memberRespondent = TestHelper.registerActivateAndPromote("MEMBER")
+        val viewerId = TestHelper.findUser(viewer.username)!!.id
+        val memberRespondentId = TestHelper.findUser(memberRespondent.username)!!.id
 
-        val event = eventFactory.create(
-            committee = committee,
+        val committeeId = TestHelper.createCommittee(name = "Signups Committee $marker")
+        TestHelper.addCommitteeMember(committeeId, viewer.username)
+
+        val eventId = TestHelper.createEvent(
+            committeeId = committeeId,
+            title = "Event SignUps $marker",
+            startTime = Instant.now().plusSeconds(2 * 3600),
+            endTime = Instant.now().plusSeconds(3 * 3600),
             approved = true,
             signUp = true,
-            title = "Event SignUps $marker"
         )
 
-        val signUpForm = Survey()
+        val surveyId = TestHelper.attachSurveyToEvent(eventId)
         val openQuestionLabel = "What do you expect?"
         val radioQuestionLabel = "Do you need transport?"
         val checkboxQuestionLabel = "Preferred activities"
-        signUpForm.replaceQuestions(
-            listOf(
-                Question(
-                    idx = 0,
-                    survey = signUpForm,
-                    type = QuestionType.OPEN,
-                    label = openQuestionLabel
-                ),
-                Question(
-                    idx = 1,
-                    survey = signUpForm,
-                    type = QuestionType.RADIO,
-                    label = radioQuestionLabel,
-                    choiceLabels = mutableListOf("Yes", "No")
-                ),
-                Question(
-                    idx = 2,
-                    survey = signUpForm,
-                    type = QuestionType.CHECKBOX,
-                    label = checkboxQuestionLabel,
-                    choiceLabels = mutableListOf("LAN", "Board Games", "Dinner")
-                )
-            )
+
+        val openQuestionId = TestHelper.createQuestion(
+            surveyId = surveyId,
+            idx = 0,
+            type = "OPEN",
+            label = openQuestionLabel,
         )
-        event.replaceSignUpForm(signUpForm)
-        val persistedEvent: Event = eventRepository.saveAndFlush(event)
-        val eventId = checkNotNull(persistedEvent.id) { "Expected persisted event id" }
+        val radioQuestionId = TestHelper.createQuestion(
+            surveyId = surveyId,
+            idx = 1,
+            type = "RADIO",
+            label = radioQuestionLabel,
+            choiceLabels = listOf("Yes", "No"),
+        )
+        val checkboxQuestionId = TestHelper.createQuestion(
+            surveyId = surveyId,
+            idx = 2,
+            type = "CHECKBOX",
+            label = checkboxQuestionLabel,
+            choiceLabels = listOf("LAN", "Board Games", "Dinner"),
+        )
 
-        val questionsByLabel = persistedEvent.signUpForm
-            ?.questions
-            ?.associateBy { it.label }
-            .orEmpty()
-        val openQuestion = checkNotNull(questionsByLabel[openQuestionLabel]) { "Expected open question to be persisted" }
-        val radioQuestion = checkNotNull(questionsByLabel[radioQuestionLabel]) { "Expected radio question to be persisted" }
-        val checkboxQuestion =
-            checkNotNull(questionsByLabel[checkboxQuestionLabel]) { "Expected checkbox question to be persisted" }
-
-        val memberSignUp = eventFactory.createSignUp(persistedEvent, user = memberRespondent)
+        val memberSignUpId = TestHelper.createUserEventSignUp(eventId, memberRespondentId)
         val guestName = "Guest $marker"
-        val guest = eventFactory.createGuest(name = guestName, accessToken = "guest-token-$marker")
-        val guestSignUp = eventFactory.createSignUp(persistedEvent, guest = guest)
+        val guestId = TestHelper.createGuest(
+            name = guestName,
+            discord = "guest_$marker",
+            email = "guest-$marker@example.com",
+            accessToken = "guest-token-$marker",
+        )
+        val guestSignUpId = TestHelper.createGuestEventSignUp(eventId, guestId)
 
         val memberOpenAnswer = "Member open answer $marker"
         val guestOpenAnswer = "Guest open answer $marker"
 
-        val memberAnswers = listOf(
-            answerRepository.saveAndFlush(Answer(question = openQuestion, textResponse = memberOpenAnswer)),
-            answerRepository.saveAndFlush(
-                Answer(
-                    question = radioQuestion,
-                    optionSelections = mutableListOf(true, false)
-                )
-            ),
-            answerRepository.saveAndFlush(
-                Answer(
-                    question = checkboxQuestion,
-                    optionSelections = mutableListOf(true, false, true)
-                )
-            )
+        TestHelper.createEventSignUpAnswer(memberSignUpId, openQuestionId, textResponse = memberOpenAnswer)
+        TestHelper.createEventSignUpAnswer(
+            memberSignUpId,
+            radioQuestionId,
+            optionSelections = listOf(true, false),
         )
-        val guestAnswers = listOf(
-            answerRepository.saveAndFlush(Answer(question = openQuestion, textResponse = guestOpenAnswer)),
-            answerRepository.saveAndFlush(
-                Answer(
-                    question = radioQuestion,
-                    optionSelections = mutableListOf(false, true)
-                )
-            ),
-            answerRepository.saveAndFlush(
-                Answer(
-                    question = checkboxQuestion,
-                    optionSelections = mutableListOf(false, true, false)
-                )
-            )
+        TestHelper.createEventSignUpAnswer(
+            memberSignUpId,
+            checkboxQuestionId,
+            optionSelections = listOf(true, false, true),
         )
 
-        memberAnswers.forEach { answer ->
-            persistence.persist(
-                EventSignUpAnswer(
-                    eventSignUp = memberSignUp,
-                    answer = answer
-                )
-            )
-        }
-        guestAnswers.forEach { answer ->
-            persistence.persist(
-                EventSignUpAnswer(
-                    eventSignUp = guestSignUp,
-                    answer = answer
-                )
-            )
-        }
+        TestHelper.createEventSignUpAnswer(guestSignUpId, openQuestionId, textResponse = guestOpenAnswer)
+        TestHelper.createEventSignUpAnswer(
+            guestSignUpId,
+            radioQuestionId,
+            optionSelections = listOf(false, true),
+        )
+        TestHelper.createEventSignUpAnswer(
+            guestSignUpId,
+            checkboxQuestionId,
+            optionSelections = listOf(false, true, false),
+        )
 
         return SeededSignUpsData(
             eventId = eventId,
             viewer = viewer,
+            viewerId = viewerId,
             outsider = outsider,
             memberRespondent = memberRespondent,
+            memberRespondentId = memberRespondentId,
             guestName = guestName,
             memberOpenAnswer = memberOpenAnswer,
             guestOpenAnswer = guestOpenAnswer,
             radioQuestionLabel = radioQuestionLabel,
-            checkboxQuestionLabel = checkboxQuestionLabel
+            checkboxQuestionLabel = checkboxQuestionLabel,
         )
     }
 
@@ -281,9 +220,7 @@ class EventSignUpsPageSystemTest : FrontendSystemTestBase() {
         val questionCard = page.locator(".v-card:has(.v-card-title:has-text(\"$questionLabel\"))").first()
         val totalsCells = questionCard.locator(".radio-table tfoot tr td")
 
-        waitFor(
-            onTimeoutMessage = { "Expected totals row to be visible for question '$questionLabel'" }
-        ) {
+        pollFor("totals row visible for question '$questionLabel'") {
             totalsCells.count() > 1
         }
 
@@ -291,19 +228,26 @@ class EventSignUpsPageSystemTest : FrontendSystemTestBase() {
             .map { idx -> totalsCells.nth(idx).innerText().trim() }
     }
 
+    private fun pollFor(description: String, timeoutMs: Long = 10_000, predicate: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (predicate()) return
+            Thread.sleep(200)
+        }
+        throw AssertionError("Expected $description within ${timeoutMs}ms")
+    }
+
     private data class SeededSignUpsData(
         val eventId: Long,
-        val viewer: net.blueshell.api.domain.user.persistence.User,
-        val outsider: net.blueshell.api.domain.user.persistence.User,
-        val memberRespondent: net.blueshell.api.domain.user.persistence.User,
+        val viewer: TestHelper.RegisteredUser,
+        val viewerId: Long,
+        val outsider: TestHelper.RegisteredUser,
+        val memberRespondent: TestHelper.RegisteredUser,
+        val memberRespondentId: Long,
         val guestName: String,
         val memberOpenAnswer: String,
         val guestOpenAnswer: String,
         val radioQuestionLabel: String,
-        val checkboxQuestionLabel: String
+        val checkboxQuestionLabel: String,
     )
-
-    private companion object {
-        const val DEFAULT_PASSWORD = "Password123!"
-    }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -1150,31 +1150,40 @@ object TestHelper {
     }
 
     /**
-     * Insert an `event_sign_up_answers` row mirroring the JPA
-     * `EventSignUpAnswer` shape — the row stores both the answer link
-     * and a flattened `text_response` / `option_selections` so reads
-     * don't need to walk back through `answers`. Returns the row id.
+     * Insert an `answers` row + the matching `event_sign_up_answers`
+     * link in one call. V24 split the response payload out of
+     * `event_sign_up_answers` into the `answers` table — the link
+     * table now only carries `event_sign_up_id` and `answer_id`. The
+     * payload (`text_response` / `option_selections`) lives in
+     * `answers` keyed by `question_id`. Returns the new
+     * `event_sign_up_answers.id`.
      */
     fun createEventSignUpAnswer(
         eventSignUpId: Long,
         questionId: Long,
-        answerId: Long? = null,
         textResponse: String? = null,
         optionSelections: List<Boolean>? = null,
     ): Long {
         val optionsJson = optionSelections?.joinToString(prefix = "[", postfix = "]") { if (it) "true" else "false" }
         DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            val answerId = conn.prepareStatement(
+                "INSERT INTO answers (question_id, option_selections, text_response) VALUES (?, ?, ?)",
+                java.sql.Statement.RETURN_GENERATED_KEYS,
+            ).use { stmt ->
+                stmt.setLong(1, questionId)
+                if (optionsJson != null) stmt.setString(2, optionsJson) else stmt.setNull(2, java.sql.Types.VARCHAR)
+                if (textResponse != null) stmt.setString(3, textResponse) else stmt.setNull(3, java.sql.Types.VARCHAR)
+                stmt.executeUpdate()
+                val keys = stmt.generatedKeys
+                require(keys.next()) { "INSERT answers produced no id" }
+                keys.getLong(1)
+            }
             return conn.prepareStatement(
-                "INSERT INTO event_sign_up_answers " +
-                    "(event_sign_up_id, answer_id, question_id, option_selections, text_response) " +
-                    "VALUES (?, ?, ?, ?, ?)",
+                "INSERT INTO event_sign_up_answers (event_sign_up_id, answer_id) VALUES (?, ?)",
                 java.sql.Statement.RETURN_GENERATED_KEYS,
             ).use { stmt ->
                 stmt.setLong(1, eventSignUpId)
-                if (answerId != null) stmt.setLong(2, answerId) else stmt.setNull(2, java.sql.Types.BIGINT)
-                stmt.setLong(3, questionId)
-                if (optionsJson != null) stmt.setString(4, optionsJson) else stmt.setNull(4, java.sql.Types.VARCHAR)
-                if (textResponse != null) stmt.setString(5, textResponse) else stmt.setNull(5, java.sql.Types.VARCHAR)
+                stmt.setLong(2, answerId)
                 stmt.executeUpdate()
                 val keys = stmt.generatedKeys
                 require(keys.next()) { "INSERT event_sign_up_answers produced no id" }

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -980,7 +980,8 @@ object TestHelper {
      * Skipping the controller because the membership-only/active
      * checks are evaluated against the *current* logged-in principal;
      * the tests that need a pre-existing signup just want a row to
-     * exist so the UI flips into "update" mode.
+     * exist so the UI flips into "update" mode, or so a follow-up
+     * helper can attach answers to a known signup id.
      */
     fun createUserEventSignUp(eventId: Long, userId: Long): Long {
         DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
@@ -1044,6 +1045,149 @@ object TestHelper {
                 }
             }
         }
+
+    /**
+     * Insert a `surveys` row and point `events.survey_id` at it. The
+     * `surveys.event_id` column was dropped in V24 — the relationship
+     * is now one-way from event to survey via `events.survey_id`.
+     * Returns the survey id so the caller can attach questions.
+     */
+    fun attachSurveyToEvent(eventId: Long): Long {
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            val surveyId = conn.prepareStatement(
+                "INSERT INTO surveys () VALUES ()",
+                java.sql.Statement.RETURN_GENERATED_KEYS,
+            ).use { stmt ->
+                stmt.executeUpdate()
+                val keys = stmt.generatedKeys
+                require(keys.next()) { "INSERT surveys produced no id" }
+                keys.getLong(1)
+            }
+            conn.prepareStatement("UPDATE events SET survey_id = ? WHERE id = ?").use { stmt ->
+                stmt.setLong(1, surveyId)
+                stmt.setLong(2, eventId)
+                stmt.executeUpdate()
+            }
+            return surveyId
+        }
+    }
+
+    /**
+     * Insert a `questions` row attached to the given survey. `type` is
+     * one of `OPEN`, `RADIO`, `CHECKBOX`; `choiceLabels` is encoded as
+     * JSON for RADIO/CHECKBOX. Returns the question id.
+     */
+    fun createQuestion(
+        surveyId: Long,
+        idx: Int,
+        type: String,
+        label: String,
+        choiceLabels: List<String>? = null,
+    ): Long {
+        val choiceJson = choiceLabels?.joinToString(prefix = "[", postfix = "]") {
+            "\"" + it.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+        }
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            return conn.prepareStatement(
+                "INSERT INTO questions (survey_id, type, label, choice_labels, idx) VALUES (?, ?, ?, ?, ?)",
+                java.sql.Statement.RETURN_GENERATED_KEYS,
+            ).use { stmt ->
+                stmt.setLong(1, surveyId)
+                stmt.setString(2, type)
+                stmt.setString(3, label)
+                if (choiceJson != null) stmt.setString(4, choiceJson) else stmt.setNull(4, java.sql.Types.VARCHAR)
+                stmt.setInt(5, idx)
+                stmt.executeUpdate()
+                val keys = stmt.generatedKeys
+                require(keys.next()) { "INSERT questions produced no id" }
+                keys.getLong(1)
+            }
+        }
+    }
+
+    /**
+     * Insert a `guests` row with an access-token hash. Mirrors what
+     * `GuestAccessTokenCodec.hash(rawToken)` does in the api: a hex
+     * SHA-256 of the raw token, lower-cased. Returns the guest id.
+     */
+    fun createGuest(name: String, discord: String, email: String, accessToken: String): Long {
+        val hash = sha256Hex(accessToken)
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            return conn.prepareStatement(
+                "INSERT INTO guests (name, discord, email, access_token_hash) VALUES (?, ?, ?, ?)",
+                java.sql.Statement.RETURN_GENERATED_KEYS,
+            ).use { stmt ->
+                stmt.setString(1, name)
+                stmt.setString(2, discord)
+                stmt.setString(3, email)
+                stmt.setString(4, hash)
+                stmt.executeUpdate()
+                val keys = stmt.generatedKeys
+                require(keys.next()) { "INSERT guests produced no id" }
+                keys.getLong(1)
+            }
+        }
+    }
+
+    /**
+     * Insert a guest-backed `event_signups` row. Returns the signup
+     * id so the caller can wire answers to it.
+     */
+    fun createGuestEventSignUp(eventId: Long, guestId: Long): Long {
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            return conn.prepareStatement(
+                "INSERT INTO event_signups (event_id, guest_id) VALUES (?, ?)",
+                java.sql.Statement.RETURN_GENERATED_KEYS,
+            ).use { stmt ->
+                stmt.setLong(1, eventId)
+                stmt.setLong(2, guestId)
+                stmt.executeUpdate()
+                val keys = stmt.generatedKeys
+                require(keys.next()) { "INSERT event_signups (guest) produced no id" }
+                keys.getLong(1)
+            }
+        }
+    }
+
+    /**
+     * Insert an `event_sign_up_answers` row mirroring the JPA
+     * `EventSignUpAnswer` shape — the row stores both the answer link
+     * and a flattened `text_response` / `option_selections` so reads
+     * don't need to walk back through `answers`. Returns the row id.
+     */
+    fun createEventSignUpAnswer(
+        eventSignUpId: Long,
+        questionId: Long,
+        answerId: Long? = null,
+        textResponse: String? = null,
+        optionSelections: List<Boolean>? = null,
+    ): Long {
+        val optionsJson = optionSelections?.joinToString(prefix = "[", postfix = "]") { if (it) "true" else "false" }
+        DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            return conn.prepareStatement(
+                "INSERT INTO event_sign_up_answers " +
+                    "(event_sign_up_id, answer_id, question_id, option_selections, text_response) " +
+                    "VALUES (?, ?, ?, ?, ?)",
+                java.sql.Statement.RETURN_GENERATED_KEYS,
+            ).use { stmt ->
+                stmt.setLong(1, eventSignUpId)
+                if (answerId != null) stmt.setLong(2, answerId) else stmt.setNull(2, java.sql.Types.BIGINT)
+                stmt.setLong(3, questionId)
+                if (optionsJson != null) stmt.setString(4, optionsJson) else stmt.setNull(4, java.sql.Types.VARCHAR)
+                if (textResponse != null) stmt.setString(5, textResponse) else stmt.setNull(5, java.sql.Types.VARCHAR)
+                stmt.executeUpdate()
+                val keys = stmt.generatedKeys
+                require(keys.next()) { "INSERT event_sign_up_answers produced no id" }
+                keys.getLong(1)
+            }
+        }
+    }
+
+    private fun sha256Hex(input: String): String {
+        val digest = java.security.MessageDigest.getInstance("SHA-256")
+        val bytes = digest.digest(input.toByteArray(Charsets.UTF_8))
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
 
     private fun java.sql.ResultSet.toEventRow(): EventRow = EventRow(
         id = getLong("id"),


### PR DESCRIPTION
## Why
`EventSignUpsPageSystemTest` was the last test in the events surface still reaching into the api context — seven autowired dependencies (`UserFactory`, `CommitteeFactory`, `EventFactory`, `FactoryPersistenceSupport`, `EventRepository`, `AnswerRepository`, `UserErasureService`) to set up a survey-backed event with three respondents and attached answers.

## What this achieves
All three scenarios (committee-member view, outsider 403, deleted user as anonymized identity) now seed state via JDBC through `TestHelper`. The test class compiles without any reference to the api's domain or factory packages.

## How
- `EventSignUpsPageSystemTest.kt` now extends `PlaywrightTestBase` and walks `TestHelper.registerActivateAndPromote` → `createCommittee` → `addCommitteeMember` → `createEvent` → `attachSurveyToEvent` → `createQuestion` (open/radio/checkbox) → `createUserEventSignUp` / `createGuestEventSignUp` → `createEventSignUpAnswer`. Erasure flows through the existing `TestHelper.eraseUser`, which posts `DELETE /users/{id}` as a fresh admin so the same `UserErasureService` runs server-side.
- New `TestHelper` surface:
  - `createUserEventSignUp(eventId, userId)` / `createGuestEventSignUp(eventId, guestId)`: JDBC insert against `event_signups`; the controller's permission checks aren't useful for setup-only rows.
  - `attachSurveyToEvent(eventId)`: inserts a `surveys` row tied to the event (`event_id` is NOT NULL) and points `events.survey_id` back at it.
  - `createQuestion(surveyId, idx, type, label, choiceLabels?)`: inserts a `questions` row with JSON-encoded `choice_labels`.
  - `createGuest(name, discord, email, accessToken)`: inserts a `guests` row, hashing the raw access token with the same SHA-256 the api uses (`GuestAccessTokenCodec.hash`).
  - `createEventSignUpAnswer(eventSignUpId, questionId, answerId?, textResponse?, optionSelections?)`: writes the `event_sign_up_answers` row that maps a signup to its response payload.