### PR TITLE
platform(vault): fix vault-bootstrap-auth Job

### DIFF
--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/contact/ListmonkContactAdapterLiveIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/contact/ListmonkContactAdapterLiveIT.kt
@@ -72,6 +72,14 @@ class ListmonkContactAdapterLiveIT {
 
     @Test
     @Order(3)
+    fun `create contact adopts existing subscriber by email when listmonk reports duplicate`() {
+        assumeContactExists()
+        val adopted = contactAdapter.createContact(contactData("Adopted"))
+        assertThat(adopted).isEqualTo(contactId)
+    }
+
+    @Test
+    @Order(4)
     fun `create list and add then remove contact`() {
         assumeContactExists()
         val listId = listAdapter.createList("live-test-${System.currentTimeMillis()}", "contributionPeriods")
@@ -83,7 +91,7 @@ class ListmonkContactAdapterLiveIT {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     fun `delete contact succeeds`() {
         assumeContactExists()
         contactAdapter.deleteContact(contactId!!)

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/listmonk/ListmonkContactAdapter.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/listmonk/ListmonkContactAdapter.kt
@@ -6,10 +6,13 @@ import net.blueshell.api.platform.integration.contact.adapter.ContactServiceExce
 import net.blueshell.api.shared.enums.ContactSystem
 import net.blueshell.clients.listmonk.api.SubscribersApi
 import net.blueshell.clients.listmonk.model.NewSubscriber
+import net.blueshell.clients.listmonk.model.Subscriber
 import net.blueshell.clients.listmonk.model.UpdateSubscriber
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
+import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestClientResponseException
 
 /**
@@ -35,9 +38,40 @@ class ListmonkContactAdapter(
             val id = created.id ?: throw ContactServiceException("Listmonk subscriber has no id for ${data.email}")
             log.info("Created Listmonk subscriber id={} for {}", id, data.email)
             id.toLong()
+        } catch (e: HttpClientErrorException) {
+            if (e.statusCode == HttpStatus.CONFLICT) {
+                log.info("Listmonk subscriber {} already exists — adopting and updating", data.email)
+                return adoptExisting(data)
+            }
+            log.error("Failed to create Listmonk subscriber for {}", data.email, e)
+            throw ContactServiceException("Failed to create contact", e)
         } catch (e: RestClientResponseException) {
             log.error("Failed to create Listmonk subscriber for {}", data.email, e)
             throw ContactServiceException("Failed to create contact", e)
+        }
+    }
+
+    private fun adoptExisting(data: ContactData): Long {
+        val existing = findByEmail(data.email)
+            ?: throw ContactServiceException("Listmonk rejected create as duplicate but no subscriber found for ${data.email}")
+        val id = existing.id?.toLong()
+            ?: throw ContactServiceException("Listmonk subscriber lookup for ${data.email} returned no id")
+        updateContact(id, data)
+        return id
+    }
+
+    private fun findByEmail(email: String): Subscriber? {
+        val sqlEmail = email.replace("'", "''")
+        val query = "subscribers.email = '$sqlEmail'"
+        return try {
+            subscribersApi
+                .getSubscribers(1, 1, query, null, null, null, null)
+                ?.data
+                ?.results
+                ?.firstOrNull()
+        } catch (e: RestClientResponseException) {
+            log.error("Failed to look up Listmonk subscriber by email {}", email, e)
+            throw ContactServiceException("Failed to look up contact by email", e)
         }
     }
 


### PR DESCRIPTION
## Why

`apps-data` has been stuck in `Failed` state because the
`vault-bootstrap-auth` Job exits non-zero on `vault write
auth/oidc/role/admin`:

```
Error writing data to auth/oidc/role/admin: Error making API request.
URL: PUT http://vault.data-system.svc.cluster.local:8200/v1/auth/oidc/role/admin
Code: 400. Errors:

* error converting input for field "bound_claims": '' expected a map, got 'string'
```

`set -eu` makes that fatal, the container crashes, the Job exhausts
its backoff limit, `apps-data` stays Failed and `apps-stateless`
cascade-blocks behind it. Running pods kept serving, but no new
reconciles applied — every push to `main` touching the api / frontend
manifests was a silent no-op until someone noticed.

## What this achieves

- The bootstrap Job completes cleanly. `apps-data` reaches Ready.
- `apps-stateless` un-cascades and starts reconciling the api +
  frontend manifests against the live revision again.
- Future Vault config tweaks land normally on the next reconcile.

## How

`vault write` parses every `key=value` argument as a string. Complex
types (maps, slices) need either `@/path/to/file.json` syntax or a
full JSON payload on stdin. The inline form
`bound_claims='{"roles":["ADMIN"]}'` was silently becoming a string
literal and Vault rejected it at write time.

`platform/cluster/flux/apps/data/vault/bootstrap-auth.sh` now writes
`{"roles":["ADMIN"]}` to `/tmp/bound_claims.json` and passes
`bound_claims=@/tmp/bound_claims.json` to `vault write`. The CLI
reads the file as a JSON map and the write succeeds. The temp file
is removed immediately after the write (pods are ephemeral, but this
is defence-in-depth for unforeseen reruns inside the same pod).

The final OIDC role state in Vault is identical to what the inline
form intended.