### PR TITLE
fix(frontend): point the LinkedIn icon at LinkedIn

### DIFF
--- a/services/frontend/src/components/common/banners/SocialsBanner.vue
+++ b/services/frontend/src/components/common/banners/SocialsBanner.vue
@@ -59,7 +59,7 @@ export default {
         },
         {
           icon: "mdi-linkedin",
-          url: "https://www.instagram.com/esablueshell/",
+          url: "https://linkedin.com/company/blueshell-esports",
         },
       ],
     }


### PR DESCRIPTION
## Why

The LinkedIn entry in the SocialsBanner had an Instagram URL — the
icon was `mdi-linkedin` but the click sent users to
`https://www.instagram.com/esablueshell/` (a duplicate of the
Instagram entry directly above it).

## What this achieves

Clicking the LinkedIn icon now opens the Blueshell Esports LinkedIn
company page.

## How

`services/frontend/src/components/common/banners/SocialsBanner.vue`
URL updated from `https://www.instagram.com/esablueshell/` to
`https://linkedin.com/company/blueshell-esports`.