### PR TITLE
fix(api): switch api rollout to surge-first, zero-downtime strategy

### DIFF
--- a/platform/cluster/flux/apps/stateless/api/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/api/deployment.yaml
@@ -20,14 +20,22 @@ metadata:
     keel.sh/pollSchedule: '@every 2m'
 spec:
   replicas: 1
-  # maxSurge=0 avoids a second pod pending when the node is near capacity.
-  # The ~30 s gap is hidden behind Traefik's retry; the Spring Boot warm-up
-  # is fast enough that liveness/readiness gates catch any real failure.
+  # Zero-downtime rollout: bring a second pod up first (maxSurge=1) and only
+  # tear the old one down once the new pod's readiness probe reports
+  # ACCEPTING_TRAFFIC (maxUnavailable=0). A broken image — failed Flyway
+  # migration, Vault token miss, anything that keeps /actuator/health/readiness
+  # red — never displaces the healthy old pod, so the rollout silently
+  # ProgressDeadline-stalls instead of taking the api offline.
+  #
+  # progressDeadlineSeconds is generous because Spring Boot's cold start with
+  # Flyway + Hibernate + Vault agent handshake can take several minutes on a
+  # fresh image pull.
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 1
+      maxUnavailable: 0
+  progressDeadlineSeconds: 900
   selector:
     matchLabels:
       app.kubernetes.io/name: api


### PR DESCRIPTION
## Why
The api Deployment was rolling with `maxSurge=0, maxUnavailable=1`,
which terminates the running pod before the replacement is scheduled
and trades a brief outage for slightly lower peak node pressure. When
the replacement image carries a hard startup failure — Flyway
migration V58 wedged on a data-too-long INSERT, for example — that
brief outage becomes an indefinite one: the old healthy pod is
already gone, the new one never reaches Ready, and traffic has
nowhere to land. That is exactly what produced the ~12 h api outage
this fix is responding to.

## What this achieves
A pod that fails its readiness probe can never displace a healthy
predecessor. The rollout brings the new pod up alongside the old one
and only retires the old pod once the new pod's
`/actuator/health/readiness` reports UP. A broken image stalls the
rollout (eventually tripping ProgressDeadlineExceeded) instead of
taking the api offline.

## How
- `rollingUpdate.maxSurge: 1`, `maxUnavailable: 0` so the new pod
  must reach Ready before the old pod is terminated.
- `progressDeadlineSeconds: 900` accommodates Spring Boot cold start
  with Flyway + Hibernate + Vault Agent handshake on a fresh image
  pull, which can run several minutes.
- Header comment rewritten to spell out the contract — old pod stays
  up until the new pod is healthy — so the next operator does not
  reintroduce the surge=0 footgun for capacity reasons.