### PR TITLE
fix(contact): isolate per-user sync in DispatchContactSyncsJob to avoid rollback-only contamination

### DIFF
--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/DispatchContactSyncsJob.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/DispatchContactSyncsJob.kt
@@ -7,6 +7,9 @@ import net.blueshell.api.platform.integration.sync.application.ContactSyncServic
 import net.blueshell.api.shared.job.ContactJobs
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.support.TransactionTemplate
 
 /** Daily bulk refresh of every user's contact state across all targets. */
 @Component
@@ -14,17 +17,30 @@ class DispatchContactSyncsJob(
     objectMapper: ObjectMapper,
     private val userService: UserService,
     private val contactSync: ContactSyncService,
+    transactionManager: PlatformTransactionManager,
 ) : AbstractJsonJobHandler<ContactJobs.DispatchContactSyncsPayload>(
     objectMapper,
     ContactJobs.DispatchContactSyncs.payloadType,
 ) {
     override val jobType: String = ContactJobs.DispatchContactSyncs.type
 
+    // ContactSyncService.sync is @Transactional with default REQUIRED propagation,
+    // so it would join the outer @Transactional opened by AbstractJsonJobHandler.handle.
+    // A single user failing would then mark the shared transaction rollback-only,
+    // and the dispatcher's commit at the end would throw UnexpectedRollbackException
+    // even though runCatching swallowed the per-user exception. Each user gets its
+    // own REQUIRES_NEW transaction so failures isolate to that user's row.
+    private val perUserSync = TransactionTemplate(transactionManager).apply {
+        propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
+    }
+
     override fun handlePayload(payload: ContactJobs.DispatchContactSyncsPayload) {
         val users = userService.findAll()
         log.info("Refreshing contact sync for {} users", users.size)
         users.forEach { user ->
-            runCatching { contactSync.sync(user.id!!) }.onFailure { e ->
+            runCatching {
+                perUserSync.executeWithoutResult { contactSync.sync(user.id!!) }
+            }.onFailure { e ->
                 log.error("Bulk contact sync failed for user {}: {}", user.id, e.message)
             }
         }

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/job/DispatchContactSyncsJobTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/job/DispatchContactSyncsJobTest.kt
@@ -14,13 +14,18 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.SimpleTransactionStatus
 
 class DispatchContactSyncsJobTest {
 
     private val objectMapper = ObjectMapper()
     private val userService: UserService = mock()
     private val contactSync: ContactSyncService = mock()
-    private val job = DispatchContactSyncsJob(objectMapper, userService, contactSync)
+    private val transactionManager: PlatformTransactionManager = mock<PlatformTransactionManager>().also {
+        whenever(it.getTransaction(org.mockito.kotlin.any())).thenReturn(SimpleTransactionStatus())
+    }
+    private val job = DispatchContactSyncsJob(objectMapper, userService, contactSync, transactionManager)
 
     private fun userWithId(id: Long): User = mock<User>().also {
         whenever(it.id).thenReturn(id)
@@ -56,5 +61,18 @@ class DispatchContactSyncsJobTest {
 
         verify(contactSync, times(1)).sync(eq(1L))
         verify(contactSync, times(1)).sync(eq(2L))
+    }
+
+    @Test
+    fun `opens a fresh transaction per user`() {
+        val users = mutableListOf(userWithId(1L), userWithId(2L), userWithId(3L))
+        whenever(userService.findAll()).thenReturn(users)
+
+        job.handle(objectMapper.writeValueAsString(ContactJobs.DispatchContactSyncsPayload()))
+
+        // One getTransaction call per user proves the TransactionTemplate with
+        // REQUIRES_NEW propagation is invoked individually — i.e. a failing sync
+        // can only mark its own transaction rollback-only, not the dispatcher's.
+        verify(transactionManager, times(3)).getTransaction(org.mockito.kotlin.any())
     }
 }


### PR DESCRIPTION
## Why
A nightly `DispatchContactSyncs` job execution failed in production
this morning with

```
org.springframework.transaction.UnexpectedRollbackException:
  Transaction silently rolled back because it has been marked as
  rollback-only
    at DispatchContactSyncsJob$$SpringCGLIB$$0.handle
```

`DispatchContactSyncsJob.handle` is wrapped in `@Transactional` by
`AbstractJsonJobHandler`. `ContactSyncService.sync` is also
`@Transactional` with the default `REQUIRED` propagation, so each
per-user call joined the dispatcher's outer transaction. The moment
any single user's sync threw — a Brevo HTTP error, a constraint
violation, anything — Spring set the rollback-only flag on the
shared transaction. The dispatcher's `runCatching` swallowed the
exception and the loop dutifully continued, but the dispatcher's
commit at the end then exploded with `UnexpectedRollbackException`,
marking the whole `JobExecution` row Failed even when 349 of 350
users had synced fine.

## What this achieves
- A single user's failure no longer poisons the rest of the batch.
- The dispatcher's `JobExecution` row reflects reality: it succeeds
  when the loop runs through, and only fails on errors that aren't
  individual per-user sync errors.
- Per-user errors keep being logged exactly as before
  (`Bulk contact sync failed for user N: ...`), so observability is
  unchanged.

## How
- `DispatchContactSyncsJob` now owns a `TransactionTemplate` with
  `PROPAGATION_REQUIRES_NEW`. Each iteration of the user loop runs
  `contactSync.sync(user.id)` inside that template, so the per-user
  work commits or rolls back on its own without touching the
  dispatcher's transaction. The existing `runCatching` continues to
  swallow per-user exceptions so the loop keeps going.
- A header comment captures the failure mode and why
  `REQUIRES_NEW` is mandatory here, so the next person editing this
  handler does not re-introduce the joined-transaction footgun.
- Unit test asserts one `getTransaction` call per user, which
  catches a regression that removes the per-user template.