### PR TITLE
platform(edge): retire v2 IngressRoute legs and pin frontend priority

### DIFF
--- a/infra/dns/README.md
+++ b/infra/dns/README.md
@@ -13,10 +13,9 @@ Authoritative zone files, one per domain. Imported into Cloudflare via
   `kube`, `vault`, `mail-admin`, `status`, `traefik`) resolves through
   that node — admin records are external-dns managed off each
   IngressRoute.
-- `v2.esa-blueshell.nl` remains pointed at the same node as a fallback
-  during the 30-day grace period after the apex cutover; the frontend
-  and api IngressRoutes match both hostnames so legacy bookmarks keep
-  working. Retired in PR 11.
+- `v2.esa-blueshell.nl` has been retired — both the DNS records and
+  the IngressRoute Host matchers were dropped once the apex cutover
+  was confirmed healthy.
 
 ## Proxy status
 
@@ -28,7 +27,6 @@ After import, toggle the orange cloud per record:
 | `@` (MX target)              | off   | Mail cannot be proxied.                                |
 | `minecraft`                  | off   | Game traffic — Cloudflare proxy is HTTP(S) only.       |
 | `ftp`                        | off   | Non-HTTP protocol.                                     |
-| `v2`                         | on    | Grace-period fallback to the apex backend (PR 11).     |
 
 ## ACME / Let's Encrypt
 

--- a/platform/cluster/flux/apps/edge/ingressroutes/api.yaml
+++ b/platform/cluster/flux/apps/edge/ingressroutes/api.yaml
@@ -30,22 +30,21 @@ spec:
   # SecurityFilterChain matchers (which permit `/health`, `/events/**`,
   # `/csrf`, `/contributionPeriods/current`, ...) actually fire.
   #
-  # Two routes per host:
+  # Two routes:
   #   - OIDC paths under /api/* — priority 100, kept distinct in case
   #     a future change wants a different middleware on this subset.
   #   - Plain REST /api/*       — priority 50, catch-all under /api.
-  # Both apply `strip-api-prefix`. frontend.yaml's apex catch-all keeps
-  # default priority and naturally falls below both.
-  #
-  # Matched against both apex and the v2.esa-blueshell.nl fallback for
-  # the 30-day grace window after the apex cutover. Retired in PR 11.
+  # Both apply `strip-api-prefix`. frontend.yaml pins its catch-all
+  # to an explicit `priority: 1` so these routes always win on /api/*
+  # — Traefik's default priority is the rule string length, which can
+  # otherwise exceed 50 once a Host matcher grows.
   routes:
     - kind: Rule
       priority: 100
       # Single line on purpose: Traefik's rule parser rejects embedded
       # newlines, and YAML folded scalars (>-) preserve them when
       # subsequent lines are more-indented than the first.
-      match: (Host(`esa-blueshell.nl`) || Host(`v2.esa-blueshell.nl`)) && (PathPrefix(`/api/oauth2`) || PathPrefix(`/api/userinfo`) || Path(`/api/.well-known/openid-configuration`) || Path(`/api/.well-known/oauth-authorization-server`))
+      match: Host(`esa-blueshell.nl`) && (PathPrefix(`/api/oauth2`) || PathPrefix(`/api/userinfo`) || Path(`/api/.well-known/openid-configuration`) || Path(`/api/.well-known/oauth-authorization-server`))
       middlewares:
         - name: strip-api-prefix
           namespace: edge-system
@@ -55,7 +54,7 @@ spec:
           port: 8080
     - kind: Rule
       priority: 50
-      match: (Host(`esa-blueshell.nl`) || Host(`v2.esa-blueshell.nl`)) && PathPrefix(`/api`)
+      match: Host(`esa-blueshell.nl`) && PathPrefix(`/api`)
       middlewares:
         - name: strip-api-prefix
           namespace: edge-system

--- a/platform/cluster/flux/apps/edge/ingressroutes/frontend.yaml
+++ b/platform/cluster/flux/apps/edge/ingressroutes/frontend.yaml
@@ -13,18 +13,23 @@ spec:
   entryPoints:
     - websecure
   routes:
-    # Matches both apex and the v2 fallback. v2.esa-blueshell.nl keeps
-    # resolving through the 30-day grace window after the apex cutover
-    # so legacy bookmarks and the OIDC clients that haven't rolled yet
-    # land on a working frontend. Retired in PR 11.
-    #
     # `www.esa-blueshell.nl` is served via a Cloudflare-side CNAME →
     # apex; external-dns cannot CREATE an A/AAAA record next to that
     # CNAME (reconcile batch 400s with error 81054 and blocks every
     # other host), so we route the apex Host header here and leave the
     # `www` flattening to Cloudflare.
+    #
+    # Explicit `priority: 1` — Traefik computes a default priority
+    # equal to the rule string length when none is set. The api
+    # IngressRoute's `PathPrefix(/api)` catch-all sits at priority 50;
+    # without an explicit low number here, growing the Host matcher
+    # (e.g. a parallel-serve alias) can push the frontend's
+    # auto-priority above 50, sending /api/* to the SPA nginx (which
+    # returns index.html for GETs and 405 for POSTs). Anchoring the
+    # frontend at 1 makes the precedence "specificity wins" explicit.
     - kind: Rule
-      match: Host(`esa-blueshell.nl`) || Host(`v2.esa-blueshell.nl`)
+      priority: 1
+      match: Host(`esa-blueshell.nl`)
       services:
         - name: frontend
           namespace: default

--- a/platform/cluster/flux/apps/edge/traefik-default-tls.yaml
+++ b/platform/cluster/flux/apps/edge/traefik-default-tls.yaml
@@ -10,13 +10,9 @@ spec:
   #   - apex `esa-blueshell.nl`               (main site)
   #   - `*.esa-blueshell.nl`                  (admin hosts: auth, kube,
   #                                            mail-admin, status,
-  #                                            vault, traefik; plus the
-  #                                            v2.esa-blueshell.nl
-  #                                            grace-period fallback —
+  #                                            vault, traefik —
   #                                            wildcard matches one
-  #                                            label deep, so this
-  #                                            covers it without
-  #                                            adding a SAN)
+  #                                            label deep)
   #
   # ACME DNS-01 uses the Cloudflare API token stored at
   # secret/data/platform/edge.cloudflare-api-token; the Cloudflare


### PR DESCRIPTION
## Why

Two follow-up issues from the apex cutover (#223) need cleanup:

1. `v2.esa-blueshell.nl` has been removed from Cloudflare DNS now
   that the apex is confirmed healthy. The IngressRoute legs that
   matched the v2 Host header no longer correspond to any reachable
   name.
2. Adding the v2 `||` leg to the frontend rule pushed its character
   count to ~55. Traefik computes a default router priority equal to
   the rule string length when none is set, so the frontend catch-all
   ended up at priority 55 — above the api `PathPrefix(/api)` route
   at priority 50. Every `/api/*` request was routed to the SPA
   nginx; the login flow saw `GET /api/auth` returning index.html
   and `POST /api/auth` returning 405 from the frontend's nginx,
   which surfaced in the browser as `AxiosError: Request failed with
   status code 405` against `/api/auth`.

## What this achieves

- `/api/*` traffic reaches the api again. The OIDC paths (priority
  100) and the REST catch-all (priority 50) both win against the
  frontend Host catch-all unconditionally.
- The frontend IngressRoute carries an explicit `priority: 1`, so
  future Host-matcher growth (a new alias, a parallel-serve window,
  etc.) cannot silently push it back above 50.
- The cert and DNS docs reflect the post-cutover steady state — no
  more "grace-period fallback" wording, no v2 row in the Cloudflare
  proxy-status table.

## How

- `apps/edge/ingressroutes/frontend.yaml`: drop the
  `|| Host(v2.esa-blueshell.nl)` leg; add `priority: 1`; comment
  block now documents the auto-priority trap so the next change
  does not reintroduce it.
- `apps/edge/ingressroutes/api.yaml`: drop the v2 alternative from
  both the priority-100 OIDC rule and the priority-50 catch-all;
  comment now references the new explicit-priority pairing.
- `apps/edge/traefik-default-tls.yaml`: cert comment no longer
  describes the v2 SAN coverage.
- `infra/dns/README.md`: bullet about v2 grace period rewritten to
  past tense; v2 row removed from the proxy-status table.