### PR TITLE
fix(db): widen external_id_mapping.external_id to VARCHAR(1024)

### DIFF
--- a/services/api/src/main/resources/db/migration/V61__widen_external_id_mapping_external_id.sql
+++ b/services/api/src/main/resources/db/migration/V61__widen_external_id_mapping_external_id.sql
@@ -1,0 +1,10 @@
+-- Widen external_id_mapping.external_id to fit long Google Calendar event IDs.
+--
+-- The original V58 column was VARCHAR(255). Recurring-event exception ids
+-- encoded by Google can exceed that (267 chars observed in prod), which made
+-- V58 fail mid-transaction on the events backfill INSERT and crash-looped the
+-- api for ~12 h until the column was widened by hand. VARCHAR(1024) matches
+-- Google's documented upper bound; external_id is not part of any index, so
+-- the length change has no key-prefix consequences.
+
+ALTER TABLE external_id_mapping MODIFY COLUMN external_id VARCHAR(1024) NULL;


### PR DESCRIPTION
## Why
The api was crash-looping for roughly 12 hours after Keel pulled the
image that introduced `V58__external_id_mapping.sql`. V58 created
`external_id_mapping.external_id` as `VARCHAR(255)` and then backfilled
it from three sources, including `events.google_id`. Three rows in
production carry Google Calendar exception ids that are 267 chars
long, so V58's events INSERT failed with `Data too long for column`,
the whole transaction rolled back, and Flyway recorded V58 as
`success=0`. Every subsequent startup tripped Flyway validation and
the api never reached a ready state.

The deployment was running with `maxSurge=0, maxUnavailable=1`, so the
old healthy pod was terminated before the new one came up, turning the
migration failure into a full outage.

## What this achieves
- Brings the persisted schema definition in source into alignment with
  the column shape that production actually needs. A fresh
  environment, where the source tables are empty at V58 time, will now
  end up with `VARCHAR(1024)` once V61 runs, before any runtime sync
  job can insert an oversized Google id.
- Removes the latent landmine: any future event with a >255 char
  google_id would otherwise have failed the runtime
  `ListmonkContactAdapter` / Google calendar sync writes against the
  same column.

## How
- New migration `V61__widen_external_id_mapping_external_id.sql`:
  `ALTER TABLE external_id_mapping MODIFY COLUMN external_id VARCHAR(1024) NULL;`
- V58 is intentionally left untouched. It already ran (and was
  repaired in place) on the only environment that has data to
  backfill; rewriting it would change its Flyway checksum and trip
  validation on the running pod until a new image rolled out. V61
  achieves the same end state without that coordination window.
- `external_id` is referenced only by the `uk_external_id_mapping`
  unique key on `(aggregate_type, aggregate_id, system)` and the
  `idx_external_id_mapping_system` index on `(system, aggregate_type)`.
  Neither includes `external_id`, so the column-length change has no
  index-prefix or row-format implications.