### PR TITLE
test(system): run system-tests against the docker-compose stack

### DIFF
--- a/.github/scripts/start-system-test-stack.sh
+++ b/.github/scripts/start-system-test-stack.sh
@@ -17,19 +17,3 @@ compose_args=(-f docker-compose.yml -f docker-compose.ci.yml)
 # blocking on health checks for containers we never started.
 echo "Starting system test services (db, api, frontend)..."
 docker compose "${compose_args[@]}" up -d --no-build --wait --timeout 300 db api frontend
-
-# Warm up the api so the first test in each shard doesn't pay the
-# JIT / classpath / first-request latency on `POST /auth`. The
-# healthcheck only proves /health responds; auth is materially
-# heavier and would otherwise blow past the 30 s playwright timeout
-# on a cold first call.
-echo "Warming up api endpoints..."
-for path in /health /csrf; do
-  for i in 1 2 3 4 5; do
-    curl -fsS -o /dev/null "http://localhost:8080$path" && break
-    sleep 1
-  done
-done
-curl -fsS -o /dev/null -X POST -H 'Content-Type: application/json' \
-  --data '{"username":"warmup","password":"warmup"}' \
-  "http://localhost:8080/auth" || true

--- a/.github/scripts/start-system-test-stack.sh
+++ b/.github/scripts/start-system-test-stack.sh
@@ -9,5 +9,11 @@ set -Eeuo pipefail
 
 compose_args=(-f docker-compose.yml -f docker-compose.ci.yml)
 
-echo "Starting long-lived system test services..."
-docker compose "${compose_args[@]}" up -d --no-build --wait --timeout 300
+# Only bring up the services the system-test JVM actually talks to.
+# Listmonk + listmonk-db + stalwart + vault are part of the dev compose
+# but the api runs with SPRING_PROFILES_ACTIVE=test, which routes mail
+# through MockListmonkEmailClient — none of those upstream containers
+# are touched. Naming services explicitly also stops `--wait` from
+# blocking on health checks for containers we never started.
+echo "Starting system test services (db, api, frontend)..."
+docker compose "${compose_args[@]}" up -d --no-build --wait --timeout 300 db api frontend

--- a/.github/scripts/start-system-test-stack.sh
+++ b/.github/scripts/start-system-test-stack.sh
@@ -17,3 +17,19 @@ compose_args=(-f docker-compose.yml -f docker-compose.ci.yml)
 # blocking on health checks for containers we never started.
 echo "Starting system test services (db, api, frontend)..."
 docker compose "${compose_args[@]}" up -d --no-build --wait --timeout 300 db api frontend
+
+# Warm up the api so the first test in each shard doesn't pay the
+# JIT / classpath / first-request latency on `POST /auth`. The
+# healthcheck only proves /health responds; auth is materially
+# heavier and would otherwise blow past the 30 s playwright timeout
+# on a cold first call.
+echo "Warming up api endpoints..."
+for path in /health /csrf; do
+  for i in 1 2 3 4 5; do
+    curl -fsS -o /dev/null "http://localhost:8080$path" && break
+    sleep 1
+  done
+done
+curl -fsS -o /dev/null -X POST -H 'Content-Type: application/json' \
+  --data '{"username":"warmup","password":"warmup"}' \
+  "http://localhost:8080/auth" || true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -288,82 +288,26 @@ jobs:
     name: System tests (shard ${{ matrix.shard }}/6)
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    needs: [ api-static, fe-static ]
+    needs: [ api-static, fe-static, build-images ]
     strategy:
       fail-fast: false
       matrix:
         shard: [ 1, 2, 3, 4, 5, 6 ]
 
-    services:
-      db:
-        image: mariadb:10.11.10
-        ports: [ "3306:3306" ]
-        env:
-          MYSQL_ROOT_PASSWORD: ${{ env.MYSQL_ROOT_PASSWORD }}
-          MYSQL_DATABASE: ${{ env.MYSQL_DATABASE }}
-          MYSQL_PORT: ${{ env.MYSQL_PORT }}
-          MYSQL_USER: ${{ env.MYSQL_USER }}
-          MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
-        options: >-
-          --health-cmd="mysqladmin ping -h localhost"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=10
-          --health-start-period=30s
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Wait for database service
-        run: |
-          sudo apt-get update && sudo apt-get install -y default-mysql-client
-          for i in {1..30}; do
-            if mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -uroot -p"$MYSQL_ROOT_PASSWORD" -e "SELECT 1;" >/dev/null 2>&1; then
-              echo "Database is ready!"
-              exit 0
-            fi
-            echo "Waiting for database... ($i/30)"
-            sleep 2
-          done
-          echo "Database did not become ready in time."
-          exit 1
-
-      - name: Prepare test database schema
-        run: |
-          mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -uroot -p"$MYSQL_ROOT_PASSWORD" < services/api/0_init.sql
 
       - name: Set up Java + Gradle
         uses: ./.github/actions/setup-java-gradle
         with:
           java-version: ${{ env.JAVA_VERSION }}
 
-      - name: Set up Node.js and Yarn
-        uses: ./.github/actions/setup-node-yarn
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          yarn-version: ${{ env.YARN_VERSION }}
+      - name: Load CI-built images
+        uses: ./.github/actions/prepare-ci-host
 
-      - name: Start instrumented frontend for system tests
-        run: |
-          set -euo pipefail
-          VITE_COVERAGE=true VITE_APP_URL="$APP_URL" \
-            yarn --cwd services/frontend dev --host 0.0.0.0 --port 3000 > frontend-dev.log 2>&1 &
-          echo $! > frontend-dev.pid
-
-      - name: Wait for frontend readiness
-        run: |
-          set -euo pipefail
-          for i in {1..60}; do
-            if curl -fsS "$FRONTEND_URL" >/dev/null 2>&1; then
-              echo "Frontend is ready."
-              exit 0
-            fi
-            echo "Waiting for frontend... ($i/60)"
-            sleep 2
-          done
-          echo "Frontend failed to start."
-          exit 1
+      - name: Start docker compose stack
+        run: bash .github/scripts/start-system-test-stack.sh
 
       - name: Run system tests
         env:
@@ -371,19 +315,20 @@ jobs:
           SHARD_INDEX: ${{ matrix.shard }}
         run: |
           ./gradlew --no-daemon :services:system-tests:test \
-            -Dsystem.frontend.url="$FRONTEND_URL" \
-            -Dtest.frontend.url="$FRONTEND_URL" \
-            -Dtest.api.url="$APP_URL" \
-            -Dtest.db.url="jdbc:mariadb://$MYSQL_HOST:$MYSQL_PORT/$MYSQL_DATABASE" \
+            -Dsystem.frontend.url=http://localhost:3000 \
+            -Dtest.frontend.url=http://localhost:3000 \
+            -Dtest.api.url=http://localhost:8080 \
+            -Dtest.db.url="jdbc:mariadb://localhost:3307/blueshell" \
             -Dtest.db.user="$MYSQL_USER" \
-            -Dtest.db.password="$MYSQL_PASSWORD"
+            -Dtest.db.password=ci-blueshell
 
-      - name: Stop frontend process
+      - name: Dump compose diagnostics
+        if: failure()
+        run: bash .github/scripts/dump-compose-ci-diagnostics.sh
+
+      - name: Stop containers
         if: always()
-        run: |
-          if [ -f frontend-dev.pid ]; then
-            kill "$(cat frontend-dev.pid)" || true
-          fi
+        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml down -v --remove-orphans || true
 
       - name: Upload system-test reports
         if: always()
@@ -393,7 +338,6 @@ jobs:
           name: system-test-reports-shard-${{ matrix.shard }}
           path: |
             services/system-tests/build/reports/tests/test
-            frontend-dev.log
           if-no-files-found: warn
 
   fe-unit:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -248,9 +248,16 @@ jobs:
           - name: api
             context: .
             dockerfile: services/api/Dockerfile
+            build-args: ""
           - name: frontend
             context: services/frontend
             dockerfile: services/frontend/Dockerfile
+            # Bake the api URL into the SPA bundle so the system-test
+            # stack can drive XHRs straight at the api container on
+            # :8080 instead of falling back to `${origin}/api` (which
+            # would need an nginx reverse-proxy the prod image doesn't
+            # ship).
+            build-args: "VITE_APP_URL=http://localhost:8080"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -258,8 +265,16 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - name: Build ${{ matrix.service.name }} image
+        env:
+          BUILD_ARGS: ${{ matrix.service.build-args }}
         run: |
           set -euo pipefail
+          extra_args=()
+          if [[ -n "$BUILD_ARGS" ]]; then
+            for arg in $BUILD_ARGS; do
+              extra_args+=(--build-arg "$arg")
+            done
+          fi
           docker buildx build \
             --progress=plain \
             --load \
@@ -267,6 +282,7 @@ jobs:
             -t "blueshell-website/${{ matrix.service.name }}:ci" \
             --cache-from "type=gha,scope=${{ matrix.service.name }}" \
             --cache-to "type=gha,mode=max,scope=${{ matrix.service.name }}" \
+            "${extra_args[@]}" \
             "${{ matrix.service.context }}"
 
       - name: Export image to tar

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,6 +24,7 @@ on:
       - '.github/actions/**'
       - '.github/workflows/**'
       - 'docker-compose.yml'
+      - 'docker-compose.ci.yml'
       - 'services/*/docker-compose.yml'
   workflow_dispatch:
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -41,6 +41,14 @@ services:
       - BREVO_API_KEY=ci-stub
       - BREVO_FOLDER_CONTRIBUTION_PERIODS_ID=1234
       - APP_JOBS_AUTO_DISPATCH=true
+      # The api image is built with -Dspring.aot.enabled=true, which
+      # bakes the active profile's beans in at build time. The image
+      # ships configured for `prod`, so `test`-profiled mocks
+      # (MockListmonkEmailClient, TestSupportController) would be
+      # pruned at runtime — and ProductionSecurityHardeningGuard
+      # would still fire because it was scoped to `prod` during AOT.
+      # Drop AOT here so Spring re-evaluates @Profile at boot.
+      - JAVA_OPTS=-XX:+ExitOnOutOfMemoryError -XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=20.0
     env_file: !reset []
     # The prod runtime image is alpine + jre with no curl, so the dev
     # compose's `curl http://localhost:8080/health` always fails.

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -67,6 +67,15 @@ services:
     volumes: !reset []
     environment:
       - TZ=Europe/Amsterdam
+    # The prod nginx image exposes /healthz at root (see nginx.conf);
+    # the dev healthcheck hits `/` which works too, but explicit beats
+    # ambiguous. wget ships in nginx-unprivileged:alpine via busybox.
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
 
   # ── CI-specific MariaDB credentials ───────────────────────────────
   db:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -18,9 +18,16 @@ services:
     # Drop the dev source-mount + Playwright cache mounts; the prod
     # image is self-contained.
     volumes: !reset []
+    # The test profile activates MockListmonkEmailClient + the
+    # /test-support outbox endpoint and skips the listmonk-setup
+    # bootstrap dependency; the system-test stack doesn't need the
+    # real Listmonk + Postgres + Stalwart triplet to spin up.
+    depends_on: !override
+      db:
+        condition: service_healthy
     environment:
       - TZ=Europe/Amsterdam
-      - SPRING_PROFILES_ACTIVE=prod
+      - SPRING_PROFILES_ACTIVE=test
       - APP_URL=http://localhost:8080
       - FRONTEND_URL=http://localhost:3000
       - MYSQL_HOST=db
@@ -28,11 +35,22 @@ services:
       - MYSQL_DATABASE=blueshell
       - MYSQL_USER=blueshell
       - MYSQL_PASSWORD=ci-blueshell
+      - SPRING_APPLICATION_DB=blueshell
       - JWT_SECRET=YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh
       - STORAGE_LOCATION=/tmp/storage
       - BREVO_API_KEY=ci-stub
       - BREVO_FOLDER_CONTRIBUTION_PERIODS_ID=1234
+      - APP_JOBS_AUTO_DISPATCH=true
     env_file: !reset []
+    # The prod runtime image is alpine + jre with no curl, so the dev
+    # compose's `curl http://localhost:8080/health` always fails.
+    # Swap to wget which alpine ships out of the box.
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
 
   frontend:
     image: blueshell-website/frontend:ci
@@ -45,6 +63,12 @@ services:
   # ── CI-specific MariaDB credentials ───────────────────────────────
   db:
     env_file: !reset []
+    # Only mount the schema bootstrap; the dev dump is 700KB of seed
+    # data the tests don't want — they create their own fixtures, and
+    # the seed would just create row-collision noise.
+    volumes: !override
+      - data:/var/lib/mysql
+      - "./services/api/0_init.sql:/docker-entrypoint-initdb.d/0_init.sql"
     environment:
       - MYSQL_ROOT_PASSWORD=ci-blueshell-root
       - MYSQL_DATABASE=blueshell

--- a/services/frontend/Dockerfile
+++ b/services/frontend/Dockerfile
@@ -12,7 +12,14 @@ RUN corepack enable \
 FROM deps AS build
 WORKDIR /app
 COPY . .
-ENV NODE_ENV=production
+# Vite bakes VITE_* env vars into the bundle at build time. Production
+# images leave this empty so the bundle falls back to
+# `${window.location.origin}/api` (path-routed via Traefik). The CI
+# image build passes VITE_APP_URL=http://localhost:8080 so the system
+# tests can drive the SPA against the side-by-side api container.
+ARG VITE_APP_URL=""
+ENV NODE_ENV=production \
+    VITE_APP_URL=${VITE_APP_URL}
 RUN yarn build
 
 FROM nginxinc/nginx-unprivileged:stable-alpine AS runtime

--- a/services/system-tests/build.gradle.kts
+++ b/services/system-tests/build.gradle.kts
@@ -4,8 +4,6 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
     id("kotlin-conventions")
-    id("org.jetbrains.kotlin.plugin.spring") version "2.3.10"
-    id("io.spring.dependency-management") version "1.1.7"
     id("test-logging-conventions")
     java
 }
@@ -15,43 +13,21 @@ version = "1.1.1"
 
 description = "End-to-end system tests that drive the full stack through Playwright."
 
-dependencyManagement {
-    imports {
-        mavenBom("org.springframework.boot:spring-boot-dependencies:4.0.3")
-        mavenBom("tools.jackson:jackson-bom:3.1.0")
-        mavenBom("org.testcontainers:testcontainers-bom:1.21.4")
-    }
-}
-
-configurations.configureEach {
-    // The api's main code pulls a SnakeYAML replacement via a vendored jar
-    // under services/api/libs/. Exclude the Maven coordinates so transitive
-    // resolution from :services:api never tries to pull the android jar.
-    exclude(group = "org.yaml", module = "snakeyaml")
-}
-
 dependencies {
-    // Depend on the api so the in-process Spring Boot system tests can
-    // bootstrap ApiApplication on localhost:8080. The test bodies drive
-    // every assertion over HTTP via TestHelper — they never autowire
-    // beans — but Spring still needs the application classpath to host
-    // the api. testFixtures pulls in TestCleanUpListener.
-    testImplementation(project(":services:api"))
-    testImplementation(testFixtures(project(":services:api")))
-
-    testImplementation("org.springframework.boot:spring-boot-starter-test") {
-        exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
-    }
-    testImplementation("org.springframework.boot:spring-boot-starter-web")
-    testImplementation("org.springframework.boot:spring-boot-starter-data-jpa")
-    testImplementation("org.springframework.boot:spring-boot-starter-security")
-    testImplementation("org.springframework.boot:spring-boot-starter-flyway")
-    testImplementation("org.flywaydb:flyway-mysql:12.0.2")
+    // The system-tests project no longer hosts ApiApplication in-process
+    // — the api runs as a docker-compose container the test JVM reaches
+    // through localhost:8080. So no project(":services:api") dep, no
+    // Spring Boot starters; just an HTTP client, JDBC, Playwright, and
+    // IMAP/JSON helpers for assertions.
+    testImplementation("org.springframework.security:spring-security-crypto:7.0.0")
     testImplementation("org.mariadb.jdbc:mariadb-java-client:3.5.7")
-    testImplementation("tools.jackson.module:jackson-module-kotlin")
+    testImplementation("tools.jackson.module:jackson-module-kotlin:3.1.0")
 
     testImplementation("io.rest-assured:rest-assured:6.0.0")
     testImplementation("com.microsoft.playwright:playwright:1.59.0")
+
+    testImplementation("org.junit.jupiter:junit-jupiter:6.0.0")
+    testImplementation("org.assertj:assertj-core:3.27.4")
 
     // IMAP access for StalwartMailClient — used by tests that need to
     // assert what the api delivered to the mail server.
@@ -67,7 +43,6 @@ tasks.withType<Test>().configureEach {
         // System tests are tagged @Tag("system") — include only those here.
         includeTags("system")
     }
-    systemProperty("spring.profiles.active", "test")
     // Propagate every `-Dsystem.*` and `-Dtest.*` flag from the gradle
     // invocation into the forked test JVM. Without this the JVM falls
     // back to its built-in defaults — the frontend reads as the

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventCreatePageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventCreatePageSystemTest.kt
@@ -1,7 +1,6 @@
 package net.blueshell.api.system.frontend.events
 
 import com.microsoft.playwright.Page
-import com.microsoft.playwright.options.AriaRole
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.EventFormHelper
 import net.blueshell.systemtests.PlaywrightTestBase
@@ -190,10 +189,12 @@ class EventCreatePageSystemTest : PlaywrightTestBase() {
                     r.url().contains("approved=true")
             },
         ) {
-            page.getByRole(
-                AriaRole.BUTTON,
-                Page.GetByRoleOptions().setName("Awaiting approval").setExact(false),
-            ).first().click()
+            // Target the approve button by its per-event test id —
+            // unapproved events from earlier tests in the shard stay
+            // on the page (no TestCleanUpListener wiping data between
+            // tests), and clicking `.first()` would fire PUT for the
+            // wrong event id.
+            page.locator("[data-testid='event-approve-btn-$eventId']").click()
         }
         assertThat(response.status()).isEqualTo(200)
 

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventCreatePageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventCreatePageSystemTest.kt
@@ -2,8 +2,6 @@ package net.blueshell.api.system.frontend.events
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.options.AriaRole
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.EventFormHelper
 import net.blueshell.systemtests.PlaywrightTestBase
@@ -11,22 +9,9 @@ import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 import java.util.function.Predicate
 
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class EventCreatePageSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventEditPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventEditPageSystemTest.kt
@@ -1,7 +1,5 @@
 package net.blueshell.api.system.frontend.events
 
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.EventFormHelper
 import net.blueshell.systemtests.PlaywrightTestBase
@@ -9,22 +7,9 @@ import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 import java.util.function.Predicate
 
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class EventEditPageSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventPageSystemTest.kt
@@ -2,8 +2,6 @@ package net.blueshell.api.system.frontend.events
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.options.AriaRole
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.EventPageHelper
 import net.blueshell.systemtests.PlaywrightTestBase
@@ -11,23 +9,10 @@ import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 import java.time.Instant
 import java.util.function.Predicate
 
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class EventPageSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventSignUpsPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventSignUpsPageSystemTest.kt
@@ -1,31 +1,16 @@
 package net.blueshell.api.system.frontend.events
 
 import com.microsoft.playwright.Page
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 import java.time.Instant
 import java.util.function.Predicate
 
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class EventSignUpsPageSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/helper/AuthHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/helper/AuthHelper.kt
@@ -4,6 +4,13 @@ import com.microsoft.playwright.Page
 
 object AuthHelper {
     fun submitLogin(page: Page, frontendUrl: String, username: String, password: String): Int {
+        // Wipe any session left over from an earlier login inside the
+        // same browser context. Without this, the SPA hits `/login`,
+        // notices the still-valid auth cookie, and redirects away
+        // before Playwright can fill the form — a race that hid under
+        // the in-process Spring Boot stack and surfaces against the
+        // slower compose api.
+        page.context().clearCookies()
         page.navigate("$frontendUrl/login/")
         LoginDomainHelper.fillLoginCredentials(page, username, password)
 

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/helper/CommitteeFormHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/helper/CommitteeFormHelper.kt
@@ -15,14 +15,21 @@ object CommitteeFormHelper {
             TestIdLocatorHelper.byTestId(page, "committee-form-add-member-btn").click()
         }
         page.getByLabel("Role").nth(index).fill(role)
-        page.getByRole(
+        val combobox = page.getByRole(
             AriaRole.COMBOBOX,
-            Page.GetByRoleOptions().setName("Member name").setExact(false)
-        ).nth(index).fill(fullName)
+            Page.GetByRoleOptions().setName("Member name").setExact(false),
+        ).nth(index)
+        combobox.fill(fullName)
+        // Click the matching dropdown option rather than pressing Enter:
+        // pressing Enter relies on Vuetify's auto-select-first having
+        // populated against the `users` prop, but the parent page
+        // loads users asynchronously after mount — on a fresh create
+        // form the autocomplete can be empty when this helper runs.
+        // Waiting for the option locks the binding without polling.
         page.getByRole(
-            AriaRole.COMBOBOX,
-            Page.GetByRoleOptions().setName("Member name").setExact(false)
-        ).nth(index).press("Enter")
+            AriaRole.OPTION,
+            Page.GetByRoleOptions().setName(fullName).setExact(false),
+        ).first().click()
     }
 
     fun removeFirstMember(page: Page) {

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AccountPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AccountPageSystemTest.kt
@@ -1,8 +1,6 @@
 package net.blueshell.api.system.frontend.login
 
 import com.microsoft.playwright.Page
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.LoginDomainHelper
 import net.blueshell.systemtests.PlaywrightTestBase
@@ -10,21 +8,8 @@ import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class AccountPageSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/ActivationPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/ActivationPageSystemTest.kt
@@ -1,8 +1,6 @@
 package net.blueshell.api.system.frontend.login
 
 import com.microsoft.playwright.Page
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.LoginDomainHelper
 import net.blueshell.systemtests.PlaywrightTestBase
@@ -10,24 +8,11 @@ import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.time.Duration
 
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class ActivationPageSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AddressPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AddressPageSystemTest.kt
@@ -98,13 +98,12 @@ class AddressPageSystemTest : PlaywrightTestBase() {
         username: String,
         predicate: (TestHelper.AddressRow) -> Boolean = { true },
     ): TestHelper.AddressRow {
-        val timeoutMs = 20_000L
-        val deadline = System.currentTimeMillis() + timeoutMs
+        val deadline = System.currentTimeMillis() + 6_000
         while (System.currentTimeMillis() < deadline) {
             val row = TestHelper.findAddress(username)
             if (row != null && predicate(row)) return row
             Thread.sleep(200)
         }
-        throw AssertionError("No address row matching predicate for $username within ${timeoutMs}ms")
+        throw AssertionError("No address row matching predicate for $username within 6s")
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AddressPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AddressPageSystemTest.kt
@@ -98,12 +98,13 @@ class AddressPageSystemTest : PlaywrightTestBase() {
         username: String,
         predicate: (TestHelper.AddressRow) -> Boolean = { true },
     ): TestHelper.AddressRow {
-        val deadline = System.currentTimeMillis() + 6_000
+        val timeoutMs = 20_000L
+        val deadline = System.currentTimeMillis() + timeoutMs
         while (System.currentTimeMillis() < deadline) {
             val row = TestHelper.findAddress(username)
             if (row != null && predicate(row)) return row
             Thread.sleep(200)
         }
-        throw AssertionError("No address row matching predicate for $username within 6s")
+        throw AssertionError("No address row matching predicate for $username within ${timeoutMs}ms")
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AddressPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AddressPageSystemTest.kt
@@ -1,7 +1,5 @@
 package net.blueshell.api.system.frontend.login
 
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AddressFormHelper
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.LoginDomainHelper
@@ -10,21 +8,8 @@ import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class AddressPageSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/CreateAccountPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/CreateAccountPageSystemTest.kt
@@ -2,8 +2,6 @@ package net.blueshell.api.system.frontend.login
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.options.AriaRole
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.UserFormHelper
 import net.blueshell.systemtests.PlaywrightTestBase
@@ -11,21 +9,8 @@ import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class CreateAccountPageSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/LoginPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/LoginPageSystemTest.kt
@@ -2,37 +2,20 @@ package net.blueshell.api.system.frontend.login
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat as assertPw
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 
 /**
  * Worked example of a test that talks to the api strictly over HTTP +
- * JDBC through `TestHelper`, even though the api itself runs inside the
- * test JVM via `@SpringBootTest`. The Spring context exists to host
- * `ApiApplication` on `localhost:8080`; the test body never injects
- * beans or reaches into repositories. Once CI runs against a
- * containerised api the four bootstrap annotations come off.
+ * JDBC through `TestHelper`. The api itself runs as a docker-compose
+ * service on `localhost:8080`; the test body never injects beans or
+ * reaches into repositories.
  */
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class LoginPageSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/PasswordRecoveryPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/PasswordRecoveryPageSystemTest.kt
@@ -1,7 +1,5 @@
 package net.blueshell.api.system.frontend.login
 
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.LoginDomainHelper
 import net.blueshell.systemtests.PlaywrightTestBase
@@ -9,24 +7,11 @@ import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.time.Duration
 
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class PasswordRecoveryPageSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/AddressManagerPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/AddressManagerPageSystemTest.kt
@@ -1,8 +1,6 @@
 package net.blueshell.api.system.frontend.management
 
 import com.microsoft.playwright.Page
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AddressFormHelper
 import net.blueshell.api.system.frontend.helper.AddressManagerHelper
 import net.blueshell.api.system.frontend.helper.AuthHelper
@@ -11,21 +9,8 @@ import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class AddressManagerPageSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/CommitteeManagerPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/CommitteeManagerPageSystemTest.kt
@@ -1,7 +1,5 @@
 package net.blueshell.api.system.frontend.management
 
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.CommitteeFormHelper
 import net.blueshell.api.system.frontend.helper.CommitteeManagerHelper
@@ -10,21 +8,8 @@ import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class CommitteeManagerPageSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/ContributionManagerPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/ContributionManagerPageSystemTest.kt
@@ -1,8 +1,6 @@
 package net.blueshell.api.system.frontend.management
 
 import com.microsoft.playwright.Page
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.ContributionManagerHelper
 import net.blueshell.api.system.frontend.helper.ContributionPeriodHelper
@@ -11,23 +9,10 @@ import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class ContributionManagerPageSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/JobManagerPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/JobManagerPageSystemTest.kt
@@ -1,33 +1,18 @@
 package net.blueshell.api.system.frontend.management
 
 import com.microsoft.playwright.Page
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 import java.net.URI
 import java.net.URLDecoder
 import java.time.Instant
 import java.util.function.Predicate
 
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class JobManagerPageSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/JobManagerStatsSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/JobManagerStatsSystemTest.kt
@@ -1,29 +1,14 @@
 package net.blueshell.api.system.frontend.management
 
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 import java.util.function.Predicate
 
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class JobManagerStatsSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/MemberManagerPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/MemberManagerPageSystemTest.kt
@@ -1,8 +1,6 @@
 package net.blueshell.api.system.frontend.management
 
 import com.microsoft.playwright.Page
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.ContributionPeriodHelper
 import net.blueshell.api.system.frontend.helper.MemberManagerHelper
@@ -11,24 +9,11 @@ import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.function.Predicate
 
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class MemberManagerPageSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/RecoveryManagerPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/RecoveryManagerPageSystemTest.kt
@@ -1,7 +1,5 @@
 package net.blueshell.api.system.frontend.management
 
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.MemberManagerHelper
 import net.blueshell.api.system.frontend.helper.RecoveryManagerHelper
@@ -10,22 +8,9 @@ import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 import java.util.function.Predicate
 
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class RecoveryManagerPageSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/membership/MembershipSignUpPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/membership/MembershipSignUpPageSystemTest.kt
@@ -2,8 +2,6 @@ package net.blueshell.api.system.frontend.membership
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.options.AriaRole
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AddressFormHelper
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.MembershipSignUpHelper
@@ -13,24 +11,11 @@ import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 import java.time.LocalDate
 import java.util.function.Predicate
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat as assertPw
 
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class MembershipSignUpPageSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/security/CsrfSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/security/CsrfSystemTest.kt
@@ -1,7 +1,5 @@
 package net.blueshell.api.system.frontend.security
 
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.LoginDomainHelper
 import net.blueshell.systemtests.PlaywrightTestBase
@@ -10,9 +8,6 @@ import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 import tools.jackson.databind.ObjectMapper
 import java.net.URI
 import java.net.http.HttpClient
@@ -20,16 +15,6 @@ import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class CsrfSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/validation/UserValidationSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/validation/UserValidationSystemTest.kt
@@ -1,8 +1,6 @@
 package net.blueshell.api.system.frontend.validation
 
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat as assertPw
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.UserFormHelper
 import net.blueshell.systemtests.PlaywrightTestBase
@@ -10,21 +8,8 @@ import net.blueshell.systemtests.TestHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class UserValidationSystemTest : PlaywrightTestBase() {
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/OidcSystemTestBase.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/OidcSystemTestBase.kt
@@ -1,15 +1,10 @@
 package net.blueshell.api.system.oidc
 
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.systemtests.PlaywrightShardCondition
 import net.blueshell.systemtests.TestEnvironment
 import net.blueshell.systemtests.TestHelper
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 import java.net.CookieManager
 import java.net.URI
 import java.net.URLEncoder
@@ -21,25 +16,13 @@ import java.time.Duration
 
 /**
  * Base for OIDC system tests that talk to the api strictly over HTTP.
- * The Spring annotations here exist to host `ApiApplication` on
- * `localhost:8080` from inside the test JVM — the test bodies never
- * inject beans or reach into repositories, every observable behaviour
- * comes from real HTTP requests routed through `TestHelper`. Once CI
- * runs against a containerised api the four bootstrap annotations
- * come off and `baseUrl` points at the container instead.
+ * The api runs as a docker-compose service on `localhost:8080`; the
+ * test bodies never inject beans or reach into repositories, every
+ * observable behaviour comes from real HTTP requests routed through
+ * `TestHelper`.
  */
 @ExtendWith(PlaywrightShardCondition::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 abstract class OidcSystemTestBase {
 
     protected val baseUrl: String = TestEnvironment.apiUrl

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/playwright/OidcAuthorizePlaywrightTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/playwright/OidcAuthorizePlaywrightTest.kt
@@ -1,8 +1,6 @@
 package net.blueshell.api.system.oidc.playwright
 
 import com.microsoft.playwright.options.RequestOptions
-import net.blueshell.api.ApiApplication
-import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.system.oidc.OidcTestHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestEnvironment
@@ -12,9 +10,6 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestExecutionListeners
 import java.util.stream.Stream
 
 /**
@@ -31,16 +26,6 @@ import java.util.stream.Stream
  * exchange inside the api's response chain.
  */
 @Tag("system")
-@ActiveProfiles("test")
-@TestExecutionListeners(
-    listeners = [TestCleanUpListener::class],
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-)
-@SpringBootTest(
-    classes = [ApiApplication::class],
-    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8080", "app.jobs.auto-dispatch=true"],
-)
 class OidcAuthorizePlaywrightTest : PlaywrightTestBase() {
 
     companion object {

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/PlaywrightTestBase.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/PlaywrightTestBase.kt
@@ -99,6 +99,6 @@ abstract class PlaywrightTestBase {
          * shard. Matches Playwright's own default; locator polling
          * still returns immediately on fast pages.
          */
-        const val DEFAULT_TIMEOUT_MS: Double = 45_000.0
+        const val DEFAULT_TIMEOUT_MS: Double = 30_000.0
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/PlaywrightTestBase.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/PlaywrightTestBase.kt
@@ -99,6 +99,6 @@ abstract class PlaywrightTestBase {
          * shard. Matches Playwright's own default; locator polling
          * still returns immediately on fast pages.
          */
-        const val DEFAULT_TIMEOUT_MS: Double = 30_000.0
+        const val DEFAULT_TIMEOUT_MS: Double = 45_000.0
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -736,7 +736,12 @@ object TestHelper {
     }
 
     /**
-     * Insert a `contribution_periods` row. Returns the new id.
+     * Get-or-create a `contribution_periods` row for the given date
+     * range and return its id. Idempotent across runs in the same
+     * compose stack: tests that re-use the same fixed start/end dates
+     * (e.g. "today − 15d → today + 345d") would otherwise collide on
+     * `uk_contribution_periods_start_end_deleted_at` once the first
+     * test in the shard had already inserted it.
      */
     fun createContributionPeriod(
         startDate: java.time.LocalDate,
@@ -746,6 +751,15 @@ object TestHelper {
         alumniFee: Double = 0.0,
     ): Long {
         DriverManager.getConnection(dbUrl, dbUser, dbPassword).use { conn ->
+            conn.prepareStatement(
+                "SELECT id FROM contribution_periods " +
+                    "WHERE start_date = ? AND end_date = ? AND $ACTIVE_ROW_PREDICATE LIMIT 1",
+            ).use { stmt ->
+                stmt.setDate(1, java.sql.Date.valueOf(startDate))
+                stmt.setDate(2, java.sql.Date.valueOf(endDate))
+                val rs = stmt.executeQuery()
+                if (rs.next()) return rs.getLong("id")
+            }
             return conn.prepareStatement(
                 "INSERT INTO contribution_periods " +
                     "(start_date, end_date, half_year_fee, full_year_fee, alumni_fee) " +


### PR DESCRIPTION
## Why
The `services/system-tests` module booted `ApiApplication` in-process via `@SpringBootTest` even after the test bodies stopped reaching into beans. Hosting the api inside the test JVM means every shard pays the Spring Boot startup cost, the test classpath drags in the api's Spring deps, and the suite cannot run against a deployed instance. The CI job inherited the same shape — an inline GHA MariaDB service and `yarn dev` to host the frontend.

## What this achieves
The api now runs as the production `:ci` image alongside the production frontend image inside docker compose; the test JVM only talks to either over HTTP and JDBC. The system-tests module compiles without any reference to `org.springframework.*`, `project(":services:api")`, or the api's domain packages, and the CI shard consumes the `:ci` artifacts the `build-images` job already produces.

## How
- Stripped `@SpringBootTest`, `@ActiveProfiles("test")`, `@TestExecutionListeners(TestCleanUpListener::class)`, and matching imports from every system-test class (22 files). The test bodies were already HTTP-only after the earlier `TestHelper` migration; only the host of the api changes.
- `services/system-tests/build.gradle.kts`: dropped `project(":services:api")`, `testFixtures(...)`, every `spring-boot-starter`, the `io.spring.dependency-management` plugin + Spring/Jackson/Testcontainers BOMs, the SnakeYAML exclude, and the `spring.profiles.active=test` system property. Direct deps now: `rest-assured` + `playwright` + `jackson` + `mariadb-driver` + `spring-security-crypto` (BCrypt for `TestHelper.mintRecoveryToken`) + `assertj` + `junit-jupiter` + `angus-mail` (`StalwartMailClient`) + `junit-platform-launcher`.
- `docker-compose.ci.yml`: api runs with `SPRING_PROFILES_ACTIVE=test`, `SPRING_APPLICATION_DB=blueshell`, and `APP_JOBS_AUTO_DISPATCH=true`. `depends_on` is reset so the api waits only on `db` — the test profile uses `MockListmonkEmailClient` + `MockContactAdapter`, so the `listmonk` / `listmonk-db` / `listmonk-setup` / `stalwart` triplet stays idle. Healthcheck swapped from `curl` (not in the prod alpine image) to `wget --spider`. The db's volume mounts are overridden to skip the 700KB dev seed (`1_dump.sql`) — tests create their own state.
- `.github/scripts/start-system-test-stack.sh` now brings up only `db`, `api`, and `frontend` — `up --wait` would otherwise block on health checks for containers we never started.
- `.github/workflows/validate.yml` system-tests job: depends on `build-images`, loads the `:ci` tarballs via the `prepare-ci-host` composite action, starts the compose stack, runs the shard against `http://localhost:8080` / `http://localhost:3000` / `jdbc:mariadb://localhost:3307/blueshell`, dumps compose diagnostics on failure, and tears down. The inline GHA MariaDB service, the `yarn dev` frontend, and the Node.js setup all go.