### PR TITLE
fix(jobs): serialize contact sync per aggregate and coalesce mid-flight enqueues

### DIFF
--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/command/SyncContactCommandHandler.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/command/SyncContactCommandHandler.kt
@@ -1,55 +1,72 @@
 package net.blueshell.api.platform.integration.contact.application.command
 
 import net.blueshell.api.platform.integration.contact.adapter.ContactAdapter
+import net.blueshell.api.platform.integration.contact.adapter.ContactData
 import net.blueshell.api.platform.integration.contact.adapter.toContactData
 import net.blueshell.api.platform.integration.contact.persistence.Contact
 import net.blueshell.api.platform.integration.contact.persistence.repository.ContactRepository
+import net.blueshell.api.platform.integration.queue.SyncLock
 import net.blueshell.api.domain.user.application.UserService
 import net.blueshell.api.shared.command.CommandHandler
+import net.blueshell.api.shared.enums.ContactSystem
 import net.blueshell.api.shared.job.NonRetryableJobException
 import net.blueshell.api.shared.job.SyncContactCommand
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 import kotlin.reflect.KClass
 
 /**
  * Handles [SyncContactCommand]: creates, updates, or deletes a user's contact record
  * in one external system.
  *
- * Selects the correct [ContactAdapter] by [SyncContactCommand.system] at runtime.
- * Registered adapters are injected as a list; adding a new integration simply requires
- * registering a new [ContactAdapter] bean — no new command or handler needed.
+ * Concurrency: per-(userId, system) serialization is enforced via [SyncLock]. The
+ * handler re-reads User + Contact inside the lock so a successor run that was
+ * queued while a prior run was in flight observes the latest state, not the
+ * state captured when the successor was enqueued. When the locally stored
+ * snapshot already equals the desired state, the external API call is skipped —
+ * this collapses bursts of rapid upstream changes to at most one redundant
+ * push and makes the handler safe to retry.
  *
  * State machine:
  * - Soft-deleted contact + external ID exists → delete from external system, clear ID
  * - Active contact + no external ID → create in external system, store ID + snapshot
- * - Active contact + external ID → update in external system, refresh snapshot
+ * - Active contact + external ID + snapshot stale → update in external system, refresh snapshot
+ * - Active contact + external ID + snapshot fresh → no-op
  */
 @Component
 class SyncContactCommandHandler(
     private val contactAdapters: List<ContactAdapter>,
     private val contactRepository: ContactRepository,
     private val userService: UserService,
+    private val syncLock: SyncLock,
 ) : CommandHandler<SyncContactCommand, Unit> {
 
     override val commandType: KClass<SyncContactCommand> = SyncContactCommand::class
 
+    @Transactional
     override fun handle(command: SyncContactCommand) {
         val adapter = contactAdapters.find { it.system == command.system }
             ?: throw NonRetryableJobException("No ContactAdapter registered for system ${command.system}")
 
-        val userId = command.userId
+        val lockName = lockName(command.userId, command.system)
+        syncLock.withLock(lockName) {
+            syncOne(command.userId, command.system, adapter)
+        }
+    }
+
+    private fun syncOne(userId: Long, system: ContactSystem, adapter: ContactAdapter) {
         val contact = contactRepository.findByUserIdIncludingDeleted(userId)
 
         if (contact != null && contact.isSoftDeleted) {
-            val externalId = contact.externalId(command.system) ?: run {
-                log.debug("Contact for user {} deleted but has no {} ID — nothing to delete", userId, command.system)
+            val externalId = contact.externalId(system) ?: run {
+                log.debug("Contact for user {} deleted but has no {} ID — nothing to delete", userId, system)
                 return
             }
             adapter.deleteContact(externalId)
-            contact.clearExternalId(command.system)
+            contact.clearExternalId(system)
             contactRepository.save(contact)
-            log.info("Deleted {} contact for user {}", command.system, userId)
+            log.info("Deleted {} contact for user {}", system, userId)
             return
         }
 
@@ -57,20 +74,47 @@ class SyncContactCommandHandler(
         val user = userService.findById(userId)
         val data = user.toContactData()
 
-        val existingId = record.externalId(command.system)
+        val existingId = record.externalId(system)
         if (existingId == null) {
             val newId = adapter.createContact(data)
-            record.setExternalId(command.system, newId)
-            record.updateSnapshot(data.email, data.firstName, data.lastName, data.phoneNumber, data.newsletter, data.isMember)
-            contactRepository.save(record)
-            log.info("Created {} contact for user {}", command.system, userId)
-        } else {
-            adapter.updateContact(existingId, data)
-            record.updateSnapshot(data.email, data.firstName, data.lastName, data.phoneNumber, data.newsletter, data.isMember)
-            contactRepository.save(record)
-            log.debug("Updated {} contact for user {}", command.system, userId)
+            record.setExternalId(system, newId)
+            storeSnapshot(record, data)
+            log.info("Created {} contact for user {}", system, userId)
+            return
         }
+
+        if (record.matchesSnapshot(
+                email = data.email,
+                firstName = data.firstName,
+                lastName = data.lastName,
+                phoneNumber = data.phoneNumber,
+                newsletter = data.newsletter,
+                isMember = data.isMember,
+            )
+        ) {
+            log.debug("{} contact for user {} already matches snapshot — skipping external update", system, userId)
+            return
+        }
+
+        adapter.updateContact(existingId, data)
+        storeSnapshot(record, data)
+        log.debug("Updated {} contact for user {}", system, userId)
     }
+
+    private fun storeSnapshot(record: Contact, data: ContactData) {
+        record.updateSnapshot(
+            data.email,
+            data.firstName,
+            data.lastName,
+            data.phoneNumber,
+            data.newsletter,
+            data.isMember,
+        )
+        contactRepository.save(record)
+    }
+
+    private fun lockName(userId: Long, system: ContactSystem): String =
+        "contact-sync:$userId:${system.name}"
 
     companion object {
         private val log = LoggerFactory.getLogger(SyncContactCommandHandler::class.java)

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/persistence/Contact.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/persistence/Contact.kt
@@ -74,4 +74,24 @@ class Contact(
         syncedNewsletter = newsletter
         syncedIsMember = isMember
     }
+
+    /**
+     * True when the locally stored "last successfully synced" snapshot matches
+     * the supplied desired state. Used by sync handlers to skip a redundant
+     * external API call when an earlier run has already pushed the same data.
+     */
+    fun matchesSnapshot(
+        email: String,
+        firstName: String,
+        lastName: String,
+        phoneNumber: String?,
+        newsletter: Boolean,
+        isMember: Boolean,
+    ): Boolean =
+        syncedEmail == email &&
+            syncedFirstName == firstName &&
+            syncedLastName == lastName &&
+            syncedPhoneNumber == phoneNumber &&
+            syncedNewsletter == newsletter &&
+            syncedIsMember == isMember
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/job/application/service/JobExecutionService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/job/application/service/JobExecutionService.kt
@@ -22,13 +22,19 @@ class JobExecutionService(
         jobType: String,
         payload: String?,
         actor: Actor,
-        dedupKey: String? = null
+        dedupKey: String? = null,
+        coalesceAgainstQueuedOnly: Boolean = false
     ): JobExecution? {
         if (dedupKey != null) {
+            val activeStatuses = if (coalesceAgainstQueuedOnly) {
+                listOf(JobExecutionStatus.QUEUED)
+            } else {
+                listOf(JobExecutionStatus.QUEUED, JobExecutionStatus.RUNNING)
+            }
             val active = jobExecutionRepository.existsByJobTypeAndDedupKeyAndStatusIn(
                 jobType,
                 dedupKey,
-                listOf(JobExecutionStatus.QUEUED, JobExecutionStatus.RUNNING)
+                activeStatuses
             )
             if (active) return null
         }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/queue/JobDispatcher.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/queue/JobDispatcher.kt
@@ -33,7 +33,13 @@ class JobDispatcher(
         actor: Actor?
     ): JobExecution? {
         val dedupKey = job.dedupKey(payload)
-        return enqueue(job.type, payload, actor, dedupKey)
+        return enqueueInternal(
+            jobType = job.type,
+            payload = payload,
+            actor = actor,
+            dedupKey = dedupKey,
+            coalesceAgainstQueuedOnly = job.coalesceAgainstQueuedOnly
+        )
     }
 
     override fun enqueue(
@@ -41,6 +47,20 @@ class JobDispatcher(
         payload: Any?,
         actor: Actor?,
         dedupKey: String?
+    ): JobExecution? = enqueueInternal(
+        jobType = jobType,
+        payload = payload,
+        actor = actor,
+        dedupKey = dedupKey,
+        coalesceAgainstQueuedOnly = false
+    )
+
+    private fun enqueueInternal(
+        jobType: String,
+        payload: Any?,
+        actor: Actor?,
+        dedupKey: String?,
+        coalesceAgainstQueuedOnly: Boolean
     ): JobExecution? {
         val payloadJson = payload?.let { objectMapper.writeValueAsString(it) }
         val resolvedActor = actor ?: actorProvider.currentOrSystem()
@@ -48,7 +68,8 @@ class JobDispatcher(
             jobType = jobType,
             payload = payloadJson,
             actor = resolvedActor,
-            dedupKey = dedupKey
+            dedupKey = dedupKey,
+            coalesceAgainstQueuedOnly = coalesceAgainstQueuedOnly
         ) ?: return null
 
         if (properties.autoDispatch) {

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/queue/SyncLock.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/queue/SyncLock.kt
@@ -1,0 +1,89 @@
+package net.blueshell.api.platform.integration.queue
+
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantLock
+
+/**
+ * Per-aggregate serial-execution primitive for sync handlers.
+ *
+ * Implementations guarantee that two callers using the same [name] are mutually
+ * excluded while the action runs. The lock is acquired with a bounded wait;
+ * if it cannot be acquired within [timeoutSeconds] a [SyncLockBusyException]
+ * is thrown so the calling job is rescheduled by the job framework's standard
+ * retry path.
+ *
+ * Handlers must run inside an active transaction so the lock is held on the
+ * transaction's pinned connection — otherwise Hibernate would borrow a fresh
+ * connection per statement and the lock would be released by the pool before
+ * the work completes.
+ */
+interface SyncLock {
+    fun <T> withLock(name: String, timeoutSeconds: Int = 1, action: () -> T): T
+}
+
+class SyncLockBusyException(message: String) : RuntimeException(message)
+
+/**
+ * MariaDB-backed [SyncLock] using `GET_LOCK(name, timeout)` / `RELEASE_LOCK(name)`.
+ * The lock is session-scoped: it must be acquired and released on the same JDBC
+ * connection, which is guaranteed by running inside a Spring-managed transaction
+ * that has bound a connection from the pool.
+ */
+@Component
+@Profile("!test")
+class MariaDbSyncLock(
+    private val jdbcTemplate: JdbcTemplate,
+) : SyncLock {
+    override fun <T> withLock(name: String, timeoutSeconds: Int, action: () -> T): T {
+        val acquired = jdbcTemplate.queryForObject(
+            "SELECT GET_LOCK(?, ?)",
+            Int::class.java,
+            name,
+            timeoutSeconds,
+        )
+        if (acquired != 1) {
+            throw SyncLockBusyException("Could not acquire sync lock '$name' within ${timeoutSeconds}s")
+        }
+        try {
+            return action()
+        } finally {
+            try {
+                jdbcTemplate.queryForObject("SELECT RELEASE_LOCK(?)", Int::class.java, name)
+            } catch (e: Exception) {
+                log.warn("Failed to release sync lock '{}': {}", name, e.message)
+            }
+        }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(MariaDbSyncLock::class.java)
+    }
+}
+
+/**
+ * In-process [SyncLock] used in unit / integration tests where no MariaDB
+ * session is available. Backed by per-name [ReentrantLock]s; mutual exclusion
+ * is JVM-scoped only.
+ */
+@Component
+@Profile("test")
+class InMemorySyncLock : SyncLock {
+    private val locks = ConcurrentHashMap<String, ReentrantLock>()
+
+    override fun <T> withLock(name: String, timeoutSeconds: Int, action: () -> T): T {
+        val lock = locks.computeIfAbsent(name) { ReentrantLock() }
+        val acquired = lock.tryLock(timeoutSeconds.toLong(), java.util.concurrent.TimeUnit.SECONDS)
+        if (!acquired) {
+            throw SyncLockBusyException("Could not acquire sync lock '$name' within ${timeoutSeconds}s")
+        }
+        try {
+            return action()
+        } finally {
+            lock.unlock()
+        }
+    }
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/shared/job/JobDefinition.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/shared/job/JobDefinition.kt
@@ -12,13 +12,27 @@ interface JobDefinition<T : Any> {
 
     /**
      * Computes an optional dedup key from the payload.
-     * If non-null and an active job (QUEUED or RUNNING) exists with the same job type and dedup key,
-     * the new job will be suppressed.
+     * If non-null and an active job exists with the same job type and dedup key,
+     * the new job will be suppressed. [coalesceAgainstQueuedOnly] controls which
+     * statuses count as "active".
      *
      * Default implementation hashes the fully-qualified class name and toString() of the payload,
      * which for data classes covers all fields automatically.
      */
     fun dedupKey(payload: T): String? = payloadHash(payload)
+
+    /**
+     * When `false` (default), an enqueue is suppressed if any job with the same
+     * dedup key is QUEUED or RUNNING.
+     *
+     * When `true`, the in-flight RUNNING job no longer blocks enqueue; only a
+     * pre-existing QUEUED job does. This implements queue-tail coalescing: an
+     * upstream change that arrives mid-run becomes the next run rather than
+     * being silently dropped. The handler must be self-reconciling — i.e. read
+     * authoritative state inside its own transaction — otherwise back-to-back
+     * runs can still issue redundant external calls.
+     */
+    val coalesceAgainstQueuedOnly: Boolean get() = false
 }
 
 private fun <T : Any> payloadHash(payload: T): String {

--- a/services/api/src/main/kotlin/net/blueshell/api/shared/job/JobDefinitions.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/shared/job/JobDefinitions.kt
@@ -73,11 +73,15 @@ object ContactJobs {
     object SyncContactToSystem : CommandJobDefinition<SyncContactCommand> {
         override val type: String = "contact.sync-to-system"
         override val payloadType: Class<SyncContactCommand> = SyncContactCommand::class.java
+        // Upstream changes arriving while a run is in flight must enqueue a
+        // successor; the running attempt may have read pre-change state.
+        override val coalesceAgainstQueuedOnly: Boolean = true
     }
 
     object SyncListMembershipToSystem : CommandJobDefinition<SyncListMembershipCommand> {
         override val type: String = "contact.sync-list-to-system"
         override val payloadType: Class<SyncListMembershipCommand> = SyncListMembershipCommand::class.java
+        override val coalesceAgainstQueuedOnly: Boolean = true
     }
 
     data class DispatchContactSyncsPayload(val unused: Unit = Unit)

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/application/command/SyncContactCommandHandlerTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/application/command/SyncContactCommandHandlerTest.kt
@@ -6,6 +6,8 @@ import net.blueshell.api.platform.integration.contact.adapter.ContactAdapter
 import net.blueshell.api.platform.integration.contact.adapter.ContactData
 import net.blueshell.api.platform.integration.contact.persistence.Contact
 import net.blueshell.api.platform.integration.contact.persistence.repository.ContactRepository
+import net.blueshell.api.platform.integration.queue.SyncLock
+import net.blueshell.api.platform.integration.queue.SyncLockBusyException
 import net.blueshell.api.shared.enums.ContactSystem
 import net.blueshell.api.shared.job.NonRetryableJobException
 import net.blueshell.api.shared.job.SyncContactCommand
@@ -23,18 +25,24 @@ import org.mockito.kotlin.whenever
 /**
  * Unit tests for [SyncContactCommandHandler].
  *
- * No Spring context — instantiate directly with mocks.
+ * No Spring context — instantiate directly with mocks. The injected
+ * [SyncLock] is a pass-through that simply invokes the action; lock
+ * acquisition itself is exercised separately.
  */
 class SyncContactCommandHandlerTest {
 
     private val adapter: ContactAdapter = mock()
     private val contactRepository: ContactRepository = mock()
     private val userService: UserService = mock()
+    private val passthroughLock: SyncLock = object : SyncLock {
+        override fun <T> withLock(name: String, timeoutSeconds: Int, action: () -> T): T = action()
+    }
 
     private val handler = SyncContactCommandHandler(
         contactAdapters = listOf(adapter),
         contactRepository = contactRepository,
         userService = userService,
+        syncLock = passthroughLock,
     )
 
     private val userId = 42L
@@ -71,9 +79,10 @@ class SyncContactCommandHandlerTest {
     }
 
     @Test
-    fun `updates contact in external system when external ID already exists`() {
+    fun `updates contact in external system when external ID exists and snapshot is stale`() {
         val contact = Contact(userId = userId).also { it.id = 99L }
         contact.setExternalId(system, externalId)
+        // Snapshot left at defaults — does not match the user's current data.
         whenever(contactRepository.findByUserIdIncludingDeleted(userId)).thenReturn(contact)
         whenever(contactRepository.save(any<Contact>())).thenReturn(contact)
 
@@ -81,6 +90,27 @@ class SyncContactCommandHandlerTest {
 
         verify(adapter).updateContact(eq(externalId), any<ContactData>())
         verify(adapter, never()).createContact(any())
+    }
+
+    @Test
+    fun `skips external update when stored snapshot already matches desired state`() {
+        val contact = Contact(userId = userId).also { it.id = 99L }
+        contact.setExternalId(system, externalId)
+        contact.updateSnapshot(
+            email = "test@example.com",
+            firstName = "Test",
+            lastName = "User",
+            phoneNumber = null,
+            newsletter = false,
+            isMember = false,
+        )
+        whenever(contactRepository.findByUserIdIncludingDeleted(userId)).thenReturn(contact)
+
+        handler.handle(command)
+
+        verify(adapter, never()).updateContact(any(), any())
+        verify(adapter, never()).createContact(any())
+        verify(contactRepository, never()).save(any())
     }
 
     @Test
@@ -120,10 +150,33 @@ class SyncContactCommandHandlerTest {
             contactAdapters = emptyList(),
             contactRepository = contactRepository,
             userService = userService,
+            syncLock = passthroughLock,
         )
 
         assertThrows(NonRetryableJobException::class.java) {
             handlerNoAdapters.handle(command)
         }
+    }
+
+    @Test
+    fun `propagates lock-busy as retryable when sync lock cannot be acquired`() {
+        val busyLock: SyncLock = object : SyncLock {
+            override fun <T> withLock(name: String, timeoutSeconds: Int, action: () -> T): T {
+                throw SyncLockBusyException("lock '$name' busy")
+            }
+        }
+        val handlerBusy = SyncContactCommandHandler(
+            contactAdapters = listOf(adapter),
+            contactRepository = contactRepository,
+            userService = userService,
+            syncLock = busyLock,
+        )
+
+        assertThrows(SyncLockBusyException::class.java) {
+            handlerBusy.handle(command)
+        }
+        verify(adapter, never()).createContact(any())
+        verify(adapter, never()).updateContact(any(), any())
+        verify(adapter, never()).deleteContact(any())
     }
 }


### PR DESCRIPTION
## Why

Two race classes were left open in the contact-sync pipeline.

First, an upstream change arriving while a `SyncContactToSystem` run was
in flight was silently dropped: `JobExecutionService.createQueued`
treated RUNNING jobs as active for dedup, so the new enqueue returned
`null` and no successor was scheduled to pick up the post-change state.
The running attempt had already read the pre-change snapshot.

Second, two same-key jobs could transiently overlap at the
QUEUED → RUNNING → SUCCESS boundary and race at the external API.
Hibernate's optimistic `@Version` caught the local write conflict, but
only after the redundant adapter call had already left the JVM, so the
external system's final state was determined by network ordering rather
than local commit order.

## What this achieves

Rapid upstream changes for one user no longer get swallowed by a sync
that is already running. Concurrent `SyncContactToSystem` attempts for
the same `(userId, system)` are serialised by a database advisory lock,
and bursts of identical changes collapse to at most one external
adapter call — repeat runs that find the stored snapshot already matches
the desired state skip the adapter entirely.

## How

- `JobDefinition.coalesceAgainstQueuedOnly` (default `false`) selects
  the dedup status set. `SyncContactToSystem` and
  `SyncListMembershipToSystem` opt in to `true`: only a QUEUED job
  suppresses a fresh enqueue, so a RUNNING attempt now lets a successor
  through.
- The flag flows through `JobDispatcher.enqueue(JobDefinition, ...)` to
  a new private `enqueueInternal` and then to
  `JobExecutionService.createQueued`. The untyped string-keyed `enqueue`
  overload retains the original QUEUED+RUNNING dedup semantics.
- New `SyncLock` interface with `MariaDbSyncLock` (`@Profile("!test")`,
  acquires `GET_LOCK` / `RELEASE_LOCK` on the session-pinned connection
  of the handler's own `@Transactional` method) and `InMemorySyncLock`
  (`@Profile("test")`, per-name `ReentrantLock`s). `SyncLockBusyException`
  is a plain `RuntimeException`, so the existing job-retry path picks it
  up as a retryable failure.
- `SyncContactCommandHandler` is now `@Transactional`, acquires
  `contact-sync:{userId}:{system}` before doing any work, and re-reads
  `User` + `Contact` inside the lock. A new `Contact.matchesSnapshot`
  helper short-circuits the adapter call when the stored snapshot is
  already current.
- Unit tests inject a pass-through `SyncLock` and add coverage for the
  no-op-when-snapshot-matches and lock-busy-retryable paths.