### PR TITLE
feat(frontend): dismiss the 401 snackbar on login + keep navbar visible

### DIFF
--- a/services/frontend/src/App.vue
+++ b/services/frontend/src/App.vue
@@ -6,7 +6,7 @@
          the canonical case — where the top bar / drawer / footer are
          purely visual noise around the login form. -->
     <v-app-bar
-      v-if="!route.meta.bare"
+      v-if="!isBareLayout"
       theme="dark"
     >
       <v-btn
@@ -268,7 +268,7 @@
     </v-app-bar>
 
     <v-navigation-drawer
-      v-if="!route.meta.bare"
+      v-if="!isBareLayout"
       v-model="drawer"
       temporary
     >
@@ -424,7 +424,8 @@
 
     <router-view />
 
-    <footer-banner v-if="!route.meta.bare" />
+    <footer-banner v-if="!isBareLayout" />
+
 
 
     <v-snackbar
@@ -451,6 +452,14 @@
       <!-- eslint-disable-next-line vue/no-v-html -->
       <span v-html="DOMPurify.sanitize(statusSnackbarMessage)" />
       <template #actions>
+        <v-btn
+          v-if="statusSnackbarAction"
+          color="primary"
+          variant="text"
+          @click="handleSnackbarAction(statusSnackbarAction)"
+        >
+          {{ statusSnackbarAction.label }}
+        </v-btn>
         <v-btn
           color="blue"
           variant="text"
@@ -487,9 +496,10 @@
 </template>
 
 <script lang="ts" setup>
-import {computed, onMounted, ref} from "vue"
+import {computed, onMounted, ref, watch} from "vue"
 import {useStore} from "vuex"
-import {useRoute} from "vue-router"
+import {useRoute, useRouter} from "vue-router"
+import type {SnackbarAction} from "@/plugins/store"
 import {useDisplay, useTheme} from "vuetify"
 import FooterBanner from "@/components/common/banners/FooterBanner.vue"
 import {$goto} from "@/plugins/goto"
@@ -511,6 +521,7 @@ const {
 // Composables
 const store = useStore()
 const route = useRoute()
+const router = useRouter()
 const theme = useTheme()
 const display = useDisplay()
 
@@ -519,6 +530,32 @@ const statusSnackbarMessage = computed({
   get: (): string => store.state.statusSnackbarMessage,
   set: (message: string) => store.commit("setStatusSnackbarMessage", message),
 })
+
+const statusSnackbarAction = computed((): SnackbarAction | null => store.state.statusSnackbarAction)
+
+// Drop the bare layout for /login when the caller explicitly asked
+// for the regular site chrome (e.g. the 401 snackbar's Login action,
+// which embeds `chrome=keep` in the href). Vault's OIDC popup still
+// omits the param and falls through to the meta.bare default.
+const isBareLayout = computed((): boolean => !!route.meta.bare && route.query.chrome !== "keep")
+
+// Auto-dismiss the snackbar (and its Login action) the moment we
+// reach /login. Belt-and-braces: the action button below already
+// clears state on click, but a direct navbar/browser-history hop to
+// /login should drop the stale "you're not logged in" toast too.
+watch(
+  () => route.path,
+  (path) => {
+    if (path === "/login") {
+      store.commit("clearStatusSnackbar")
+    }
+  },
+)
+
+async function handleSnackbarAction(action: SnackbarAction): Promise<void> {
+  store.commit("clearStatusSnackbar")
+  await router.push(action.to)
+}
 
 const isLoggedIn = computed((): boolean => store.getters.isLoggedIn)
 const isBoard = computed((): boolean => store.getters.isBoard)

--- a/services/frontend/src/plugins/handleNetworkError.ts
+++ b/services/frontend/src/plugins/handleNetworkError.ts
@@ -33,12 +33,18 @@ export function $handleNetworkError(err: unknown): void {
         // Don't auto-logout or auto-redirect on a 401: the user might
         // genuinely still be signed in (the Vault OIDC popup chain hit
         // this path repeatedly, blowing away live sessions). Surface a
-        // snackbar with a Login link instead and let the user decide.
+        // snackbar with a Login action instead and let the user decide.
+        // `chrome=keep` tells App.vue to leave the navbar/footer in
+        // place when /login is reached from inside the app, so the
+        // user can navigate elsewhere instead of being trapped on a
+        // bare login screen.
         const redirectTarget = (currentRoute.query.redirect as string)
           || currentRoute.fullPath
-        const loginHref = `/login?redirect=${encodeURIComponent(redirectTarget)}`
-        errorMessage = `Woah there, looks like you're not logged in (anymore). <a href="${loginHref}" class="text-decoration-none">Login</a>`
-        break
+        const loginHref = `/login?redirect=${encodeURIComponent(redirectTarget)}&chrome=keep`
+        errorMessage = "Woah there, looks like you're not logged in (anymore)."
+        store.commit("setStatusSnackbarMessage", errorMessage)
+        store.commit("setStatusSnackbarAction", {label: "Login", to: loginHref})
+        return
       }
       case 403:
         errorMessage = "Woah there, you don't have enough authority to access this. Go to jail and DO NOT PASS GO, DO NOT COLLECT $200."

--- a/services/frontend/src/plugins/store.ts
+++ b/services/frontend/src/plugins/store.ts
@@ -7,11 +7,17 @@ export type GuestSessionData = GuestResponse & {
   accessToken: string;
 }
 
+export interface SnackbarAction {
+  label: string;
+  to: string;
+}
+
 export interface State {
   login: LoginResponse | null;
   authToken: string | null;
   guestData: GuestSessionData | null;
   statusSnackbarMessage: string | null;
+  statusSnackbarAction: SnackbarAction | null;
   loggedInSnackbar: boolean;
   xsrfToken: string | null;
 }
@@ -28,6 +34,10 @@ export interface Mutations {
   setAddressId(state: State, addressId: number): void;
 
   setStatusSnackbarMessage(state: State, message: string): void;
+
+  setStatusSnackbarAction(state: State, action: SnackbarAction | null): void;
+
+  clearStatusSnackbar(state: State): void;
 
   saveGuestData(state: State, data: GuestSessionData): void;
 
@@ -105,6 +115,7 @@ const store = createStore<State>({
       authToken: null,
       guestData: readJsonCookie<GuestSessionData>("guestData"),
       statusSnackbarMessage: null,
+      statusSnackbarAction: null,
       loggedInSnackbar: false,
       xsrfToken: null,
     }
@@ -147,7 +158,15 @@ const store = createStore<State>({
         state.statusSnackbarMessage = message
       } else {
         state.statusSnackbarMessage = null
+        state.statusSnackbarAction = null
       }
+    },
+    setStatusSnackbarAction(state: State, action: SnackbarAction | null): void {
+      state.statusSnackbarAction = action
+    },
+    clearStatusSnackbar(state: State): void {
+      state.statusSnackbarMessage = null
+      state.statusSnackbarAction = null
     },
     saveGuestData(state: State, data: GuestSessionData): void {
       writeJsonCookie("guestData", data)

--- a/services/frontend/tests/unit/plugins/handleNetworkError.test.ts
+++ b/services/frontend/tests/unit/plugins/handleNetworkError.test.ts
@@ -41,21 +41,21 @@ describe("handleNetworkError plugin", () => {
     expect(mockCommit).toHaveBeenCalledWith("setStatusSnackbarMessage", expect.stringContaining("unknown error"))
   })
 
-  it("surfaces a login-link snackbar on 401 without auto-logout or auto-redirect", () => {
+  it("surfaces a login-action snackbar on 401 without auto-logout or auto-redirect", () => {
     $handleNetworkError(axiosStatusError(401))
     // No auto-logout, no auto-router push: the user might genuinely
     // still be signed in (Vault's OIDC popup chain hits 401 transiently).
-    // We just show a snackbar with a Login link and let the user act.
+    // We just show a snackbar with a Login action and let the user act.
     expect(mockCommit).not.toHaveBeenCalledWith("logout")
     expect(mockPush).not.toHaveBeenCalled()
     expect(mockCommit).toHaveBeenCalledWith(
       "setStatusSnackbarMessage",
       expect.stringContaining("not logged in"),
     )
-    expect(mockCommit).toHaveBeenCalledWith(
-      "setStatusSnackbarMessage",
-      expect.stringContaining(`/login?redirect=${encodeURIComponent("/events")}`),
-    )
+    expect(mockCommit).toHaveBeenCalledWith("setStatusSnackbarAction", {
+      label: "Login",
+      to: `/login?redirect=${encodeURIComponent("/events")}&chrome=keep`,
+    })
   })
 
   it("surfaces a snackbar on 403 without auto-redirecting to /account", () => {


### PR DESCRIPTION
## Why
The "you're not logged in (anymore)" snackbar embedded a raw `<a href="/login?…">` inside its `v-html`'d message. Clicking it forced a full page reload — which incidentally cleared the snackbar but also dropped the rest of the in-flight app state and stranded the user on the bare login page (no navbar, no footer) per the existing `meta.bare` flag on `/login`. The stale toast also lingered when the user reached `/login` through the navbar or browser history.

## What this achieves
- The snackbar's Login action runs an SPA navigation and clears itself before pushing — no full reload, no flash of stale toast.
- The destination keeps the regular site chrome (navbar + footer) so the user can navigate away if they didn't actually mean to sign in. Vault's OIDC popup, which lands on `/login` without the new query flag, still gets the bare chrome it needs.
- Any navigation to `/login` (navbar click, back button, deep link) also dismisses a stale "logged out" snackbar.

## How
- `services/frontend/src/plugins/store.ts` adds `statusSnackbarAction: { label, to } | null` next to the existing message slot, plus mutations to set the action and to clear the whole snackbar at once. Setting the message to empty also wipes the action so an old Login button doesn't outlive its parent toast.
- `services/frontend/src/plugins/handleNetworkError.ts` for the 401 branch now sets the message as plain text and commits a structured action `{ label: "Login", to: "/login?redirect=…&chrome=keep" }` instead of inlining an anchor.
- `services/frontend/src/App.vue` renders the action button next to the existing Close button when an action is present, navigates via `router.push`, and clears the snackbar on click. A `watch(route.path)` clears the snackbar whenever we land on `/login`. The `route.meta.bare` check moves into an `isBareLayout` computed that returns `false` when `route.query.chrome === 'keep'`, so the v-app-bar / drawer / footer-banner stay mounted on the snackbar-driven login path.