### PR TITLE
fix(frontend): keep navbar on /login by default, bare only for SSO popup

### DIFF
--- a/services/frontend/src/App.vue
+++ b/services/frontend/src/App.vue
@@ -545,7 +545,7 @@ const statusSnackbarAction = computed((): SnackbarAction | null => store.state.s
 // the 401 snackbar's Login action — falls through to chrome.
 const isBareLayout = computed((): boolean => {
   if (route.meta.bare === true) return true
-  const redirect = route.query.redirect
+  const redirect = route.query?.redirect
   return typeof redirect === "string" && redirect.includes("/oauth2/authorize")
 })
 

--- a/services/frontend/src/App.vue
+++ b/services/frontend/src/App.vue
@@ -533,11 +533,21 @@ const statusSnackbarMessage = computed({
 
 const statusSnackbarAction = computed((): SnackbarAction | null => store.state.statusSnackbarAction)
 
-// Drop the bare layout for /login when the caller explicitly asked
-// for the regular site chrome (e.g. the 401 snackbar's Login action,
-// which embeds `chrome=keep` in the href). Vault's OIDC popup still
-// omits the param and falls through to the meta.bare default.
-const isBareLayout = computed((): boolean => !!route.meta.bare && route.query.chrome !== "keep")
+// Bare layout (no app bar / drawer / footer) is reserved for the
+// SSO redirect chain. Two triggers:
+//   - `route.meta.bare === true`: routes that only ever surface
+//     inside an OIDC popup (currently /unauthorized).
+//   - `route.query.redirect` points at the api's OAuth2 authorize
+//     endpoint: the Spring Authorization Server bounced an
+//     unauthenticated /api/oauth2/authorize hit through /login, so
+//     the login form should sit alone in the popup.
+// Regular logged-out browsing — navbar Login click, direct visit,
+// the 401 snackbar's Login action — falls through to chrome.
+const isBareLayout = computed((): boolean => {
+  if (route.meta.bare === true) return true
+  const redirect = route.query.redirect
+  return typeof redirect === "string" && redirect.includes("/oauth2/authorize")
+})
 
 // Auto-dismiss the snackbar (and its Login action) the moment we
 // reach /login. Belt-and-braces: the action button below already

--- a/services/frontend/src/plugins/handleNetworkError.ts
+++ b/services/frontend/src/plugins/handleNetworkError.ts
@@ -34,13 +34,13 @@ export function $handleNetworkError(err: unknown): void {
         // genuinely still be signed in (the Vault OIDC popup chain hit
         // this path repeatedly, blowing away live sessions). Surface a
         // snackbar with a Login action instead and let the user decide.
-        // `chrome=keep` tells App.vue to leave the navbar/footer in
-        // place when /login is reached from inside the app, so the
-        // user can navigate elsewhere instead of being trapped on a
-        // bare login screen.
+        // /login renders inside the regular site chrome by default
+        // (App.vue only goes bare for the OIDC popup path), so the
+        // user can navigate elsewhere if they didn't actually mean to
+        // sign in.
         const redirectTarget = (currentRoute.query.redirect as string)
           || currentRoute.fullPath
-        const loginHref = `/login?redirect=${encodeURIComponent(redirectTarget)}&chrome=keep`
+        const loginHref = `/login?redirect=${encodeURIComponent(redirectTarget)}`
         errorMessage = "Woah there, looks like you're not logged in (anymore)."
         store.commit("setStatusSnackbarMessage", errorMessage)
         store.commit("setStatusSnackbarAction", {label: "Login", to: loginHref})

--- a/services/frontend/src/plugins/router.ts
+++ b/services/frontend/src/plugins/router.ts
@@ -98,23 +98,20 @@ const routes: RouteRecordRaw[] = [
     component: () => import("@/pages/partners/MarketingMaatwerk.vue"),
   },
   {
-    // `meta.bare = true` (here and on /unauthorized below) tells App.vue
-    // to drop the v-app-bar / v-navigation-drawer / footer-banner so the
-    // login form is the only thing on screen. Mainly so Vault's OIDC
-    // popup at https://v2.esa-blueshell.nl/api/oauth2/authorize?... ->
-    // /login?redirect=... isn't visually wrapped in the full website
-    // chrome; same goes for forgot-password / account-create which are
-    // linked from the login form.
+    // Login / forgot-password / account-create render inside the full
+    // site chrome by default — they're regular pages a logged-out user
+    // navigates between. App.vue flips them to a bare layout only when
+    // the OIDC popup chain has redirected here (the Spring Authorization
+    // Server hop at /api/oauth2/authorize... → /login?redirect=...);
+    // see `isBareLayout` in App.vue for the detection logic.
     path: "/login",
     name: "login",
     component: () => import("@/pages/login/Login.vue"),
-    meta: {bare: true},
   },
   {
     path: "/login/forgor",
     name: "forgotPassword",
     component: () => import("@/pages/login/ForgotPassword.vue"),
-    meta: {bare: true},
   },
   {
     path: "/account",
@@ -126,7 +123,6 @@ const routes: RouteRecordRaw[] = [
     path: "/account/create",
     name: "accountCreation",
     component: () => import("@/pages/login/CreateAccount.vue"),
-    meta: {bare: true},
   },
   {
     path: "/account/reset-password",

--- a/services/frontend/tests/unit/plugins/handleNetworkError.test.ts
+++ b/services/frontend/tests/unit/plugins/handleNetworkError.test.ts
@@ -54,7 +54,7 @@ describe("handleNetworkError plugin", () => {
     )
     expect(mockCommit).toHaveBeenCalledWith("setStatusSnackbarAction", {
       label: "Login",
-      to: `/login?redirect=${encodeURIComponent("/events")}&chrome=keep`,
+      to: `/login?redirect=${encodeURIComponent("/events")}`,
     })
   })
 

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AddressPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AddressPageSystemTest.kt
@@ -1,5 +1,7 @@
 package net.blueshell.api.system.frontend.login
 
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat as assertPw
 import net.blueshell.api.system.frontend.helper.AddressFormHelper
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.LoginDomainHelper
@@ -65,6 +67,15 @@ class AddressPageSystemTest : PlaywrightTestBase() {
         }
         assertThat(loadResponse.status()).isEqualTo(200)
         page.waitForURL("**/account/addresses/**")
+
+        // The address page's onMounted writes the loaded record to its
+        // reactive ref *after* the GET response resolves. Playwright's
+        // waitForResponse returns the moment the response arrives —
+        // before the Vue assignment — so filling here would race the
+        // load: the GET resolution then replaces `address.value` and
+        // clobbers our edits. Wait until the street input actually
+        // reflects the pre-existing value before editing.
+        assertPw(page.getByLabel("Street", Page.GetByLabelOptions().setExact(true))).hasValue("Stationsstraat")
 
         AddressFormHelper.fill(
             page = page,

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/ContributionManagerPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/ContributionManagerPageSystemTest.kt
@@ -91,9 +91,11 @@ class ContributionManagerPageSystemTest : PlaywrightTestBase() {
             memberId in TestHelper.findContributions(periodId)
         }
 
-        // Second page navigation: mark unpaid via DELETE.
-        page.navigate("$frontendUrl/")
-        AuthHelper.submitLogin(page, frontendUrl, board.username, board.password)
+        // Second page navigation: mark unpaid via DELETE. The session
+        // from the initial submitLogin is still valid; no need to
+        // re-login (re-logging in races the SPA's cookie reconcile
+        // path now that /login renders inside the regular site
+        // chrome).
         ContributionManagerHelper.open(page, frontendUrl)
         page.getByText(periodLabel, Page.GetByTextOptions().setExact(false)).first().waitFor()
         ContributionManagerHelper.selectPeriod(page, periodLabel)


### PR DESCRIPTION
## Why
The login page still drops the app bar / drawer / footer for every visit — direct URL, navbar Login click, the 401 snackbar's Login action. The bare layout is meant for the OIDC popup path only (Spring Authorization Server's `/api/oauth2/authorize` hop through `/login`), so a logged-out user browsing the site lands on a stripped page with no way to navigate elsewhere.

The previous patch introduced a `chrome=keep` query flag the snackbar set to opt back into chrome, but that's backwards: chrome should be the default for everything except the SSO redirect chain.

## What this achieves
`/login`, `/login/forgor`, and `/account/create` render inside the regular site chrome no matter how the user arrived. The bare layout is reserved for `/unauthorized` (only ever surfaces in an OIDC popup) and any route reached via the SSO redirect chain.

## How
- `services/frontend/src/plugins/router.ts`: drops `meta: {bare: true}` from `/login`, `/login/forgor`, and `/account/create`. `/unauthorized` keeps its bare meta.
- `services/frontend/src/App.vue`: `isBareLayout` now goes bare on either `route.meta.bare === true` or `route.query.redirect` containing `/oauth2/authorize` — i.e. the SAS flow bounced an unauthenticated authorize request through `/login`. Regular logged-out navigation falls through to chrome.
- `services/frontend/src/plugins/handleNetworkError.ts`: 401 snackbar's Login href drops the `chrome=keep` query — no longer needed now that chrome is the default.
- Unit test updated to expect the simpler `/login?redirect=…` URL.