### PR TITLE
test(frontend): set prefers-reduced-motion in Playwright config to deflake e2e

### DIFF
--- a/services/frontend/playwright.config.ts
+++ b/services/frontend/playwright.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     baseURL: "http://127.0.0.1:4173",
     trace: "on-first-retry",
     navigationTimeout: 60_000,
+    reducedMotion: "reduce",
   },
   webServer: {
     command: "VITE_COVERAGE=true yarn dev --host 127.0.0.1 --port 4173",


### PR DESCRIPTION
## Why
The Playwright job `Frontend end-to-end tests` flaked on the mobile-chrome project in the `management recovery lifecycle › deletes user from member manager and restores in recovery manager` test. The click on `member-user-delete-btn-…` succeeded, but `expect(page.getByTestId('deletion-confirmation-dialog')).toBeVisible()` timed out at 15s. Desktop chromium ran the same test in the same run and passed.

The diff between the two: the non-members panel uses `<v-expand-transition>` over its content; right after `ensureExpanded` flips `aria-expanded` the panel's inline `max-height` is still animating from 0 to its full size, and Vuetify applies `overflow: hidden` (plus, briefly, `pointer-events: none`) on the transitioning element. On the wider chromium viewport the animation finished before Playwright dispatched the click; on the Pixel 7 emulation the click fired during the unstable window and `openDelete` never fired, so the dialog never mounted.

## What this achieves
Tests no longer race the panel and dialog transitions. The expand panel snaps open and `v-dialog` mounts without a fade, so the click that opens the deletion-confirmation dialog lands deterministically on both the chromium and mobile-chrome projects. Other tests that exercise transitions (event-card expansion, navbar drawer, snackbars) benefit from the same determinism without any per-test changes.

## How
- `services/frontend/playwright.config.ts` — adds `reducedMotion: "reduce"` to the top-level `use` block. The browser advertises `prefers-reduced-motion: reduce`; Vuetify 3 honours that across its transition components (`v-expand-transition`, `v-dialog`, `v-snackbar`, etc.) and skips the animation phase entirely. No timeouts are extended and no per-test waits are introduced.