### PR TITLE
fix(vault): post oidc admin role payload as JSON so bound_claims types as a map

### DIFF
--- a/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
+++ b/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
@@ -266,14 +266,25 @@ if vault kv get -field=vault-oidc-client-secret secret/api >/dev/null 2>&1; then
       default_role="admin"; then
     # `bound_claims` is defence-in-depth: the api already 403s non-admins
     # at /oauth2/authorize. `roles` is emitted as Role.name ("ADMIN").
-    vault write auth/oidc/role/admin \
-      bound_audiences="vault" \
-      allowed_redirect_uris="https://vault.esa-blueshell.nl/ui/vault/auth/oidc/oidc/callback" \
-      user_claim="sub" \
-      groups_claim="groups" \
-      oidc_scopes="openid,profile,email,groups" \
-      bound_claims='{"roles":["ADMIN"]}' \
-      token_policies="admin"
+    #
+    # bound_claims must arrive at Vault as a map, not a JSON-encoded
+    # string. `vault write key=value` always serialises the value as a
+    # string, so the entire role payload is posted as a JSON request
+    # body via `@-` (read from stdin) instead — that keeps the nested
+    # object typed correctly. Without this the OIDC plugin rejects
+    # the write with: `error converting input for field "bound_claims":
+    # '' expected a map, got 'string'`.
+    vault write auth/oidc/role/admin - <<'JSON'
+{
+  "bound_audiences": "vault",
+  "allowed_redirect_uris": "https://vault.esa-blueshell.nl/ui/vault/auth/oidc/oidc/callback",
+  "user_claim": "sub",
+  "groups_claim": "groups",
+  "oidc_scopes": "openid,profile,email,groups",
+  "bound_claims": {"roles": ["ADMIN"]},
+  "token_policies": "admin"
+}
+JSON
   else
     echo "auth/oidc/config write failed (api OIDC discovery URL likely not"
     echo "reachable yet — fresh cluster, apps-stateless not Ready). Skipping"


### PR DESCRIPTION
## Why
`vault-bootstrap-auth` has been failing in production since
2026-05-21 with

```
error converting input for field "bound_claims":
'' expected a map, got 'string'
```

`vault write k=v` always serialises the value as a string, so the
existing form

```sh
bound_claims='{"roles":["ADMIN"]}'
```

reached the OIDC backend as a string literal instead of a
`map[string][]string`. The plugin rejected the write, the Job
exhausted its backoff, and `apps-data` stayed unready — which in
turn blocked `apps-stateless`. Any change to the api Deployment
manifest in this repo has therefore been sitting unmerged-into-the-
cluster for ~4 days, including rollout-strategy fixes intended to
prevent api outages.

## What this achieves
- `vault-bootstrap-auth` completes Successfully on every run, so
  Flux reconciles `apps-data` → `apps-stateless` → the api
  Deployment, which means manifest edits in this repo actually
  reach the cluster again.
- The OIDC `admin` role now has a properly-typed `bound_claims`
  map, so the defence-in-depth claim check Vault is supposed to
  apply (`roles` must include `ADMIN`) is actually enforced.

## How
- Switched the role write to post a full JSON body via `vault write
  auth/oidc/role/admin -` reading from a heredoc on stdin. Nested
  object types survive the request because Vault parses the body
  itself instead of receiving stringified fields from the CLI.
- Comment on the surrounding block records the failure mode and
  why the heredoc form is required, so the next person editing
  this script does not re-introduce the `k=v` form.
- Verified by running the new command against the live Vault
  (`vault read auth/oidc/role/admin` reports
  `bound_claims map[roles:[ADMIN]]`).