### PR TITLE
feat(api,frontend): raise event banner upload limit to 10 MB

### DIFF
--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/domain/file/web/FileControllerIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/domain/file/web/FileControllerIT.kt
@@ -109,7 +109,7 @@ class FileControllerIT : UserTestSupport() {
         @Test
         fun `returns bad request for oversized file`() {
             val committee = createUserWithRole(Role.COMMITTEE)
-            val oversized = ByteArray(2 * 1024 * 1024 + 1) { 1 }
+            val oversized = ByteArray(10 * 1024 * 1024 + 1) { 1 }
             val file = MockMultipartFile(
                 "file",
                 "large.png",

--- a/services/api/src/main/kotlin/net/blueshell/api/domain/file/web/FileController.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/domain/file/web/FileController.kt
@@ -37,7 +37,7 @@ class FileController(
     )
     @PreAuthorize("hasPermission('__NO_TARGET__', 'EventBanner', 'write')")
     fun uploadEventBanner(
-        @RequestPart("file") @NotNull(message = "File is required") @FileSize(max = 2 * 1024 * 1024) @AllowedContentTypes(
+        @RequestPart("file") @NotNull(message = "File is required") @FileSize(max = 10 * 1024 * 1024) @AllowedContentTypes(
             "image/png",
             "image/jpeg",
             "image/jpg",

--- a/services/frontend/src/components/form/EventForm.vue
+++ b/services/frontend/src/components/form/EventForm.vue
@@ -92,7 +92,7 @@ const signUpFormIsDirty = computed(() => JSON.stringify(event.value.signUpForm) 
 defineRule("fileSize", (value: File | File[] | null) => {
   const f = Array.isArray(value) ? value[0] ?? null : (value as File | null)
   if (!f) return true
-  return f.size <= 2 * 1024 * 1024 || "Promo image must be ≤ 2MB"
+  return f.size <= 10 * 1024 * 1024 || "Promo image must be ≤ 10MB"
 })
 
 const eventFieldMap: FieldMap = {
@@ -424,7 +424,7 @@ defineExpose({validate, save})
               'show-size': true
             }"
             :update="(file: File, handle: HandleChange<string>) => onBannerChange(file as File | null, handle)"
-            label="Promo image (Max 2MB)"
+            label="Promo image (Max 10MB)"
             name="banner"
             rules="fileSize"
           />


### PR DESCRIPTION
## Why
The previous 2 MB cap on event promo banners rejected reasonably-sized images straight from a phone camera, forcing committees to downscale every banner before upload. 10 MB is generous enough to accept JPEGs and PNGs at modern phone resolutions without manual editing while staying well under the 50 MB Spring multipart ceiling.

## What this achieves
Committees can upload promo images up to 10 MB through the event editor without preprocessing. Server-side validation, client-side rule, and the user-visible label all agree on the new cap so the form's helper text matches what the API will accept.

## How
- `services/api/src/main/kotlin/net/blueshell/api/domain/file/web/FileController.kt` — `@FileSize(max = …)` on the `uploadEventBanner` request part raised from `2 * 1024 * 1024` to `10 * 1024 * 1024`.
- `services/api/src/integrationTest/kotlin/net/blueshell/api/domain/file/web/FileControllerIT.kt` — the "oversized file" assertion now allocates `10 * 1024 * 1024 + 1` bytes so it still trips the validator.
- `services/frontend/src/components/form/EventForm.vue` — the `fileSize` VeeValidate rule and the `v-file-input` label both reference 10 MB; the validation message reads `Promo image must be ≤ 10MB`.