### PR TITLE
platform(traefik): switch Deployment to Recreate strategy

### DIFF
--- a/platform/cluster/flux/apps/core/traefik/release.yaml
+++ b/platform/cluster/flux/apps/core/traefik/release.yaml
@@ -13,6 +13,21 @@ spec:
         name: traefik
         namespace: ingress-system
   values:
+    # Force Recreate on upgrade. The chart default is RollingUpdate
+    # with maxSurge=1/maxUnavailable=0, which on this single-node
+    # cluster guarantees a deadlock: the new pod is scheduled before
+    # the old one is killed, but only one pod can hold hostPort 80
+    # and 443. The new pod stays Pending with
+    # `FailedScheduling: didn't have free ports for the requested pod
+    # ports` until the Helm upgrade times out, the HelmRelease goes
+    # to `Failed`, and apps-core cascade-blocks every downstream
+    # Kustomization. Recreate accepts a brief 80/443 gap on the node
+    # in exchange for an upgrade path that actually completes.
+    deployment:
+      kind: Deployment
+      strategy:
+        type: Recreate
+        rollingUpdate: null
     ingressClass:
       enabled: true
       isDefaultClass: true


### PR DESCRIPTION
## Why

The Traefik chart defaults to RollingUpdate with maxSurge=1 /
maxUnavailable=0. On this single-node cluster the api-host binds
hostPort 80 and 443 directly — only one pod can hold those ports at
a time. RollingUpdate insists on scheduling the new pod *before*
killing the old, so the upgrade never completes:

```
0/1 nodes are available: 1 node(s) didn't have free ports for the
requested pod ports.
```

The next Helm upgrade — chart bump, config tweak, anything — sits in
this trap for ten minutes, the HelmRelease lands in `Failed`, and
because `apps-core` health-checks the Traefik HelmRelease, every
downstream Kustomization (apps-edge, apps-stateless, apps-data,
apps-mail, apps-utility-system, apps-vso-secrets) cascade-blocks
with `dependency 'flux-system/apps-core' is not ready`. A previous
chart upgrade sat in this state for ~7 days unnoticed and needed a
manual `kubectl delete pod traefik-…` followed by `flux suspend /
flux resume` on the HelmRelease to recover. The IngressRoute changes
from the apex cutover only landed after that manual unstick.

## What this achieves

Future Helm upgrades complete on their own. The trade-off is a brief
inbound-traffic gap on 80/443 while the old pod terminates and the
new one starts — acceptable for chart bumps that happen at most once
per release, and far cheaper than the alternative (a stuck upgrade
that silently masks every other reconcile in the cluster).

## How

`platform/cluster/flux/apps/core/traefik/release.yaml` adds:

```yaml
deployment:
  kind: Deployment
  strategy:
    type: Recreate
    rollingUpdate: null
```

`rollingUpdate` is explicitly nulled so the chart's conditional
`if eq .Values.deployment.strategy.type "RollingUpdate"` block falls
through cleanly. A comment in-file records the single-node + hostPort
constraint so the next person tempted to switch back to RollingUpdate
sees the trap.