### PR TITLE
platform: cut over to esa-blueshell.nl

### DIFF
--- a/infra/dns/README.md
+++ b/infra/dns/README.md
@@ -7,14 +7,16 @@ Authoritative zone files, one per domain. Imported into Cloudflare via
 
 - Zone: [`esa-blueshell.nl.zone`](./esa-blueshell.nl.zone)
 - Migrated off TransIP on 2026-04-21.
-- Apex `esa-blueshell.nl` continues to serve the legacy single-VPS stack at
-  `136.144.191.63`.
-- The new NixOS + k3s platform lives under `v2.esa-blueshell.nl` and the
-  `*.v2` wildcard (`157.173.115.164` / `2a02:c207:2316:2642::1`). Every
-  service hostname the platform advertises (`api.v2`, `kube.v2`, `vault.v2`,
-  `mail.v2`, `auth.v2`, `status.v2`, …) resolves through that wildcard.
-- Once the v2 stack is validated end-to-end the apex A/AAAA records flip
-  to the v2 backend and the `v2` label retires.
+- Apex `esa-blueshell.nl` serves the NixOS + k3s stack at
+  `157.173.115.164` / `2a02:c207:2316:2642::1`. Every service hostname
+  the platform advertises (`api` lives at apex `/api`, plus admin hosts
+  `kube`, `vault`, `mail-admin`, `status`, `traefik`) resolves through
+  that node — admin records are external-dns managed off each
+  IngressRoute.
+- `v2.esa-blueshell.nl` remains pointed at the same node as a fallback
+  during the 30-day grace period after the apex cutover; the frontend
+  and api IngressRoutes match both hostnames so legacy bookmarks keep
+  working. Retired in PR 11.
 
 ## Proxy status
 
@@ -26,11 +28,11 @@ After import, toggle the orange cloud per record:
 | `@` (MX target)              | off   | Mail cannot be proxied.                                |
 | `minecraft`                  | off   | Game traffic — Cloudflare proxy is HTTP(S) only.       |
 | `ftp`                        | off   | Non-HTTP protocol.                                     |
-| `v2`, `*.v2`                 | off   | Different backend; wildcard wildcard-cert via DNS-01.  |
+| `v2`                         | on    | Grace-period fallback to the apex backend (PR 11).     |
 
 ## ACME / Let's Encrypt
 
-Wildcard `*.v2.esa-blueshell.nl` is issued via DNS-01. cert-manager writes
-the challenge TXT record at `_acme-challenge.v2.esa-blueshell.nl` through
+Wildcard `*.esa-blueshell.nl` is issued via DNS-01. cert-manager writes
+the challenge TXT record at `_acme-challenge.esa-blueshell.nl` through
 the Cloudflare API. The API token needs `Zone:DNS:Edit` scoped to this
 zone.

--- a/infra/dns/esa-blueshell.nl.zone
+++ b/infra/dns/esa-blueshell.nl.zone
@@ -1,38 +1,94 @@
-; Zone file for esa-blueshell.nl
-; Import into Cloudflare via Dashboard → DNS → Records → Import
-; Source: migrated from TransIP DNS (2026-04-21)
-;
-; Notes on proxy status (set after import in Cloudflare UI):
-;   - Proxy ON  (orange cloud): @, www
-;   - Proxy OFF (grey cloud, "DNS only"):
-;       * MX target (esa-blueshell.nl itself cannot be proxied for mail)
-;       * minecraft  (game traffic — Cloudflare proxy is HTTP/S only)
-;       * ftp        (non-HTTP protocol)
-;       * v2, *.v2   (different backend IP; proxy only if it serves HTTP(S))
-;
-; Apex / website ----------------------------------------------------------
-; No wildcard at the apex — only the explicit hostnames below resolve.
-@           1   IN  A       136.144.191.63
-@           1   IN  AAAA    2a01:7c8:aacb:1e5::101:55
-@           1   IN  MX  10  esa-blueshell.nl.
+;;
+;; Domain:     esa-blueshell.nl.
+;; Exported:   2026-05-21 08:03:30
+;;
+;; This file is intended for use for informational and archival
+;; purposes ONLY and MUST be edited before use on a production
+;; DNS server.  In particular, you must:
+;;   -- update the SOA record with the correct authoritative name server
+;;   -- update the SOA record with the contact e-mail address information
+;;   -- update the NS record(s) with the authoritative name servers for this domain.
+;;
+;; For further information, please consult the BIND documentation
+;; located on the following website:
+;;
+;; http://www.isc.org/
+;;
+;; And RFC 1035:
+;;
+;; http://www.ietf.org/rfc/rfc1035.txt
+;;
+;; Please note that we do NOT offer technical support for any use
+;; of this zone data, the BIND name server, or any other third-party
+;; DNS software.
+;;
+;; Use at your own risk.
+;; SOA Record
+esa-blueshell.nl	3600	IN	SOA	dakota.ns.cloudflare.com. dns.cloudflare.com. 2053101721 10000 2400 604800 3600
 
-; www ---------------------------------------------------------------------
-www         1   IN  CNAME   esa-blueshell.nl.
+;; NS Records
+esa-blueshell.nl.	86400	IN	NS	dakota.ns.cloudflare.com.
+esa-blueshell.nl.	86400	IN	NS	karina.ns.cloudflare.com.
 
-; ftp ---------------------------------------------------------------------
-ftp         1   IN  CNAME   esa-blueshell.nl.
+;; A Records
+auth.esa-blueshell.nl.	1	IN	A	157.173.115.164 ; cf_tags=cf-proxied:true
+esa-blueshell.nl.	1	IN	A	157.173.115.164 ; cf_tags=cf-proxied:true
+headlamp.esa-blueshell.nl.	1	IN	A	157.173.115.164 ; cf_tags=cf-proxied:true
+kube.esa-blueshell.nl.	1	IN	A	157.173.115.164 ; cf_tags=cf-proxied:true
+listmonk.esa-blueshell.nl.	1	IN	A	157.173.115.164 ; cf_tags=cf-proxied:true
+mail-admin.esa-blueshell.nl.	1	IN	A	157.173.115.164 ; cf_tags=cf-proxied:true
+minecraft.event.esa-blueshell.nl.	1	IN	A	193.123.34.253 ; cf_tags=cf-proxied:false
+minecraft.server.esa-blueshell.nl.	1	IN	A	130.89.149.197 ; cf_tags=cf-proxied:false
+stalwart.esa-blueshell.nl.	1	IN	A	157.173.115.164 ; cf_tags=cf-proxied:true
+status.esa-blueshell.nl.	1	IN	A	157.173.115.164 ; cf_tags=cf-proxied:true
+traefik.esa-blueshell.nl.	1	IN	A	157.173.115.164 ; cf_tags=cf-proxied:true
+v2.esa-blueshell.nl.	1	IN	A	157.173.115.164 ; cf_tags=cf-proxied:true
+vault.esa-blueshell.nl.	1	IN	A	157.173.115.164 ; cf_tags=cf-proxied:true
 
-; Minecraft server --------------------------------------------------------
-minecraft   1   IN  A       162.33.20.159
+;; AAAA Records
+auth.esa-blueshell.nl.	1	IN	AAAA	2a02:c207:2316:2642::1 ; cf_tags=cf-proxied:true
+esa-blueshell.nl.	1	IN	AAAA	2a02:c207:2316:2642::1 ; cf_tags=cf-proxied:true
+headlamp.esa-blueshell.nl.	1	IN	AAAA	2a02:c207:2316:2642::1 ; cf_tags=cf-proxied:true
+kube.esa-blueshell.nl.	1	IN	AAAA	2a02:c207:2316:2642::1 ; cf_tags=cf-proxied:true
+listmonk.esa-blueshell.nl.	1	IN	AAAA	2a02:c207:2316:2642::1 ; cf_tags=cf-proxied:true
+mail-admin.esa-blueshell.nl.	1	IN	AAAA	2a02:c207:2316:2642::1 ; cf_tags=cf-proxied:true
+stalwart.esa-blueshell.nl.	1	IN	AAAA	2a02:c207:2316:2642::1 ; cf_tags=cf-proxied:true
+status.esa-blueshell.nl.	1	IN	AAAA	2a02:c207:2316:2642::1 ; cf_tags=cf-proxied:true
+traefik.esa-blueshell.nl.	1	IN	AAAA	2a02:c207:2316:2642::1 ; cf_tags=cf-proxied:true
+v2.esa-blueshell.nl.	1	IN	AAAA	2a02:c207:2316:2642::1 ; cf_tags=cf-proxied:true
+vault.esa-blueshell.nl.	1	IN	AAAA	2a02:c207:2316:2642::1 ; cf_tags=cf-proxied:true
 
-; v2 backend (different host than apex) -----------------------------------
-v2          1   IN  A       157.173.115.164
-v2          1   IN  AAAA    2a02:c207:2316:2642::1
+;; CNAME Records
+ftp.esa-blueshell.nl.	1	IN	CNAME	esa-blueshell.nl. ; cf_tags=cf-proxied:false
+www.esa-blueshell.nl.	1	IN	CNAME	esa-blueshell.nl. ; cf_tags=cf-proxied:true
 
-; Wildcard for *.v2.esa-blueshell.nl → v2 backend -------------------------
-; ACME DNS-01 for the *.v2 wildcard cert uses a TXT record at
-; _acme-challenge.v2.esa-blueshell.nl, written dynamically by the ACME
-; client via the Cloudflare API (token needs Zone:DNS:Edit on this zone).
-; No conflict with these A/AAAA records — TXT lives at a different label.
-*.v2        1   IN  A       157.173.115.164
-*.v2        1   IN  AAAA    2a02:c207:2316:2642::1
+;; MX Records
+esa-blueshell.nl.	1	IN	MX	10 esa-blueshell.nl.
+
+;; TXT Records
+aaaa-auth.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/auth"
+aaaa-headlamp.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/headlamp"
+aaaa-kube.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/headlamp"
+aaaa-listmonk.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/listmonk"
+aaaa-mail-admin.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/listmonk"
+aaaa-stalwart.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/stalwart-admin"
+aaaa-status.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/status"
+aaaa-traefik.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/traefik-dashboard"
+aaaa-vault.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/vault"
+aaaa-www.v2.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/frontend"
+a-auth.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/auth"
+a-headlamp.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/headlamp"
+a-kube.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/headlamp"
+a-listmonk.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/listmonk"
+a-mail-admin.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/listmonk"
+a-stalwart.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/stalwart-admin"
+a-status.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/status"
+a-traefik.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/traefik-dashboard"
+a-vault.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/vault"
+a-www.v2.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/frontend"
+cname-api.v2.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/api"
+cname-auth.v2.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/auth"
+cname-kube.v2.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/headlamp"
+cname-mail-admin.v2.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/listmonk"
+cname-status.v2.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/status"
+cname-www.v2.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/frontend"

--- a/platform/cluster/flux/apps/core/external-dns/release.yaml
+++ b/platform/cluster/flux/apps/core/external-dns/release.yaml
@@ -56,7 +56,7 @@ spec:
       - --annotation-filter=kubernetes.io/ingress.class=traefik-public
       # Zone-wide. We manage one-label admin hosts directly under
       # `esa-blueshell.nl` (auth, kube, mail-admin, status, vault)
-      # rather than two-label hosts under `*.v2.esa-blueshell.nl`,
+      # rather than two-label hosts under `*.esa-blueshell.nl`,
       # because Cloudflare's free Universal SSL edge cert only covers
       # one label deep (`*.esa-blueshell.nl`). Policy stays upsert-only
       # (external-dns default) so apex records managed outside the

--- a/platform/cluster/flux/apps/core/traefik/release.yaml
+++ b/platform/cluster/flux/apps/core/traefik/release.yaml
@@ -40,7 +40,7 @@ spec:
         publishedService:
           enabled: true
     # No MetalLB / LoadBalancer assignment on this single-node cluster.
-    # Cloudflare points v2.esa-blueshell.nl and the one-label admin
+    # Cloudflare points esa-blueshell.nl and the one-label admin
     # hosts (auth/kube/mail-admin/status.esa-blueshell.nl) straight at
     # the node's public IP via external-dns; Traefik binds hostPort
     # 80/443 directly on the node. Service type stays ClusterIP.

--- a/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
+++ b/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
@@ -260,7 +260,7 @@ if vault kv get -field=vault-oidc-client-secret secret/api >/dev/null 2>&1; then
   # for the first run on a cold cluster (api not yet Ready); the next
   # reconcile re-runs this Job idempotently.
   if vault write auth/oidc/config \
-      oidc_discovery_url="https://v2.esa-blueshell.nl/api" \
+      oidc_discovery_url="https://esa-blueshell.nl/api" \
       oidc_client_id="vault" \
       oidc_client_secret="${OIDC_CLIENT_SECRET}" \
       default_role="admin"; then

--- a/platform/cluster/flux/apps/edge/ingressroutes/api.yaml
+++ b/platform/cluster/flux/apps/edge/ingressroutes/api.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: edge-system
   annotations:
     # No DNS record of our own — the frontend IngressRoute already
-    # publishes `v2.esa-blueshell.nl`. We just piggy-back on that
+    # publishes `esa-blueshell.nl`. We just piggy-back on that
     # host with path-based rules that win over frontend's catch-all.
     kubernetes.io/ingress.class: traefik-public
 spec:
@@ -23,26 +23,29 @@ spec:
     - websecure
   # Same-origin /api/*. Spring Authorization Server's `issuer` setting
   # advertises every endpoint nested under /api (jwks_uri etc. are
-  # https://v2.esa-blueshell.nl/api/oauth2/jwks), but every controller
+  # https://esa-blueshell.nl/api/oauth2/jwks), but every controller
   # in the api is mapped at root paths — `/health`, `/events`,
   # `/me/services`, `/oauth2/...`. We strip the `/api` prefix uniformly
   # before forwarding so REST paths reach their controllers AND the
   # SecurityFilterChain matchers (which permit `/health`, `/events/**`,
   # `/csrf`, `/contributionPeriods/current`, ...) actually fire.
   #
-  # Two routes on this host:
+  # Two routes per host:
   #   - OIDC paths under /api/* — priority 100, kept distinct in case
   #     a future change wants a different middleware on this subset.
   #   - Plain REST /api/*       — priority 50, catch-all under /api.
-  # Both apply `strip-api-prefix`. frontend.yaml's `Host(v2)` catch-all
-  # keeps default priority and naturally falls below both.
+  # Both apply `strip-api-prefix`. frontend.yaml's apex catch-all keeps
+  # default priority and naturally falls below both.
+  #
+  # Matched against both apex and the v2.esa-blueshell.nl fallback for
+  # the 30-day grace window after the apex cutover. Retired in PR 11.
   routes:
     - kind: Rule
       priority: 100
       # Single line on purpose: Traefik's rule parser rejects embedded
       # newlines, and YAML folded scalars (>-) preserve them when
       # subsequent lines are more-indented than the first.
-      match: Host(`v2.esa-blueshell.nl`) && (PathPrefix(`/api/oauth2`) || PathPrefix(`/api/userinfo`) || Path(`/api/.well-known/openid-configuration`) || Path(`/api/.well-known/oauth-authorization-server`))
+      match: (Host(`esa-blueshell.nl`) || Host(`v2.esa-blueshell.nl`)) && (PathPrefix(`/api/oauth2`) || PathPrefix(`/api/userinfo`) || Path(`/api/.well-known/openid-configuration`) || Path(`/api/.well-known/oauth-authorization-server`))
       middlewares:
         - name: strip-api-prefix
           namespace: edge-system
@@ -52,7 +55,7 @@ spec:
           port: 8080
     - kind: Rule
       priority: 50
-      match: Host(`v2.esa-blueshell.nl`) && PathPrefix(`/api`)
+      match: (Host(`esa-blueshell.nl`) || Host(`v2.esa-blueshell.nl`)) && PathPrefix(`/api`)
       middlewares:
         - name: strip-api-prefix
           namespace: edge-system

--- a/platform/cluster/flux/apps/edge/ingressroutes/frontend.yaml
+++ b/platform/cluster/flux/apps/edge/ingressroutes/frontend.yaml
@@ -13,15 +13,18 @@ spec:
   entryPoints:
     - websecure
   routes:
-    # `www.v2.esa-blueshell.nl` is intentionally NOT served. Cloudflare
-    # already holds an operator-managed CNAME at that name, and
-    # external-dns cannot CREATE an A/AAAA record next to a CNAME — the
-    # whole reconcile batch 400s with error 81054, which in turn blocks
-    # every other subdomain from being created in the same run. The
-    # `www.` alias can come back (or get routed via a CF page-rule
-    # redirect) at PR 10 apex cutover.
+    # Matches both apex and the v2 fallback. v2.esa-blueshell.nl keeps
+    # resolving through the 30-day grace window after the apex cutover
+    # so legacy bookmarks and the OIDC clients that haven't rolled yet
+    # land on a working frontend. Retired in PR 11.
+    #
+    # `www.esa-blueshell.nl` is served via a Cloudflare-side CNAME →
+    # apex; external-dns cannot CREATE an A/AAAA record next to that
+    # CNAME (reconcile batch 400s with error 81054 and blocks every
+    # other host), so we route the apex Host header here and leave the
+    # `www` flattening to Cloudflare.
     - kind: Rule
-      match: Host(`v2.esa-blueshell.nl`)
+      match: Host(`esa-blueshell.nl`) || Host(`v2.esa-blueshell.nl`)
       services:
         - name: frontend
           namespace: default

--- a/platform/cluster/flux/apps/edge/traefik-default-tls.yaml
+++ b/platform/cluster/flux/apps/edge/traefik-default-tls.yaml
@@ -7,20 +7,16 @@ spec:
   secretName: esa-blueshell-nl-tls
   commonName: esa-blueshell.nl
   # One cert covers:
-  #   - `v2.esa-blueshell.nl`                 (main site during staged
-  #                                            bringup; still matches
-  #                                            *.esa-blueshell.nl)
-  #   - `auth|kube|mail-admin|status|vault.esa-blueshell.nl`
-  #                                           (admin hosts — one label
-  #                                            deep, so they also fit
-  #                                            inside Cloudflare's
-  #                                            Universal SSL
-  #                                            `*.esa-blueshell.nl`
-  #                                            edge cert while proxied)
-  #   - apex `esa-blueshell.nl`               (pre-issued for PR 10
-  #                                            cutover; no harm while
-  #                                            the apex still serves
-  #                                            from the old VPS)
+  #   - apex `esa-blueshell.nl`               (main site)
+  #   - `*.esa-blueshell.nl`                  (admin hosts: auth, kube,
+  #                                            mail-admin, status,
+  #                                            vault, traefik; plus the
+  #                                            v2.esa-blueshell.nl
+  #                                            grace-period fallback —
+  #                                            wildcard matches one
+  #                                            label deep, so this
+  #                                            covers it without
+  #                                            adding a SAN)
   #
   # ACME DNS-01 uses the Cloudflare API token stored at
   # secret/data/platform/edge.cloudflare-api-token; the Cloudflare

--- a/platform/cluster/flux/apps/mail/stalwart/deployment.yaml
+++ b/platform/cluster/flux/apps/mail/stalwart/deployment.yaml
@@ -50,8 +50,8 @@ spec:
           {{- with secret "secret/data/platform/edge" }}
           CF_DNS_API_TOKEN={{ index .Data.data "cloudflare.dns_api_token" }}
           {{- end }}
-          STALWART_HOSTNAME=stalwart.v2.esa-blueshell.nl
-          STALWART_DOMAIN=v2.esa-blueshell.nl
+          STALWART_HOSTNAME=stalwart.esa-blueshell.nl
+          STALWART_DOMAIN=esa-blueshell.nl
     spec:
       serviceAccountName: stalwart
       containers:
@@ -69,7 +69,7 @@ spec:
               cp /config/config.toml /opt/stalwart/etc/config.toml
               exec /usr/local/bin/entrypoint.sh /usr/local/bin/stalwart
           # Mail protocols are raw TCP and cannot traverse Cloudflare's HTTP
-          # proxy. stalwart.v2.esa-blueshell.nl is a non-proxied A record pointing
+          # proxy. stalwart.esa-blueshell.nl is a non-proxied A record pointing
           # directly at the VPS IP. Each mail port binds on the host via
           # hostPort so the pod answers directly without MetalLB.
           ports:

--- a/platform/cluster/flux/apps/stateless/api/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/api/deployment.yaml
@@ -133,14 +133,14 @@ spec:
             - name: MYSQL_PORT
               value: '3306'
             - name: APP_URL
-              value: https://v2.esa-blueshell.nl/api
+              value: https://esa-blueshell.nl/api
             - name: FRONTEND_URL
-              value: https://v2.esa-blueshell.nl
+              value: https://esa-blueshell.nl
             # Leading dot scopes BSH_AUTH (and the future logout cookie)
             # to every subdomain of esa-blueshell.nl. Traefik forwardAuth
             # on vault/headlamp/listmonk/stalwart/traefik subdomains can't
             # authenticate the user without it (host-only cookie set on
-            # v2.esa-blueshell.nl wouldn't be sent to the others).
+            # esa-blueshell.nl wouldn't be sent to the others).
             - name: AUTH_COOKIE_DOMAIN
               value: .esa-blueshell.nl
             - name: STORAGE_LOCATION
@@ -148,7 +148,7 @@ spec:
             - name: LISTMONK_API_BASE_URL
               value: http://listmonk.default.svc.cluster.local:9000/api
             - name: LISTMONK_FROM_ADDRESS
-              value: no-reply@v2.esa-blueshell.nl
+              value: no-reply@esa-blueshell.nl
             - name: LISTMONK_REPLY_TO_ADDRESS
               value: sitecie@esa-blueshell.nl
             - name: LISTMONK_BOUNCE_MAILBOX_ENABLED
@@ -162,7 +162,7 @@ spec:
             - name: LISTMONK_BOUNCE_MAILBOX_FOLDER
               value: INBOX
             - name: LISTMONK_BOUNCE_MAILBOX_RETURN_PATH
-              value: bounce@v2.esa-blueshell.nl
+              value: bounce@esa-blueshell.nl
             # Listmonk admin credentials synced from Vault via VSO remain the
             # bootstrap fallback. Once listmonk-setup creates the runtime
             # listmonk-api-token Secret, the api reads

--- a/platform/cluster/flux/apps/stateless/listmonk/setup-job.yaml
+++ b/platform/cluster/flux/apps/stateless/listmonk/setup-job.yaml
@@ -127,7 +127,7 @@ spec:
                   key: bounce-mailbox-password
                   optional: true
             - name: LISTMONK_SMTP_HELLO_HOSTNAME
-              value: stalwart.v2.esa-blueshell.nl
+              value: stalwart.esa-blueshell.nl
             - name: LISTMONK_SMTP_TLS_TYPE
               value: STARTTLS
             - name: LISTMONK_BOUNCE_MAILBOX_ENABLED
@@ -153,7 +153,7 @@ spec:
             - name: LISTMONK_BOUNCE_MAILBOX_FOLDER
               value: INBOX
             - name: LISTMONK_BOUNCE_MAILBOX_RETURN_PATH
-              value: bounce@v2.esa-blueshell.nl
+              value: bounce@esa-blueshell.nl
           volumeMounts:
             - name: setup-script
               mountPath: /scripts

--- a/platform/cluster/flux/apps/utility-system/gatus/gatus-config-configmap.yaml
+++ b/platform/cluster/flux/apps/utility-system/gatus/gatus-config-configmap.yaml
@@ -10,5 +10,5 @@ data:
       path: /data/data.db
     ui:
       title: Blueshell Esports status
-      description: Uptime for the v2.esa-blueshell.nl stack.
+      description: Uptime for the esa-blueshell.nl stack.
       header: Blueshell Esports

--- a/platform/cluster/flux/apps/utility-system/gatus/gatus-endpoints-configmap.yaml
+++ b/platform/cluster/flux/apps/utility-system/gatus/gatus-endpoints-configmap.yaml
@@ -26,7 +26,7 @@ data:
     # ---------- Public (browser-equivalent) ----------
     - name: "Blueshell Frontend"
       group: "public"
-      url: "https://v2.esa-blueshell.nl/"
+      url: "https://esa-blueshell.nl/"
       interval: "60s"
       conditions:
       - "[STATUS] == 200"
@@ -37,7 +37,7 @@ data:
       # Same-origin /api/health routes via the apex PathPrefix(/api)
       # rule in apps/edge/ingressroutes/api.yaml. Handler:
       # `MainController.healthCheck` (registers /health + /api/health).
-      url: "https://v2.esa-blueshell.nl/api/health"
+      url: "https://esa-blueshell.nl/api/health"
       interval: "60s"
       conditions:
       - "[STATUS] == 200"
@@ -55,7 +55,7 @@ data:
       interval: "60s"
       conditions:
       - "[STATUS] == 200"
-      - "[BODY].issuer == https://v2.esa-blueshell.nl/api"
+      - "[BODY].issuer == https://esa-blueshell.nl/api"
       - "[RESPONSE_TIME] < 500"
 
     # ---------- Admin services (forward-auth) ----------

--- a/platform/cluster/flux/apps/utility-system/headlamp/release.yaml
+++ b/platform/cluster/flux/apps/utility-system/headlamp/release.yaml
@@ -19,7 +19,7 @@ spec:
       # OIDC front-door. Users hit headlamp.esa-blueshell.nl, the website
       # api issues an id-token, and Headlamp passes that token to the
       # k3s API server. k3s is configured to trust the
-      # https://v2.esa-blueshell.nl/api issuer
+      # https://esa-blueshell.nl/api issuer
       # (platform/nix/modules/roles/single-node.nix); the user's RBAC
       # is decided by the `groups` claim via oidc-admin-binding.yaml.
       #
@@ -28,7 +28,7 @@ spec:
       # flow will fail; the deployment otherwise reconciles fine.
       oidc:
         clientID: headlamp
-        issuerURL: https://v2.esa-blueshell.nl/api
+        issuerURL: https://esa-blueshell.nl/api
         scopes: openid profile email groups
         callbackURL: https://headlamp.esa-blueshell.nl/oidc-callback
         usePKCE: true

--- a/platform/cluster/flux/apps/vso-secrets/cloudflare.yaml
+++ b/platform/cluster/flux/apps/vso-secrets/cloudflare.yaml
@@ -1,5 +1,5 @@
 # cert-manager reads cloudflare-api-token.api-token to satisfy DNS-01
-# challenges for *.v2.esa-blueshell.nl. external-dns reads the same secret
+# challenges for *.esa-blueshell.nl. external-dns reads the same secret
 # shape to manage A/AAAA records. VSO syncs both from the same Vault path
 # (`secret/platform/edge:cloudflare.dns_api_token`).
 #

--- a/platform/docs/bringup-v2.md
+++ b/platform/docs/bringup-v2.md
@@ -1,6 +1,6 @@
 # Bringing up the v2 stack on the Frankfurt Contabo VPS
 
-Stands up the NixOS + k3s + Flux stack at `*.v2.esa-blueshell.nl` on
+Stands up the NixOS + k3s + Flux stack at `*.esa-blueshell.nl` on
 a fresh Contabo VPS. Use this when provisioning a replacement node or
 a recovery box.
 
@@ -9,7 +9,7 @@ a recovery box.
 - **Contabo VPS 20** — 6 vCPU / 12 GB RAM / 400 GB NVMe SSD
 - **Public IPv4:** `157.173.115.164` (permanent — baked into the flake)
 - **Hostname (nix + k8s):** `frankfurt-contabo-1`
-- **DNS:** `v2.esa-blueshell.nl` + wildcard `*.v2.esa-blueshell.nl`
+- **DNS:** `esa-blueshell.nl` + wildcard `*.esa-blueshell.nl`
 - **SSH:** `~/.ssh/bs-deploy` throughout
   - Pre-install: `admin@157.173.115.164:2222` (Debian base image; the
     `admin` account disappears once NixOS is installed).
@@ -176,7 +176,7 @@ Later, once `listmonk-setup` has run successfully, also expect
 kubectl -n edge-system get certificate -w
 ```
 
-Expect `wildcard-v2-esa-blueshell-nl` → Ready in 3–8 min (DNS-01
+Expect `wildcard-esa-blueshell-nl` → Ready in 3–8 min (DNS-01
 propagation).
 
 ```bash
@@ -231,11 +231,11 @@ S3/B2 bucket: dump → upload → `kubectl cp` from workstation → restore.
 
 Cloudflare zone `esa-blueshell.nl`:
 
-- `v2.esa-blueshell.nl` A → `157.173.115.164`, AAAA →
+- `esa-blueshell.nl` A → `157.173.115.164`, AAAA →
   `2a02:c207:2316:2642::1`, both proxied (orange cloud).
-- `*.v2.esa-blueshell.nl` — external-dns auto-materialises records
+- `*.esa-blueshell.nl` — external-dns auto-materialises records
   from every IngressRoute; no manual action needed.
-- `stalwart.v2.esa-blueshell.nl` A → `157.173.115.164`, **grey cloud**
+- `stalwart.esa-blueshell.nl` A → `157.173.115.164`, **grey cloud**
   (Cloudflare cannot proxy SMTP/IMAP).
 - `esa-blueshell.nl` apex + `www.esa-blueshell.nl`: A records also
   pointing at `157.173.115.164`, **orange cloud**.
@@ -243,25 +243,25 @@ Cloudflare zone `esa-blueshell.nl`:
 ## 10. Verify
 
 ```bash
-curl -I https://v2.esa-blueshell.nl
+curl -I https://esa-blueshell.nl
 ```
 ```bash
-curl https://v2.esa-blueshell.nl/api/health
+curl https://esa-blueshell.nl/api/health
 ```
 ```bash
-curl https://v2.esa-blueshell.nl/api/.well-known/openid-configuration | jq .issuer
+curl https://esa-blueshell.nl/api/.well-known/openid-configuration | jq .issuer
 ```
 ```bash
-curl https://status.v2.esa-blueshell.nl/
+curl https://status.esa-blueshell.nl/
 ```
 ```bash
-SYSTEM_TEST_BASE_URL=https://v2.esa-blueshell.nl ./gradlew :services:system-tests:test
+SYSTEM_TEST_BASE_URL=https://esa-blueshell.nl ./gradlew :services:system-tests:test
 ```
 ```bash
 vault login -method=oidc
 ```
 
-All Gatus monitors green on `https://status.v2.esa-blueshell.nl` is
+All Gatus monitors green on `https://status.esa-blueshell.nl` is
 the headline check.
 
 ## 11. Retire the old admin key
@@ -285,7 +285,7 @@ mv ~/.ssh/blueshell-admin.pub ~/.ssh/blueshell-admin.pub.retired
 - `vault login -method=oidc` + Headlamp login both succeed and land
   the user at `cluster-admin`.
 - `:services:system-tests:test` passes against
-  `https://v2.esa-blueshell.nl`.
+  `https://esa-blueshell.nl`.
 
 ## Ongoing updates
 

--- a/platform/docs/runbook.md
+++ b/platform/docs/runbook.md
@@ -4,7 +4,7 @@ The `platform/` tree manages the production stack:
 **NixOS + k3s + FluxCD + Kustomize + Helm**.
 
 Production runs on a single Contabo VPS (`frankfurt-contabo-1`) under
-`v2.esa-blueshell.nl`. Flux reconciles every manifest from this
+`esa-blueshell.nl`. Flux reconciles every manifest from this
 repository against `main`; Keel rolls Deployments when new
 `ghcr.io/esa-blueshell/*:latest` images appear.
 

--- a/platform/docs/vault-bootstrap.md
+++ b/platform/docs/vault-bootstrap.md
@@ -79,7 +79,7 @@ of them blocks at least one downstream Secret.
 - **GHCR pull credential**: GitHub username + a fine-grained PAT scoped
   to `read:packages` on `ESA-Blueshell` (private api/frontend images).
 - **Stalwart admin user/password** + base64-encoded RSA-2048 DKIM
-  private key + bounce mailbox `bounce@v2.esa-blueshell.nl` credentials.
+  private key + bounce mailbox `bounce@esa-blueshell.nl` credentials.
 - **One-shot generated values** (only if missing from the legacy env):
   - `JWT_SECRET` — `openssl rand -base64 64`.
   - `vault-oidc-client-secret` — `openssl rand -hex 32`.
@@ -182,7 +182,7 @@ vault kv put secret/platform/mail \
   admin-user=admin \
   admin-password=<stalwart-admin-password> \
   dkim-private-key=<base64-encoded-rsa-2048-pem> \
-  bounce-mailbox-user=bounce@v2.esa-blueshell.nl \
+  bounce-mailbox-user=bounce@esa-blueshell.nl \
   bounce-mailbox-password=<bounce-mailbox-password>
 ```
 

--- a/platform/nix/hosts/frankfurt-contabo-1/default.nix
+++ b/platform/nix/hosts/frankfurt-contabo-1/default.nix
@@ -30,7 +30,7 @@
 
   networking = {
     hostName = "frankfurt-contabo-1";
-    domain = "v2.esa-blueshell.nl";
+    domain = "esa-blueshell.nl";
     # Contabo does not run DHCP — the cidata ISO ships static config that
     # Debian picks up on first boot. We bake those exact values here; the
     # public IP is permanent for the lifetime of this VPS.

--- a/platform/nix/modules/roles/single-node.nix
+++ b/platform/nix/modules/roles/single-node.nix
@@ -22,7 +22,7 @@
       # The oidc: prefix keeps these identities disjoint from the
       # built-in system:* groups so a human-issued token is never
       # implicitly bound to a system role.
-      "--kube-apiserver-arg=oidc-issuer-url=https://v2.esa-blueshell.nl/api"
+      "--kube-apiserver-arg=oidc-issuer-url=https://esa-blueshell.nl/api"
       "--kube-apiserver-arg=oidc-client-id=headlamp"
       "--kube-apiserver-arg=oidc-username-claim=preferred_username"
       "--kube-apiserver-arg=oidc-username-prefix=oidc:"

--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/web/oidc/ForwardAuthControllerIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/web/oidc/ForwardAuthControllerIT.kt
@@ -36,7 +36,7 @@ class ForwardAuthControllerIT : UserTestSupport() {
                     .header("X-Forwarded-Uri", "/ui/dashboard")
             )
                 .andExpect(status().isFound)
-                .andExpect(redirectedUrlPattern("https://v2.esa-blueshell.nl/login?redirect=*"))
+                .andExpect(redirectedUrlPattern("https://esa-blueshell.nl/login?redirect=*"))
                 .andExpect(header().string(HttpHeaders.LOCATION, org.hamcrest.Matchers.containsString("vault.esa-blueshell.nl%2Fui%2Fdashboard")))
         }
 
@@ -61,7 +61,7 @@ class ForwardAuthControllerIT : UserTestSupport() {
                     .header("X-Forwarded-Uri", "/")
             )
                 .andExpect(status().isFound)
-                .andExpect(redirectedUrlPattern("https://v2.esa-blueshell.nl/login?redirect=*"))
+                .andExpect(redirectedUrlPattern("https://esa-blueshell.nl/login?redirect=*"))
         }
     }
 
@@ -78,7 +78,7 @@ class ForwardAuthControllerIT : UserTestSupport() {
                     .header("X-Forwarded-Uri", "/")
             )
                 .andExpect(status().isFound)
-                .andExpect(header().string(HttpHeaders.LOCATION, "https://v2.esa-blueshell.nl/unauthorized?service=vault.esa-blueshell.nl"))
+                .andExpect(header().string(HttpHeaders.LOCATION, "https://esa-blueshell.nl/unauthorized?service=vault.esa-blueshell.nl"))
         }
 
         @Test
@@ -92,7 +92,7 @@ class ForwardAuthControllerIT : UserTestSupport() {
                     .header("X-Forwarded-Uri", "/")
             )
                 .andExpect(status().isFound)
-                .andExpect(header().string(HttpHeaders.LOCATION, "https://v2.esa-blueshell.nl/unauthorized?service=vault.esa-blueshell.nl"))
+                .andExpect(header().string(HttpHeaders.LOCATION, "https://esa-blueshell.nl/unauthorized?service=vault.esa-blueshell.nl"))
         }
 
         @Test

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/config/ListmonkProperties.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/config/ListmonkProperties.kt
@@ -21,7 +21,7 @@ data class ListmonkProperties(
     )
 
     data class FromProperties(
-        val address: String = "no-reply@mg.v2.esa-blueshell.nl",
+        val address: String = "no-reply@mg.esa-blueshell.nl",
     )
 
     data class BounceProperties(

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/oidc/AuthorizationServerConfig.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/oidc/AuthorizationServerConfig.kt
@@ -123,7 +123,7 @@ class AuthorizationServerConfig {
 
     @Bean
     fun authorizationServerSettings(
-        @Value("\${auth.issuer:https://v2.esa-blueshell.nl/api}") issuer: String,
+        @Value("\${auth.issuer:https://esa-blueshell.nl/api}") issuer: String,
     ): AuthorizationServerSettings {
         return AuthorizationServerSettings.builder()
             .issuer(issuer)

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/web/MainController.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/web/MainController.kt
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController
 @Tag(name = "Health")
 class MainController {
     // `/health` is the external-facing endpoint: the public Gatus probe at
-    // `https://v2.esa-blueshell.nl/api/health` arrives here as `/health`
+    // `https://esa-blueshell.nl/api/health` arrives here as `/health`
     // because Traefik's apex `PathPrefix(/api)` rule strips the `/api`
     // prefix uniformly (see apps/edge/ingressroutes/api.yaml).
     // Pod-level k8s probes use Spring Boot's

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/web/oidc/ForwardAuthController.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/web/oidc/ForwardAuthController.kt
@@ -42,7 +42,7 @@ import java.nio.charset.StandardCharsets
 @Tag(name = "Forward Auth")
 @RequestMapping("/oauth2/forward-auth")
 class ForwardAuthController(
-    @param:Value($$"${forward-auth.frontend-base-url:https://v2.esa-blueshell.nl}")
+    @param:Value($$"${forward-auth.frontend-base-url:https://esa-blueshell.nl}")
     private val frontendBaseUrl: String,
 ) {
 
@@ -68,7 +68,7 @@ class ForwardAuthController(
         }
 
         // SPAs (Stalwart webadmin, Headlamp, …) fetch their own /api/* via XHR.
-        // A 302 to v2.esa-blueshell.nl/login auto-follows cross-origin and the
+        // A 302 to esa-blueshell.nl/login auto-follows cross-origin and the
         // browser blocks it with CORS, surfacing as a generic network error in
         // the SPA. 401 lets the SPA show a proper "session expired" state.
         val wantsHtml = request.getHeader(HttpHeaders.ACCEPT).orEmpty().contains("text/html")

--- a/services/api/src/main/kotlin/net/blueshell/api/shared/email/EmailContent.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/shared/email/EmailContent.kt
@@ -11,6 +11,6 @@ data class EmailContent(
     val subject: String,
     val markdownContent: String,
     val senderName: String = "Blueshell",
-    val senderAddress: String = "no-reply@mg.v2.esa-blueshell.nl",
+    val senderAddress: String = "no-reply@mg.esa-blueshell.nl",
     val replyTo: String = "sitecie@blueshell.utwente.nl"
 )

--- a/services/api/src/main/resources/application.yaml
+++ b/services/api/src/main/resources/application.yaml
@@ -131,7 +131,7 @@ server:
 security:
   cors:
     allowed-origins:
-      - ${FRONTEND_URL:https://v2.esa-blueshell.nl}
+      - ${FRONTEND_URL:https://esa-blueshell.nl}
   auth-cookie:
     name: BSH_AUTH
     path: /
@@ -160,7 +160,7 @@ listmonk:
     api-user: ${LISTMONK_ADMIN_API_USER:api}
     token-file: ${LISTMONK_API_TOKEN_FILE:/run/secrets/listmonk/api-token.env}
   from:
-    address: ${LISTMONK_FROM_ADDRESS:no-reply@mg.v2.esa-blueshell.nl}
+    address: ${LISTMONK_FROM_ADDRESS:no-reply@mg.esa-blueshell.nl}
   reply-to: ${LISTMONK_REPLY_TO_ADDRESS:sitecie@blueshell.utwente.nl}
   # ID of the pre-existing "Blueshell Transactional" template in Listmonk.
   # Provisioned by the listmonk setup Job or manually via the admin UI; the
@@ -209,7 +209,7 @@ management:
         http.server.requests: 0.5, 0.95, 0.99
 
 auth:
-  issuer: ${AUTH_ISSUER:https://v2.esa-blueshell.nl/api}
+  issuer: ${AUTH_ISSUER:https://esa-blueshell.nl/api}
   transit:
     enabled: ${AUTH_TRANSIT_ENABLED:false}
     key-name: ${AUTH_TRANSIT_KEY_NAME:api-jwt}

--- a/services/frontend/vite.config.mjs
+++ b/services/frontend/vite.config.mjs
@@ -69,7 +69,7 @@ export default defineConfig({
     server: {
         port: 3000,
         host: true,
-        allowedHosts: ['frontend', process.env.ALLOWED_HOST || 'v2.esa-blueshell.nl'],
+        allowedHosts: ['frontend', process.env.ALLOWED_HOST || 'esa-blueshell.nl'],
         hmr: {
             protocol: 'ws'
         },

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/ForwardAuthChainSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/oidc/ForwardAuthChainSystemTest.kt
@@ -19,7 +19,7 @@ import java.util.stream.Stream
 class ForwardAuthChainSystemTest : OidcSystemTestBase() {
 
     companion object {
-        private const val FRONTEND_BASE = "https://v2.esa-blueshell.nl"
+        private const val FRONTEND_BASE = "https://esa-blueshell.nl"
 
         @JvmStatic
         fun adminGatedHosts(): Stream<Arguments> = Stream.of(


### PR DESCRIPTION
## Why

The new NixOS + k3s stack has been serving on `v2.esa-blueshell.nl`
since PR 9, and the database + storage are now restored from the
latest production backup. Keeping the `v2.` prefix would mean every
external bookmark, OIDC client, and link in transactional email keeps
pointing at a staging-shaped hostname for a permanent install. The
apex `esa-blueshell.nl` is the long-term home; this PR makes the
stack answer to it everywhere, while leaving `v2.esa-blueshell.nl`
working as a fallback through the PR 11 decommission window.

## What this achieves

- `https://esa-blueshell.nl/` and `https://esa-blueshell.nl/api/*`
  serve the production stack directly from the apex.
- OIDC issuer is `https://esa-blueshell.nl/api`. Vault and Headlamp
  pick the new discovery URL up on next reconcile; the k3s apiserver
  trusts the apex issuer via the nix flake.
- Listmonk transactional from/return-path moves to `@esa-blueshell.nl`
  and Stalwart announces itself as `stalwart.esa-blueshell.nl`.
- Frontend + API IngressRoutes still match `v2.esa-blueshell.nl`
  alongside the apex Host header. Old bookmarks and any OIDC client
  that has not rolled yet keep working, and Cloudflare's
  `*.esa-blueshell.nl` Universal SSL covers v2 (one label deep).
- Cert-manager already had a `wildcard-esa-blueshell-nl` Certificate
  for `esa-blueshell.nl` + `*.esa-blueshell.nl`, so no DNS-01
  ceremony was needed for the cutover itself.

## How

- Edge: `apps/edge/ingressroutes/{frontend,api}.yaml` match
  `Host(`esa-blueshell.nl`) || Host(`v2.esa-blueshell.nl`)`. Stale
  comments about "staged bringup" and "PR 10 cutover" replaced.
  `traefik-default-tls.yaml` comment now describes the cert
  coverage (apex + wildcard, no separate v2 SAN).
- Core: `external-dns` + `traefik` release comments updated to apex.
- VSO: `vso-secrets/cloudflare.yaml` comment now describes
  `*.esa-blueshell.nl` DNS-01.
- Data: `apps/data/vault/bootstrap-auth.sh` writes
  `oidc_discovery_url=https://esa-blueshell.nl/api` next reconcile.
- Apps:
  - `stateless/api/deployment.yaml` — `APP_URL`, `FRONTEND_URL`,
    `LISTMONK_FROM_ADDRESS`, `LISTMONK_BOUNCE_MAILBOX_RETURN_PATH`.
  - `stateless/listmonk/setup-job.yaml` —
    `LISTMONK_SMTP_HELLO_HOSTNAME`, bounce return-path.
  - `mail/stalwart/deployment.yaml` — `STALWART_HOSTNAME` +
    `STALWART_DOMAIN`.
  - `utility-system/headlamp/release.yaml` — `oidc.issuerURL`.
  - `utility-system/gatus/{config,endpoints}-configmap.yaml` —
    Frontend probe + OIDC discovery issuer assertion.
- Nix: `hosts/frankfurt-contabo-1/default.nix` (`networking.domain`)
  and `modules/roles/single-node.nix` (k3s
  `--oidc-issuer-url`).
- API:
  - `AuthorizationServerConfig.kt` issuer default.
  - `ForwardAuthController.kt` frontend-base-url default.
  - `ListmonkProperties.kt` From default + `EmailContent.kt`
    sender default.
  - `MainController.kt` Gatus URL in the doc-comment.
  - `application.yaml` — `security.cors.allowed-origins`,
    `listmonk.from.address`, `auth.issuer`.
- Tests:
  - `ForwardAuthControllerIT.kt` expects redirects to
    `https://esa-blueshell.nl/...`.
  - `ForwardAuthChainSystemTest.kt` `FRONTEND_BASE` updated.
- Docs: `bringup-v2.md`, `vault-bootstrap.md`, `runbook.md` reflect
  the apex hostnames; `infra/dns/README.md` describes the new layout
  and the v2 grace-period A record.
- Frontend: `vite.config.mjs` dev-server `allowedHosts` default.
- DNS: `infra/dns/esa-blueshell.nl.zone` re-export from Cloudflare
  showing apex + admin records on `157.173.115.164`, with the
  `v2.esa-blueshell.nl` A/AAAA kept proxied as the safety net.