### PR TITLE
refactor(sync): queue every contact + calendar push as its own JobExecution

### DIFF
--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/queue/JobExecutorIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/queue/JobExecutorIT.kt
@@ -33,15 +33,18 @@ class JobExecutorIT : ServiceTestSupport() {
     }
 
     @Test
-    fun `first failure schedules a retry and increments attempts`() {
+    fun `first failure schedules a retry and bumps attempts to 2`() {
         retryingHandler.failForFirstCalls(1)
+        // Enqueue starts attempts at 1 (the initial run is already counted).
         val execution = dispatcher.enqueue(RetryingTestJobHandler.JOB_TYPE, mapOf("id" to "123"))!!
+        assertThat(execution.attempts).describedAs("initial enqueue counts as attempt 1").isEqualTo(1)
 
         executor.execute(jobExecutions.findById(execution.id!!).orElseThrow())
 
         val updated = jobExecutions.findById(execution.id!!).orElseThrow()
         assertThat(updated.status).isEqualTo(JobExecutionStatus.QUEUED)
-        assertThat(updated.attempts).isEqualTo(1)
+        // First failure scheduled a retry → the upcoming attempt is the 2nd.
+        assertThat(updated.attempts).isEqualTo(2)
         assertThat(updated.nextAttemptAt).isNotNull()
         assertThat(updated.errorType).isEqualTo(IllegalStateException::class.java.name)
         assertThat(retryingHandler.invocations()).isEqualTo(1)
@@ -89,7 +92,8 @@ class JobExecutorIT : ServiceTestSupport() {
         assertThat(updated.status).isEqualTo(JobExecutionStatus.DEAD)
         assertThat(updated.errorType).isEqualTo("NoHandlerRegisteredException")
         assertThat(updated.errorReason).contains("No handler registered for job type test.missing.handler.")
-        assertThat(updated.attempts).isEqualTo(0)
+        // Initial enqueue counts as attempt 1; markDead leaves it untouched.
+        assertThat(updated.attempts).isEqualTo(1)
     }
 
     @Test

--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/sync/SyncListenerIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/sync/SyncListenerIT.kt
@@ -78,9 +78,9 @@ class SyncListenerIT : UserTestSupport() {
             )
             current?.externalId == null
         }
-        assertThat(externalId)
+        assertThat(mockContactAdapter.getAllContacts().keys)
             .describedAs("adapter dropped the contact after the remove job ran")
-            .matches { it !in mockContactAdapter.getAllContacts().keys }
+            .doesNotContain(externalId)
     }
 
     @Test

--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/sync/SyncListenerIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/sync/SyncListenerIT.kt
@@ -7,6 +7,7 @@ import net.blueshell.api.domain.user.application.event.UserCreated
 import net.blueshell.api.domain.user.application.event.UserDeleted
 import net.blueshell.api.platform.integration.mock.MockCalendarAdapter
 import net.blueshell.api.platform.integration.mock.MockContactAdapter
+import net.blueshell.api.platform.integration.sync.persistence.ExternalIdMapping
 import net.blueshell.api.platform.integration.sync.persistence.repository.ExternalIdMappingRepository
 import net.blueshell.api.platform.integration.sync.port.TargetSystem
 import net.blueshell.api.shared.enums.Role
@@ -35,19 +36,17 @@ class SyncListenerIT : UserTestSupport() {
     @Autowired private lateinit var jdbc: JdbcTemplate
     @Autowired private lateinit var tx: TransactionTemplate
 
-    // job_executions is intentionally NOT reset between tests: with
-    // auto-dispatch on, an in-flight @Async job from the previous test
-    // can still be inside JobExecutor when the next test starts. Deleting
-    // its row mid-execution causes the executor's markSuccess /
-    // markRetryScheduled call to throw "JobExecution not found", which
-    // then races with the new test's assertions. Each test asserts on
-    // its own aggregate's adapter / mapping state instead, which is
-    // already isolated by user / event id.
+    // job_executions / external_id_mapping rows are wiped by TestCleanUpListener
+    // between tests, so this reset only takes care of in-memory adapter state
+    // and the Modulith event_publication outbox. Asserting on the mapping (a
+    // row only visible AFTER the job's transaction commits) is the test's
+    // signal that the whole pipeline ran; mocking the adapter alone is not
+    // enough because the mock is touched in-memory before the surrounding
+    // transaction commits.
     @BeforeEach
     fun reset() {
         mockContactAdapter.clear()
         mockCalendarAdapter.clear()
-        mappings.deleteAll()
         jdbc.update("DELETE FROM EVENT_PUBLICATION")
     }
 
@@ -57,29 +56,31 @@ class SyncListenerIT : UserTestSupport() {
 
         tx.executeWithoutResult { publisher.publishEvent(UserCreated(user.id!!)) }
 
-        awaitCondition { mockContactAdapter.getAllContacts().any { it.value.email == user.email } }
-
-        val mapping = mappings.findByAggregateTypeAndAggregateIdAndSystem(
-            "USER", user.id!!, TargetSystem.BREVO.name,
-        )
-        assertThat(mapping).describedAs("external_id_mapping should hold the new external id").isNotNull
-        assertThat(mapping!!.externalId).isNotBlank
+        val mapping = awaitMapping("USER", user.id!!, TargetSystem.BREVO)
+        assertThat(mapping.externalId).describedAs("external id is set after the push").isNotBlank
+        assertThat(mockContactAdapter.getAllContacts().values)
+            .describedAs("adapter received the user")
+            .anySatisfy { contact -> assertThat(contact.email).isEqualTo(user.email) }
     }
 
     @Test
     fun `publishing UserDeleted enqueues a RemoveContact job that clears every contact target`() {
         val user = createUserWithRole(Role.MEMBER)
         tx.executeWithoutResult { publisher.publishEvent(UserCreated(user.id!!)) }
-        awaitCondition { mockContactAdapter.getAllContacts().any { it.value.email == user.email } }
-        val externalId = mockContactAdapter.getAllContacts().entries.single { it.value.email == user.email }.key
+        val mapping = awaitMapping("USER", user.id!!, TargetSystem.BREVO)
+        val externalId = mapping.externalId!!
 
         tx.executeWithoutResult { publisher.publishEvent(UserDeleted(user.id!!)) }
 
-        awaitCondition { externalId !in mockContactAdapter.getAllContacts().keys }
-        val mapping = mappings.findByAggregateTypeAndAggregateIdAndSystem(
-            "USER", user.id!!, TargetSystem.BREVO.name,
-        )
-        assertThat(mapping?.externalId).describedAs("mapping external id is cleared on delete").isNull()
+        awaitCondition {
+            val current = mappings.findByAggregateTypeAndAggregateIdAndSystem(
+                "USER", user.id!!, TargetSystem.BREVO.name,
+            )
+            current?.externalId == null
+        }
+        assertThat(externalId)
+            .describedAs("adapter dropped the contact after the remove job ran")
+            .matches { it !in mockContactAdapter.getAllContacts().keys }
     }
 
     @Test
@@ -87,18 +88,16 @@ class SyncListenerIT : UserTestSupport() {
         val event: Event = createEventFixture()
         tx.executeWithoutResult { publisher.publishEvent(EventChanged(event.id!!, EventChange.CREATED)) }
 
-        awaitCondition { mockCalendarAdapter.getAllEvents().isNotEmpty() }
-        val mapping = mappings.findByAggregateTypeAndAggregateIdAndSystem(
-            "EVENT", event.id!!, TargetSystem.GOOGLE_CALENDAR.name,
-        )
-        assertThat(mapping?.externalId).describedAs("calendar external id should be stored").isNotNull
+        val mapping = awaitMapping("EVENT", event.id!!, TargetSystem.GOOGLE_CALENDAR)
+        assertThat(mapping.externalId).describedAs("calendar external id is stored").isNotBlank
+        assertThat(mockCalendarAdapter.getAllEvents()).describedAs("adapter received the event").isNotEmpty
     }
 
     @Test
     fun `Modulith writes an event_publication row that completes after the listener enqueues`() {
         val user = createUserWithRole(Role.MEMBER)
         tx.executeWithoutResult { publisher.publishEvent(UserCreated(user.id!!)) }
-        awaitCondition { mockContactAdapter.getAllContacts().any { it.value.email == user.email } }
+        awaitMapping("USER", user.id!!, TargetSystem.BREVO)
 
         val rows = jdbc.queryForList(
             "SELECT LISTENER_ID, COMPLETION_DATE FROM EVENT_PUBLICATION WHERE EVENT_TYPE = ?",
@@ -114,5 +113,16 @@ class SyncListenerIT : UserTestSupport() {
 
     private fun awaitCondition(condition: () -> Boolean) {
         await().atMost(Duration.ofSeconds(15)).pollInterval(Duration.ofMillis(50)).until(condition)
+    }
+
+    private fun awaitMapping(
+        aggregateType: String,
+        aggregateId: Long,
+        system: TargetSystem,
+    ): ExternalIdMapping {
+        await().atMost(Duration.ofSeconds(15)).pollInterval(Duration.ofMillis(50)).until {
+            mappings.findByAggregateTypeAndAggregateIdAndSystem(aggregateType, aggregateId, system.name) != null
+        }
+        return mappings.findByAggregateTypeAndAggregateIdAndSystem(aggregateType, aggregateId, system.name)!!
     }
 }

--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/sync/SyncListenerIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/sync/SyncListenerIT.kt
@@ -22,11 +22,13 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.context.TestPropertySource
 import org.springframework.transaction.support.TransactionTemplate
 import java.time.Duration
 
 /** Verifies that publishing user / event domain events drives the queued sync pipeline end-to-end. */
 @SpringBootTest
+@TestPropertySource(properties = ["app.jobs.auto-dispatch=true"])
 class SyncListenerIT : UserTestSupport() {
 
     @Autowired private lateinit var publisher: ApplicationEventPublisher

--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/sync/SyncListenerIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/sync/SyncListenerIT.kt
@@ -68,7 +68,7 @@ class SyncListenerIT : UserTestSupport() {
         val user = createUserWithRole(Role.MEMBER)
         tx.executeWithoutResult { publisher.publishEvent(UserCreated(user.id!!)) }
         val mapping = awaitMapping("USER", user.id!!, TargetSystem.BREVO)
-        val externalId = mapping.externalId!!
+        val externalIdLong = mapping.externalId!!.toLong()
 
         tx.executeWithoutResult { publisher.publishEvent(UserDeleted(user.id!!)) }
 
@@ -80,7 +80,7 @@ class SyncListenerIT : UserTestSupport() {
         }
         assertThat(mockContactAdapter.getAllContacts().keys)
             .describedAs("adapter dropped the contact after the remove job ran")
-            .doesNotContain(externalId)
+            .doesNotContain(externalIdLong)
     }
 
     @Test

--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/sync/SyncListenerIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/sync/SyncListenerIT.kt
@@ -9,10 +9,7 @@ import net.blueshell.api.platform.integration.mock.MockCalendarAdapter
 import net.blueshell.api.platform.integration.mock.MockContactAdapter
 import net.blueshell.api.platform.integration.sync.persistence.repository.ExternalIdMappingRepository
 import net.blueshell.api.platform.integration.sync.port.TargetSystem
-import net.blueshell.api.shared.enums.JobExecutionStatus
 import net.blueshell.api.shared.enums.Role
-import net.blueshell.api.shared.job.CalendarJobs
-import net.blueshell.api.shared.job.ContactJobs
 import net.blueshell.api.testsupport.UserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility.await
@@ -38,13 +35,20 @@ class SyncListenerIT : UserTestSupport() {
     @Autowired private lateinit var jdbc: JdbcTemplate
     @Autowired private lateinit var tx: TransactionTemplate
 
+    // job_executions is intentionally NOT reset between tests: with
+    // auto-dispatch on, an in-flight @Async job from the previous test
+    // can still be inside JobExecutor when the next test starts. Deleting
+    // its row mid-execution causes the executor's markSuccess /
+    // markRetryScheduled call to throw "JobExecution not found", which
+    // then races with the new test's assertions. Each test asserts on
+    // its own aggregate's adapter / mapping state instead, which is
+    // already isolated by user / event id.
     @BeforeEach
     fun reset() {
         mockContactAdapter.clear()
         mockCalendarAdapter.clear()
         mappings.deleteAll()
         jdbc.update("DELETE FROM EVENT_PUBLICATION")
-        jdbc.update("DELETE FROM job_executions")
     }
 
     @Test
@@ -53,7 +57,6 @@ class SyncListenerIT : UserTestSupport() {
 
         tx.executeWithoutResult { publisher.publishEvent(UserCreated(user.id!!)) }
 
-        awaitJobSuccess(ContactJobs.SyncContact.type)
         awaitCondition { mockContactAdapter.getAllContacts().any { it.value.email == user.email } }
 
         val mapping = mappings.findByAggregateTypeAndAggregateIdAndSystem(
@@ -67,13 +70,11 @@ class SyncListenerIT : UserTestSupport() {
     fun `publishing UserDeleted enqueues a RemoveContact job that clears every contact target`() {
         val user = createUserWithRole(Role.MEMBER)
         tx.executeWithoutResult { publisher.publishEvent(UserCreated(user.id!!)) }
-        awaitJobSuccess(ContactJobs.SyncContact.type)
-        awaitCondition { mockContactAdapter.getAllContacts().isNotEmpty() }
-        val externalId = mockContactAdapter.getAllContacts().keys.single()
+        awaitCondition { mockContactAdapter.getAllContacts().any { it.value.email == user.email } }
+        val externalId = mockContactAdapter.getAllContacts().entries.single { it.value.email == user.email }.key
 
         tx.executeWithoutResult { publisher.publishEvent(UserDeleted(user.id!!)) }
 
-        awaitJobSuccess(ContactJobs.RemoveContact.type)
         awaitCondition { externalId !in mockContactAdapter.getAllContacts().keys }
         val mapping = mappings.findByAggregateTypeAndAggregateIdAndSystem(
             "USER", user.id!!, TargetSystem.BREVO.name,
@@ -86,7 +87,6 @@ class SyncListenerIT : UserTestSupport() {
         val event: Event = createEventFixture()
         tx.executeWithoutResult { publisher.publishEvent(EventChanged(event.id!!, EventChange.CREATED)) }
 
-        awaitJobSuccess(CalendarJobs.SyncCalendarEvent.type)
         awaitCondition { mockCalendarAdapter.getAllEvents().isNotEmpty() }
         val mapping = mappings.findByAggregateTypeAndAggregateIdAndSystem(
             "EVENT", event.id!!, TargetSystem.GOOGLE_CALENDAR.name,
@@ -98,7 +98,7 @@ class SyncListenerIT : UserTestSupport() {
     fun `Modulith writes an event_publication row that completes after the listener enqueues`() {
         val user = createUserWithRole(Role.MEMBER)
         tx.executeWithoutResult { publisher.publishEvent(UserCreated(user.id!!)) }
-        awaitJobSuccess(ContactJobs.SyncContact.type)
+        awaitCondition { mockContactAdapter.getAllContacts().any { it.value.email == user.email } }
 
         val rows = jdbc.queryForList(
             "SELECT LISTENER_ID, COMPLETION_DATE FROM EVENT_PUBLICATION WHERE EVENT_TYPE = ?",
@@ -113,25 +113,6 @@ class SyncListenerIT : UserTestSupport() {
     }
 
     private fun awaitCondition(condition: () -> Boolean) {
-        await().atMost(Duration.ofSeconds(10)).pollInterval(Duration.ofMillis(50)).until(condition)
-    }
-
-    private fun awaitJobSuccess(
-        jobType: String,
-        expectedCount: Int = 1,
-        timeoutMs: Long = 10_000,
-        pollMs: Long = 100,
-    ) {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (System.currentTimeMillis() < deadline) {
-            val successCount = findJobsByType(jobType).count { it.status == JobExecutionStatus.SUCCESS }
-            if (successCount >= expectedCount) return
-            Thread.sleep(pollMs)
-        }
-        val executions = findJobsByType(jobType)
-        val successCount = executions.count { it.status == JobExecutionStatus.SUCCESS }
-        assertThat(successCount)
-            .describedAs("Expected $expectedCount successful $jobType jobs, but found $successCount among $executions")
-            .isGreaterThanOrEqualTo(expectedCount)
+        await().atMost(Duration.ofSeconds(15)).pollInterval(Duration.ofMillis(50)).until(condition)
     }
 }

--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/sync/SyncListenerIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/sync/SyncListenerIT.kt
@@ -42,7 +42,7 @@ class SyncListenerIT : UserTestSupport() {
         mockCalendarAdapter.clear()
         mappings.deleteAll()
         jdbc.update("DELETE FROM EVENT_PUBLICATION")
-        jdbc.update("DELETE FROM JOB_EXECUTION")
+        jdbc.update("DELETE FROM job_executions")
     }
 
     @Test

--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/sync/SyncListenerIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/sync/SyncListenerIT.kt
@@ -9,7 +9,10 @@ import net.blueshell.api.platform.integration.mock.MockCalendarAdapter
 import net.blueshell.api.platform.integration.mock.MockContactAdapter
 import net.blueshell.api.platform.integration.sync.persistence.repository.ExternalIdMappingRepository
 import net.blueshell.api.platform.integration.sync.port.TargetSystem
+import net.blueshell.api.shared.enums.JobExecutionStatus
 import net.blueshell.api.shared.enums.Role
+import net.blueshell.api.shared.job.CalendarJobs
+import net.blueshell.api.shared.job.ContactJobs
 import net.blueshell.api.testsupport.UserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility.await
@@ -22,7 +25,7 @@ import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.transaction.support.TransactionTemplate
 import java.time.Duration
 
-/** Verifies that publishing user / event domain events drives the new sync pipeline end-to-end. */
+/** Verifies that publishing user / event domain events drives the queued sync pipeline end-to-end. */
 @SpringBootTest
 class SyncListenerIT : UserTestSupport() {
 
@@ -39,15 +42,17 @@ class SyncListenerIT : UserTestSupport() {
         mockCalendarAdapter.clear()
         mappings.deleteAll()
         jdbc.update("DELETE FROM EVENT_PUBLICATION")
+        jdbc.update("DELETE FROM JOB_EXECUTION")
     }
 
     @Test
-    fun `publishing UserCreated pushes the user to every contact target`() {
+    fun `publishing UserCreated enqueues a SyncContact job that pushes to every contact target`() {
         val user = createUserWithRole(Role.MEMBER)
 
         tx.executeWithoutResult { publisher.publishEvent(UserCreated(user.id!!)) }
 
-        awaitListener { mockContactAdapter.getAllContacts().any { it.value.email == user.email } }
+        awaitJobSuccess(ContactJobs.SyncContact.type)
+        awaitCondition { mockContactAdapter.getAllContacts().any { it.value.email == user.email } }
 
         val mapping = mappings.findByAggregateTypeAndAggregateIdAndSystem(
             "USER", user.id!!, TargetSystem.BREVO.name,
@@ -57,15 +62,17 @@ class SyncListenerIT : UserTestSupport() {
     }
 
     @Test
-    fun `publishing UserDeleted removes the user from every contact target`() {
+    fun `publishing UserDeleted enqueues a RemoveContact job that clears every contact target`() {
         val user = createUserWithRole(Role.MEMBER)
         tx.executeWithoutResult { publisher.publishEvent(UserCreated(user.id!!)) }
-        awaitListener { mockContactAdapter.getAllContacts().isNotEmpty() }
+        awaitJobSuccess(ContactJobs.SyncContact.type)
+        awaitCondition { mockContactAdapter.getAllContacts().isNotEmpty() }
         val externalId = mockContactAdapter.getAllContacts().keys.single()
 
         tx.executeWithoutResult { publisher.publishEvent(UserDeleted(user.id!!)) }
 
-        awaitListener { externalId !in mockContactAdapter.getAllContacts().keys }
+        awaitJobSuccess(ContactJobs.RemoveContact.type)
+        awaitCondition { externalId !in mockContactAdapter.getAllContacts().keys }
         val mapping = mappings.findByAggregateTypeAndAggregateIdAndSystem(
             "USER", user.id!!, TargetSystem.BREVO.name,
         )
@@ -73,11 +80,12 @@ class SyncListenerIT : UserTestSupport() {
     }
 
     @Test
-    fun `publishing EventChanged pushes the approved event to the calendar target`() {
+    fun `publishing EventChanged enqueues a SyncCalendarEvent job that pushes the approved event`() {
         val event: Event = createEventFixture()
         tx.executeWithoutResult { publisher.publishEvent(EventChanged(event.id!!, EventChange.CREATED)) }
 
-        awaitListener { mockCalendarAdapter.getAllEvents().isNotEmpty() }
+        awaitJobSuccess(CalendarJobs.SyncCalendarEvent.type)
+        awaitCondition { mockCalendarAdapter.getAllEvents().isNotEmpty() }
         val mapping = mappings.findByAggregateTypeAndAggregateIdAndSystem(
             "EVENT", event.id!!, TargetSystem.GOOGLE_CALENDAR.name,
         )
@@ -85,10 +93,10 @@ class SyncListenerIT : UserTestSupport() {
     }
 
     @Test
-    fun `Modulith writes an event_publication row that completes after the listener succeeds`() {
+    fun `Modulith writes an event_publication row that completes after the listener enqueues`() {
         val user = createUserWithRole(Role.MEMBER)
         tx.executeWithoutResult { publisher.publishEvent(UserCreated(user.id!!)) }
-        awaitListener { mockContactAdapter.getAllContacts().isNotEmpty() }
+        awaitJobSuccess(ContactJobs.SyncContact.type)
 
         val rows = jdbc.queryForList(
             "SELECT LISTENER_ID, COMPLETION_DATE FROM EVENT_PUBLICATION WHERE EVENT_TYPE = ?",
@@ -102,7 +110,26 @@ class SyncListenerIT : UserTestSupport() {
             .isNotNull
     }
 
-    private fun awaitListener(condition: () -> Boolean) {
-        await().atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(50)).until(condition)
+    private fun awaitCondition(condition: () -> Boolean) {
+        await().atMost(Duration.ofSeconds(10)).pollInterval(Duration.ofMillis(50)).until(condition)
+    }
+
+    private fun awaitJobSuccess(
+        jobType: String,
+        expectedCount: Int = 1,
+        timeoutMs: Long = 10_000,
+        pollMs: Long = 100,
+    ) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            val successCount = findJobsByType(jobType).count { it.status == JobExecutionStatus.SUCCESS }
+            if (successCount >= expectedCount) return
+            Thread.sleep(pollMs)
+        }
+        val executions = findJobsByType(jobType)
+        val successCount = executions.count { it.status == JobExecutionStatus.SUCCESS }
+        assertThat(successCount)
+            .describedAs("Expected $expectedCount successful $jobType jobs, but found $successCount among $executions")
+            .isGreaterThanOrEqualTo(expectedCount)
     }
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/calendar/application/job/SyncCalendarEventJob.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/calendar/application/job/SyncCalendarEventJob.kt
@@ -1,0 +1,29 @@
+package net.blueshell.api.platform.integration.calendar.application.job
+
+import net.blueshell.api.platform.integration.queue.AbstractJsonJobHandler
+import net.blueshell.api.platform.integration.sync.application.CalendarSyncService
+import net.blueshell.api.shared.job.CalendarJobs
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+
+/**
+ * Per-event calendar sync: pushes one event's current state to every
+ * registered calendar target (currently Google Calendar). Enqueued by
+ * [CalendarSyncListener] in response to [EventChanged] so the HTTP push
+ * runs in the job queue with retry isolation instead of inline inside
+ * the listener's transaction.
+ */
+@Component
+class SyncCalendarEventJob(
+    objectMapper: ObjectMapper,
+    private val calendarSync: CalendarSyncService,
+) : AbstractJsonJobHandler<CalendarJobs.SyncCalendarEventPayload>(
+    objectMapper,
+    CalendarJobs.SyncCalendarEvent.payloadType,
+) {
+    override val jobType: String = CalendarJobs.SyncCalendarEvent.type
+
+    override fun handlePayload(payload: CalendarJobs.SyncCalendarEventPayload) {
+        calendarSync.sync(payload.eventId)
+    }
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/DispatchContactSyncsJob.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/DispatchContactSyncsJob.kt
@@ -3,45 +3,39 @@ package net.blueshell.api.platform.integration.contact.application.job
 import tools.jackson.databind.ObjectMapper
 import net.blueshell.api.domain.user.application.UserService
 import net.blueshell.api.platform.integration.queue.AbstractJsonJobHandler
-import net.blueshell.api.platform.integration.sync.application.ContactSyncService
 import net.blueshell.api.shared.job.ContactJobs
+import net.blueshell.api.shared.job.TrackedJobDispatcher
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
-import org.springframework.transaction.PlatformTransactionManager
-import org.springframework.transaction.TransactionDefinition
-import org.springframework.transaction.support.TransactionTemplate
 
-/** Daily bulk refresh of every user's contact state across all targets. */
+/**
+ * Daily bulk refresh: fan out one [ContactJobs.SyncContact] job per user.
+ *
+ * Each per-user job becomes its own JobExecution row with its own retry
+ * schedule and observable failure state, so a single user's adapter failure
+ * does not affect the rest of the batch and does not need an extra
+ * REQUIRES_NEW transaction to isolate it. Matches the pattern already used
+ * by [DispatchListMembershipSyncsJob].
+ */
 @Component
 class DispatchContactSyncsJob(
     objectMapper: ObjectMapper,
     private val userService: UserService,
-    private val contactSync: ContactSyncService,
-    transactionManager: PlatformTransactionManager,
+    private val jobs: TrackedJobDispatcher,
 ) : AbstractJsonJobHandler<ContactJobs.DispatchContactSyncsPayload>(
     objectMapper,
     ContactJobs.DispatchContactSyncs.payloadType,
 ) {
     override val jobType: String = ContactJobs.DispatchContactSyncs.type
 
-    // ContactSyncService.sync is @Transactional with default REQUIRED propagation,
-    // so it would join the outer @Transactional opened by AbstractJsonJobHandler.handle.
-    // A single user failing would then mark the shared transaction rollback-only,
-    // and the dispatcher's commit at the end would throw UnexpectedRollbackException
-    // even though runCatching swallowed the per-user exception. Each user gets its
-    // own REQUIRES_NEW transaction so failures isolate to that user's row.
-    private val perUserSync = TransactionTemplate(transactionManager).apply {
-        propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
-    }
-
     override fun handlePayload(payload: ContactJobs.DispatchContactSyncsPayload) {
         val users = userService.findAll()
-        log.info("Refreshing contact sync for {} users", users.size)
+        log.info("Enqueueing per-user contact sync jobs for {} users", users.size)
         users.forEach { user ->
             runCatching {
-                perUserSync.executeWithoutResult { contactSync.sync(user.id!!) }
+                jobs.enqueue(ContactJobs.SyncContact, ContactJobs.SyncContactPayload(user.id!!))
             }.onFailure { e ->
-                log.error("Bulk contact sync failed for user {}: {}", user.id, e.message)
+                log.error("Failed to enqueue contact sync for user {}: {}", user.id, e.message)
             }
         }
     }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/ProcessListMembershipJob.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/ProcessListMembershipJob.kt
@@ -6,7 +6,6 @@ import net.blueshell.api.domain.contribution.application.ContributionService
 import net.blueshell.api.platform.integration.contact.adapter.ContactListAdapter
 import net.blueshell.api.platform.integration.contact.application.ContactListService
 import net.blueshell.api.platform.integration.queue.AbstractJsonJobHandler
-import net.blueshell.api.platform.integration.sync.application.ContactSyncService
 import net.blueshell.api.shared.job.ContactJobs
 import net.blueshell.api.shared.job.SyncListMembershipCommand
 import net.blueshell.api.shared.job.TrackedJobDispatcher
@@ -28,7 +27,6 @@ class ProcessListMembershipJob(
     private val contactListService: ContactListService,
     private val periods: ContributionPeriodService,
     private val contributions: ContributionService,
-    private val contactSync: ContactSyncService,
     private val listAdapters: List<ContactListAdapter>,
     private val jobs: TrackedJobDispatcher,
 ) : AbstractJsonJobHandler<ContactJobs.ProcessListMembershipPayload>(
@@ -53,11 +51,11 @@ class ProcessListMembershipJob(
 
         if (hasContribution) {
             contactListService.createMembership(contactList.id!!, payload.userId)
-            contactSync.sync(payload.userId)
+            jobs.enqueue(ContactJobs.SyncContact, ContactJobs.SyncContactPayload(payload.userId))
             listAdapters.forEach { adapter ->
                 jobs.enqueue(ContactJobs.SyncListMembershipToSystem, SyncListMembershipCommand(payload.userId, contactList.id!!, adapter.system))
             }
-            log.debug("Synced contact + queued add-to-list for user {} in list {} (period {})", payload.userId, contactList.id, payload.periodId)
+            log.debug("Queued contact sync + add-to-list for user {} in list {} (period {})", payload.userId, contactList.id, payload.periodId)
         } else {
             contactListService.deleteMembership(contactList.id!!, payload.userId)
             listAdapters.forEach { adapter ->

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/RemoveContactJob.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/RemoveContactJob.kt
@@ -1,0 +1,28 @@
+package net.blueshell.api.platform.integration.contact.application.job
+
+import net.blueshell.api.platform.integration.queue.AbstractJsonJobHandler
+import net.blueshell.api.platform.integration.sync.application.ContactSyncService
+import net.blueshell.api.shared.job.ContactJobs
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+
+/**
+ * Soft-deletes a contact and pushes the removal to every registered
+ * contact target. Enqueued by [ContactSyncListener] in response to
+ * [UserDeleted] so the external delete is observable, retried, and
+ * decoupled from the listener's own transaction.
+ */
+@Component
+class RemoveContactJob(
+    objectMapper: ObjectMapper,
+    private val contactSync: ContactSyncService,
+) : AbstractJsonJobHandler<ContactJobs.RemoveContactPayload>(
+    objectMapper,
+    ContactJobs.RemoveContact.payloadType,
+) {
+    override val jobType: String = ContactJobs.RemoveContact.type
+
+    override fun handlePayload(payload: ContactJobs.RemoveContactPayload) {
+        contactSync.remove(payload.userId)
+    }
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/SyncContactJob.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/SyncContactJob.kt
@@ -1,0 +1,31 @@
+package net.blueshell.api.platform.integration.contact.application.job
+
+import net.blueshell.api.platform.integration.queue.AbstractJsonJobHandler
+import net.blueshell.api.platform.integration.sync.application.ContactSyncService
+import net.blueshell.api.shared.job.ContactJobs
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+
+/**
+ * Per-user contact sync: pushes one user's current contact state to every
+ * registered contact target.
+ *
+ * Enqueued by [DispatchContactSyncsJob] (daily fan-out) and could also be
+ * fired ad-hoc. Each invocation is its own JobExecution row with its own
+ * retry schedule, so per-user failures stay observable in the Job Manager
+ * instead of being swallowed inside a batch handler.
+ */
+@Component
+class SyncContactJob(
+    objectMapper: ObjectMapper,
+    private val contactSync: ContactSyncService,
+) : AbstractJsonJobHandler<ContactJobs.SyncContactPayload>(
+    objectMapper,
+    ContactJobs.SyncContact.payloadType,
+) {
+    override val jobType: String = ContactJobs.SyncContact.type
+
+    override fun handlePayload(payload: ContactJobs.SyncContactPayload) {
+        contactSync.sync(payload.userId)
+    }
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/job/application/service/JobExecutionService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/job/application/service/JobExecutionService.kt
@@ -37,7 +37,10 @@ class JobExecutionService(
             jobType = jobType,
             status = JobExecutionStatus.QUEUED,
             payload = payload,
-            attempts = 0,
+            // The initial enqueue already counts: attempts represents the
+            // upcoming-or-current run number, so a job that hasn't started
+            // yet shows attempts = 1 in the UI rather than 0.
+            attempts = 1,
             queuedAt = Instant.now(),
             dedupKey = dedupKey,
             initiatedByUserId = actor.userId,

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/queue/JobExecutor.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/queue/JobExecutor.kt
@@ -85,10 +85,13 @@ class JobExecutor(
             return
         }
 
-        if (execution.attempts >= properties.maxRetries) {
+        // attempts is now the 1-indexed counter of the run that just
+        // finished. With maxRetries == 3 we permit 4 total attempts, so we
+        // give up once the just-failed run is the (maxRetries + 1)th one.
+        if (execution.attempts >= properties.maxRetries + 1) {
             logger.error(
                 "Job execution {} failed after {} attempts; giving up. errorType={}, errorReason={}.",
-                execution.id, execution.attempts + 1, errorType, errorReason, ex
+                execution.id, execution.attempts, errorType, errorReason, ex
             )
             jobExecutionService.markFailed(execution, errorType, errorReason, stackTrace)
             sample.stop(meterRegistry.timer("job.execution.duration", "job_type", execution.jobType, "outcome", "failed"))
@@ -96,10 +99,13 @@ class JobExecutor(
             return
         }
 
-        val nextAttemptAt = Instant.now().plusMillis(computeBackoffMillis(execution.attempts))
+        // Backoff schedule indexes from 0 = "first failure" so the initial
+        // delay is exactly initialBackoffMillis. attempts is 1-indexed
+        // (1 on the first failure), so subtract one before computing.
+        val nextAttemptAt = Instant.now().plusMillis(computeBackoffMillis(execution.attempts - 1))
         logger.warn(
             "Job execution {} failed (attempt {}/{}). Scheduling retry at {}. errorType={}, errorReason={}.",
-            execution.id, execution.attempts + 1, properties.maxRetries + 1, nextAttemptAt, errorType, errorReason
+            execution.id, execution.attempts, properties.maxRetries + 1, nextAttemptAt, errorType, errorReason
         )
         jobExecutionService.markRetryScheduled(execution, errorType, errorReason, stackTrace, nextAttemptAt)
         sample.stop(
@@ -109,8 +115,9 @@ class JobExecutor(
     }
 
     /**
-     * Exponential backoff. [attemptsSoFar] is the count of completed attempts
-     * (0 after the first failure). Capped at [JobQueueProperties.maxBackoffMillis].
+     * Exponential backoff. [attemptsSoFar] is the number of completed
+     * failures (0 means "this is the first failure, use the base delay").
+     * Capped at [JobQueueProperties.maxBackoffMillis].
      */
     private fun computeBackoffMillis(attemptsSoFar: Int): Long {
         val raw = properties.initialBackoffMillis.toDouble() *

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/sync/listener/CalendarSyncListener.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/sync/listener/CalendarSyncListener.kt
@@ -1,15 +1,24 @@
 package net.blueshell.api.platform.integration.sync.listener
 
 import net.blueshell.api.domain.event.application.event.EventChanged
-import net.blueshell.api.platform.integration.sync.application.CalendarSyncService
+import net.blueshell.api.shared.job.CalendarJobs
+import net.blueshell.api.shared.job.TrackedJobDispatcher
 import org.springframework.modulith.events.ApplicationModuleListener
 import org.springframework.stereotype.Component
 
-/** Modulith listener that fans event-changed out to every calendar target. */
+/**
+ * Modulith listener that fans event-changed out as a queued per-event
+ * calendar sync job. The Google Calendar HTTP push runs inside the
+ * resulting [CalendarJobs.SyncCalendarEvent] handler with its own
+ * retry schedule, so upstream blips don't propagate into the event's
+ * own transaction.
+ */
 @Component
 class CalendarSyncListener(
-    private val service: CalendarSyncService,
+    private val jobs: TrackedJobDispatcher,
 ) {
     @ApplicationModuleListener
-    fun on(event: EventChanged) = service.sync(event.eventId)
+    fun on(event: EventChanged) {
+        jobs.enqueue(CalendarJobs.SyncCalendarEvent, CalendarJobs.SyncCalendarEventPayload(event.eventId))
+    }
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/sync/listener/ContactSyncListener.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/sync/listener/ContactSyncListener.kt
@@ -3,21 +3,39 @@ package net.blueshell.api.platform.integration.sync.listener
 import net.blueshell.api.domain.user.application.event.UserCreated
 import net.blueshell.api.domain.user.application.event.UserDeleted
 import net.blueshell.api.domain.user.application.event.UserUpdated
-import net.blueshell.api.platform.integration.sync.application.ContactSyncService
+import net.blueshell.api.shared.job.ContactJobs
+import net.blueshell.api.shared.job.TrackedJobDispatcher
 import org.springframework.modulith.events.ApplicationModuleListener
 import org.springframework.stereotype.Component
 
-/** Modulith listener that fans user lifecycle events out to every contact target. */
+/**
+ * Modulith listener that fans user lifecycle events out as queued
+ * per-user contact sync jobs.
+ *
+ * The listener used to call [ContactSyncService.sync] / `.remove` inline,
+ * which meant the Brevo HTTP push happened inside the listener's
+ * transaction and had no retry visibility. Enqueueing the work as a
+ * [ContactJobs.SyncContact] / [ContactJobs.RemoveContact] job keeps the
+ * listener cheap, gives each user-change its own JobExecution row, and
+ * lets the queue's exponential backoff retry transient external
+ * failures without re-running the user-side transaction.
+ */
 @Component
 class ContactSyncListener(
-    private val service: ContactSyncService,
+    private val jobs: TrackedJobDispatcher,
 ) {
     @ApplicationModuleListener
-    fun on(event: UserCreated) = service.sync(event.userId)
+    fun on(event: UserCreated) {
+        jobs.enqueue(ContactJobs.SyncContact, ContactJobs.SyncContactPayload(event.userId))
+    }
 
     @ApplicationModuleListener
-    fun on(event: UserUpdated) = service.sync(event.userId)
+    fun on(event: UserUpdated) {
+        jobs.enqueue(ContactJobs.SyncContact, ContactJobs.SyncContactPayload(event.userId))
+    }
 
     @ApplicationModuleListener
-    fun on(event: UserDeleted) = service.remove(event.userId)
+    fun on(event: UserDeleted) {
+        jobs.enqueue(ContactJobs.RemoveContact, ContactJobs.RemoveContactPayload(event.userId))
+    }
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/shared/job/JobDefinitions.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/shared/job/JobDefinitions.kt
@@ -63,6 +63,11 @@ object ContactJobs {
         override val payloadType: Class<SyncListMembershipCommand> = SyncListMembershipCommand::class.java
     }
 
+    object SyncContact : JobDefinition<SyncContactPayload> {
+        override val type: String = "contact.sync"
+        override val payloadType: Class<SyncContactPayload> = SyncContactPayload::class.java
+    }
+
     data class DispatchContactSyncsPayload(val unused: Unit = Unit)
     data class DispatchListMembershipSyncsPayload(val unused: Unit = Unit)
 
@@ -70,4 +75,6 @@ object ContactJobs {
         val userId: Long,
         val periodId: Long
     )
+
+    data class SyncContactPayload(val userId: Long)
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/shared/job/JobDefinitions.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/shared/job/JobDefinitions.kt
@@ -68,6 +68,11 @@ object ContactJobs {
         override val payloadType: Class<SyncContactPayload> = SyncContactPayload::class.java
     }
 
+    object RemoveContact : JobDefinition<RemoveContactPayload> {
+        override val type: String = "contact.remove"
+        override val payloadType: Class<RemoveContactPayload> = RemoveContactPayload::class.java
+    }
+
     data class DispatchContactSyncsPayload(val unused: Unit = Unit)
     data class DispatchListMembershipSyncsPayload(val unused: Unit = Unit)
 
@@ -77,4 +82,14 @@ object ContactJobs {
     )
 
     data class SyncContactPayload(val userId: Long)
+    data class RemoveContactPayload(val userId: Long)
+}
+
+object CalendarJobs {
+    object SyncCalendarEvent : JobDefinition<SyncCalendarEventPayload> {
+        override val type: String = "calendar.sync-event"
+        override val payloadType: Class<SyncCalendarEventPayload> = SyncCalendarEventPayload::class.java
+    }
+
+    data class SyncCalendarEventPayload(val eventId: Long)
 }

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/calendar/job/SyncCalendarEventJobTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/calendar/job/SyncCalendarEventJobTest.kt
@@ -1,0 +1,24 @@
+package net.blueshell.api.platform.integration.calendar.job
+
+import net.blueshell.api.platform.integration.calendar.application.job.SyncCalendarEventJob
+import net.blueshell.api.platform.integration.sync.application.CalendarSyncService
+import net.blueshell.api.shared.job.CalendarJobs
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import tools.jackson.databind.ObjectMapper
+
+class SyncCalendarEventJobTest {
+
+    private val objectMapper = ObjectMapper()
+    private val calendarSync: CalendarSyncService = mock()
+    private val job = SyncCalendarEventJob(objectMapper, calendarSync)
+
+    @Test
+    fun `delegates to CalendarSyncService sync with the payload eventId`() {
+        job.handle(objectMapper.writeValueAsString(CalendarJobs.SyncCalendarEventPayload(7L)))
+
+        verify(calendarSync).sync(eq(7L))
+    }
+}

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/job/DispatchContactSyncsJobTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/job/DispatchContactSyncsJobTest.kt
@@ -4,8 +4,8 @@ import tools.jackson.databind.ObjectMapper
 import net.blueshell.api.domain.user.application.UserService
 import net.blueshell.api.domain.user.persistence.User
 import net.blueshell.api.platform.integration.contact.application.job.DispatchContactSyncsJob
-import net.blueshell.api.platform.integration.sync.application.ContactSyncService
 import net.blueshell.api.shared.job.ContactJobs
+import net.blueshell.api.shared.job.TrackedJobDispatcher
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
@@ -14,32 +14,27 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
-import org.springframework.transaction.PlatformTransactionManager
-import org.springframework.transaction.support.SimpleTransactionStatus
 
 class DispatchContactSyncsJobTest {
 
     private val objectMapper = ObjectMapper()
     private val userService: UserService = mock()
-    private val contactSync: ContactSyncService = mock()
-    private val transactionManager: PlatformTransactionManager = mock<PlatformTransactionManager>().also {
-        whenever(it.getTransaction(org.mockito.kotlin.any())).thenReturn(SimpleTransactionStatus())
-    }
-    private val job = DispatchContactSyncsJob(objectMapper, userService, contactSync, transactionManager)
+    private val jobs: TrackedJobDispatcher = mock()
+    private val job = DispatchContactSyncsJob(objectMapper, userService, jobs)
 
     private fun userWithId(id: Long): User = mock<User>().also {
         whenever(it.id).thenReturn(id)
     }
 
     @Test
-    fun `calls ContactSyncService once per user`() {
+    fun `enqueues one SyncContact job per user`() {
         val users = mutableListOf(userWithId(1L), userWithId(2L))
         whenever(userService.findAll()).thenReturn(users)
 
         job.handle(objectMapper.writeValueAsString(ContactJobs.DispatchContactSyncsPayload()))
 
-        verify(contactSync).sync(eq(1L))
-        verify(contactSync).sync(eq(2L))
+        verify(jobs).enqueue(eq(ContactJobs.SyncContact), eq(ContactJobs.SyncContactPayload(1L)))
+        verify(jobs).enqueue(eq(ContactJobs.SyncContact), eq(ContactJobs.SyncContactPayload(2L)))
     }
 
     @Test
@@ -48,31 +43,19 @@ class DispatchContactSyncsJobTest {
 
         job.handle(objectMapper.writeValueAsString(ContactJobs.DispatchContactSyncsPayload()))
 
-        verifyNoInteractions(contactSync)
+        verifyNoInteractions(jobs)
     }
 
     @Test
-    fun `continues iterating when sync throws for one user`() {
+    fun `continues enqueueing when one enqueue fails`() {
         val users = mutableListOf(userWithId(1L), userWithId(2L))
         whenever(userService.findAll()).thenReturn(users)
-        doThrow(RuntimeException("sync failure")).whenever(contactSync).sync(1L)
+        doThrow(RuntimeException("enqueue boom")).whenever(jobs)
+            .enqueue(eq(ContactJobs.SyncContact), eq(ContactJobs.SyncContactPayload(1L)))
 
         job.handle(objectMapper.writeValueAsString(ContactJobs.DispatchContactSyncsPayload()))
 
-        verify(contactSync, times(1)).sync(eq(1L))
-        verify(contactSync, times(1)).sync(eq(2L))
-    }
-
-    @Test
-    fun `opens a fresh transaction per user`() {
-        val users = mutableListOf(userWithId(1L), userWithId(2L), userWithId(3L))
-        whenever(userService.findAll()).thenReturn(users)
-
-        job.handle(objectMapper.writeValueAsString(ContactJobs.DispatchContactSyncsPayload()))
-
-        // One getTransaction call per user proves the TransactionTemplate with
-        // REQUIRES_NEW propagation is invoked individually — i.e. a failing sync
-        // can only mark its own transaction rollback-only, not the dispatcher's.
-        verify(transactionManager, times(3)).getTransaction(org.mockito.kotlin.any())
+        verify(jobs, times(1)).enqueue(eq(ContactJobs.SyncContact), eq(ContactJobs.SyncContactPayload(1L)))
+        verify(jobs, times(1)).enqueue(eq(ContactJobs.SyncContact), eq(ContactJobs.SyncContactPayload(2L)))
     }
 }

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/job/ProcessListMembershipJobTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/job/ProcessListMembershipJobTest.kt
@@ -8,7 +8,6 @@ import net.blueshell.api.platform.integration.contact.adapter.ContactListAdapter
 import net.blueshell.api.platform.integration.contact.application.ContactListService
 import net.blueshell.api.platform.integration.contact.application.job.ProcessListMembershipJob
 import net.blueshell.api.platform.integration.contact.persistence.ContactList
-import net.blueshell.api.platform.integration.sync.application.ContactSyncService
 import net.blueshell.api.shared.enums.ContactSystem
 import net.blueshell.api.shared.job.ContactJobs
 import net.blueshell.api.shared.job.JobDefinition
@@ -16,6 +15,7 @@ import net.blueshell.api.shared.job.TrackedJobDispatcher
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -27,7 +27,8 @@ import java.time.LocalDate
  * Unit tests for [ProcessListMembershipJob].
  *
  * No Spring context — instantiate directly with mocks.
- * Verifies that the job dispatches per-adapter contact and list sync jobs.
+ * Verifies that the job enqueues per-adapter list sync jobs plus, when
+ * the user has a contribution, a queued SyncContact job.
  */
 class ProcessListMembershipJobTest {
 
@@ -35,7 +36,6 @@ class ProcessListMembershipJobTest {
     private val contactListService: ContactListService = mock()
     private val periods: ContributionPeriodService = mock()
     private val contributions: ContributionService = mock()
-    private val contactSync: ContactSyncService = mock()
     private val jobs: TrackedJobDispatcher = mock()
 
     private val listAdapter: ContactListAdapter = mock<ContactListAdapter>().also {
@@ -47,7 +47,6 @@ class ProcessListMembershipJobTest {
         contactListService = contactListService,
         periods = periods,
         contributions = contributions,
-        contactSync = contactSync,
         listAdapters = listOf(listAdapter),
         jobs = jobs,
     )
@@ -72,23 +71,24 @@ class ProcessListMembershipJobTest {
     }
 
     @Test
-    fun `syncs contact and dispatches one list sync job when user has contribution`() {
+    fun `enqueues SyncContact and one list sync job when user has contribution`() {
         whenever(contributions.existsByUserIdAndPeriodId(userId, periodId)).thenReturn(true)
         whenever(contactListService.createMembership(listId, userId)).thenReturn(true)
 
         job.handle(objectMapper.writeValueAsString(ContactJobs.ProcessListMembershipPayload(userId, periodId)))
 
-        verify(contactSync, times(1)).sync(userId)
-        verify(jobs, times(1)).enqueue(any<JobDefinition<Any>>(), any())
+        verify(jobs).enqueue(eq(ContactJobs.SyncContact), eq(ContactJobs.SyncContactPayload(userId)))
+        // SyncContact + one SyncListMembershipToSystem = two enqueue calls
+        verify(jobs, times(2)).enqueue(any<JobDefinition<Any>>(), any())
     }
 
     @Test
-    fun `dispatches only list sync job and does not touch contact sync when user has no contribution`() {
+    fun `dispatches only list sync job and does not enqueue SyncContact when user has no contribution`() {
         whenever(contributions.existsByUserIdAndPeriodId(userId, periodId)).thenReturn(false)
 
         job.handle(objectMapper.writeValueAsString(ContactJobs.ProcessListMembershipPayload(userId, periodId)))
 
-        verify(contactSync, never()).sync(any())
+        verify(jobs, never()).enqueue(eq(ContactJobs.SyncContact), any())
         verify(jobs, times(1)).enqueue(any<JobDefinition<Any>>(), any())
     }
 

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/job/RemoveContactJobTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/job/RemoveContactJobTest.kt
@@ -1,0 +1,24 @@
+package net.blueshell.api.platform.integration.contact.job
+
+import net.blueshell.api.platform.integration.contact.application.job.RemoveContactJob
+import net.blueshell.api.platform.integration.sync.application.ContactSyncService
+import net.blueshell.api.shared.job.ContactJobs
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import tools.jackson.databind.ObjectMapper
+
+class RemoveContactJobTest {
+
+    private val objectMapper = ObjectMapper()
+    private val contactSync: ContactSyncService = mock()
+    private val job = RemoveContactJob(objectMapper, contactSync)
+
+    @Test
+    fun `delegates to ContactSyncService remove with the payload userId`() {
+        job.handle(objectMapper.writeValueAsString(ContactJobs.RemoveContactPayload(99L)))
+
+        verify(contactSync).remove(eq(99L))
+    }
+}

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/job/SyncContactJobTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/job/SyncContactJobTest.kt
@@ -1,0 +1,24 @@
+package net.blueshell.api.platform.integration.contact.job
+
+import net.blueshell.api.platform.integration.contact.application.job.SyncContactJob
+import net.blueshell.api.platform.integration.sync.application.ContactSyncService
+import net.blueshell.api.shared.job.ContactJobs
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import tools.jackson.databind.ObjectMapper
+
+class SyncContactJobTest {
+
+    private val objectMapper = ObjectMapper()
+    private val contactSync: ContactSyncService = mock()
+    private val job = SyncContactJob(objectMapper, contactSync)
+
+    @Test
+    fun `delegates to ContactSyncService with the payload userId`() {
+        job.handle(objectMapper.writeValueAsString(ContactJobs.SyncContactPayload(42L)))
+
+        verify(contactSync).sync(eq(42L))
+    }
+}

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/job/application/service/JobExecutionServiceTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/job/application/service/JobExecutionServiceTest.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityManager
 import net.blueshell.api.platform.integration.job.persistence.JobExecution
 import net.blueshell.api.platform.integration.job.persistence.repository.JobExecutionRepository
 import net.blueshell.api.shared.enums.JobExecutionStatus
+import net.blueshell.api.shared.tracking.Actor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -14,9 +15,11 @@ import java.lang.reflect.Field
 /**
  * Pure unit tests for [JobExecutionService]. No Spring context.
  *
- * The base [net.blueshell.api.shared.service.BaseModelService] is a JPA-aware
- * helper that uses an injected [EntityManager]; we inject a mock so `update`
- * works against the mocked repository.
+ * Attempt semantics encoded here: `attempts` counts how many times the job has
+ * been queued for execution (initial enqueue + each retry / manual requeue),
+ * NOT how many times it has finished. So a job that has just been queued for
+ * the first time already shows `attempts = 1`, and a job that has run three
+ * times shows `attempts = 3`. Pressing the retry button bumps it immediately.
  */
 class JobExecutionServiceTest {
 
@@ -24,23 +27,95 @@ class JobExecutionServiceTest {
     private val entityManager: EntityManager = mock()
     private val service = JobExecutionService(repository).also { injectEntityManager(it) }
 
+    private val systemActor = Actor.system()
+
     @Test
-    fun `requeue increments attempts from any starting value`() {
-        // Simulate a job that already failed four times (display would show "5 attempts" via +1).
-        val execution = JobExecution(jobType = "demo", attempts = 4, status = JobExecutionStatus.FAILED)
+    fun `createQueued initializes attempts to 1 so the initial run counts`() {
+        whenever(repository.saveAndFlush(any<JobExecution>())).thenAnswer { it.arguments[0] as JobExecution }
+
+        val execution = service.createQueued(jobType = "demo", payload = null, actor = systemActor)
+
+        assertThat(execution).isNotNull
+        assertThat(execution!!.attempts).isEqualTo(1)
+        assertThat(execution.status).isEqualTo(JobExecutionStatus.QUEUED)
+    }
+
+    @Test
+    fun `markRunning does not bump attempts`() {
+        val execution = JobExecution(jobType = "demo", attempts = 1, status = JobExecutionStatus.QUEUED)
+            .apply { id = 1L }
+        stubPersistence(execution)
+
+        service.markRunning(execution)
+
+        assertThat(execution.attempts).isEqualTo(1)
+        assertThat(execution.status).isEqualTo(JobExecutionStatus.RUNNING)
+    }
+
+    @Test
+    fun `markSuccess does not bump attempts`() {
+        val execution = JobExecution(jobType = "demo", attempts = 1, status = JobExecutionStatus.RUNNING)
+            .apply { id = 1L }
+        stubPersistence(execution)
+
+        service.markSuccess(execution)
+
+        assertThat(execution.attempts).isEqualTo(1)
+        assertThat(execution.status).isEqualTo(JobExecutionStatus.SUCCESS)
+    }
+
+    @Test
+    fun `markFailed does not bump attempts`() {
+        val execution = JobExecution(jobType = "demo", attempts = 3, status = JobExecutionStatus.RUNNING)
+            .apply { id = 1L }
+        stubPersistence(execution)
+
+        service.markFailed(execution, "SomeError", "boom")
+
+        assertThat(execution.attempts).isEqualTo(3)
+        assertThat(execution.status).isEqualTo(JobExecutionStatus.FAILED)
+    }
+
+    @Test
+    fun `markDead does not bump attempts`() {
+        val execution = JobExecution(jobType = "demo", attempts = 1, status = JobExecutionStatus.RUNNING)
+            .apply { id = 1L }
+        stubPersistence(execution)
+
+        service.markDead(execution, "SomeError", "boom")
+
+        assertThat(execution.attempts).isEqualTo(1)
+        assertThat(execution.status).isEqualTo(JobExecutionStatus.DEAD)
+    }
+
+    @Test
+    fun `markRetryScheduled bumps attempts so the upcoming retry is counted`() {
+        val execution = JobExecution(jobType = "demo", attempts = 1, status = JobExecutionStatus.RUNNING)
+            .apply { id = 1L }
+        stubPersistence(execution)
+
+        service.markRetryScheduled(execution, "SomeError", "boom", nextAttemptAt = java.time.Instant.now())
+
+        assertThat(execution.attempts).isEqualTo(2)
+        assertThat(execution.status).isEqualTo(JobExecutionStatus.QUEUED)
+    }
+
+    @Test
+    fun `requeue bumps attempts immediately so the count reflects the upcoming run`() {
+        val execution = JobExecution(jobType = "demo", attempts = 3, status = JobExecutionStatus.FAILED)
             .apply { id = 7L }
         stubPersistence(execution)
 
         val result = service.requeue(execution)
 
-        assertThat(result.attempts).isEqualTo(5)
+        assertThat(result.attempts).isEqualTo(4)
         assertThat(result.status).isEqualTo(JobExecutionStatus.QUEUED)
         assertThat(result.nextAttemptAt).isNull()
     }
 
     @Test
     fun `requeue increments attempts on each successive call`() {
-        val execution = JobExecution(jobType = "demo", attempts = 0, status = JobExecutionStatus.FAILED)
+        val execution = JobExecution(jobType = "demo", attempts = 1, status = JobExecutionStatus.FAILED)
             .apply { id = 7L }
         stubPersistence(execution)
 
@@ -50,21 +125,46 @@ class JobExecutionServiceTest {
         execution.status = JobExecutionStatus.FAILED
         service.requeue(execution)
 
-        assertThat(execution.attempts).isEqualTo(3)
+        assertThat(execution.attempts).isEqualTo(4)
     }
 
     /**
-     * saveAndFlush returns the persisted entity; the BaseModelService then
-     * calls em.refresh on the returned reference. The mock simply echoes the
-     * entity back so we can observe the field mutations.
+     * Walks the user's stated scenario: a job that runs three times (initial +
+     * two retries) and succeeds on the third should end at attempts == 3.
      */
+    @Test
+    fun `one successful run leaves attempts at 1; three successful runs at 3`() {
+        whenever(repository.saveAndFlush(any<JobExecution>())).thenAnswer { it.arguments[0] as JobExecution }
+
+        // One run → 1 attempt
+        val once = service.createQueued("demo", null, systemActor)!!
+            .also { it.id = 11L; whenever(repository.existsById(it.id!!)).thenReturn(true) }
+        service.markRunning(once)
+        service.markSuccess(once)
+        assertThat(once.attempts).describedAs("single successful run").isEqualTo(1)
+
+        // Three runs (fail, fail, succeed) → 3 attempts
+        val thrice = service.createQueued("demo", null, systemActor)!!
+            .also { it.id = 12L; whenever(repository.existsById(it.id!!)).thenReturn(true) }
+        service.markRunning(thrice)
+        service.markRetryScheduled(thrice, "E", "r", nextAttemptAt = java.time.Instant.now())
+        service.markRunning(thrice)
+        service.markRetryScheduled(thrice, "E", "r", nextAttemptAt = java.time.Instant.now())
+        service.markRunning(thrice)
+        service.markSuccess(thrice)
+        assertThat(thrice.attempts).describedAs("three successive runs").isEqualTo(3)
+
+        // Then admin clicks retry: attempts goes to 4 immediately
+        service.requeue(thrice)
+        assertThat(thrice.attempts).describedAs("attempts after retry click").isEqualTo(4)
+    }
+
     private fun stubPersistence(entity: JobExecution) {
         whenever(repository.existsById(entity.id!!)).thenReturn(true)
         whenever(repository.saveAndFlush(any<JobExecution>())).thenAnswer { it.arguments[0] }
     }
 
     private fun injectEntityManager(service: JobExecutionService) {
-        // BaseModelService.em is package-private lateinit; reflect to set the mock.
         val field: Field = service.javaClass.superclass.getDeclaredField("em")
         field.isAccessible = true
         field.set(service, entityManager)

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/job/application/service/JobExecutionServiceTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/job/application/service/JobExecutionServiceTest.kt
@@ -133,7 +133,7 @@ class JobExecutionServiceTest {
      * two retries) and succeeds on the third should end at attempts == 3.
      */
     @Test
-    fun `one successful run leaves attempts at 1; three successful runs at 3`() {
+    fun `one successful run leaves attempts at 1 and three successful runs at 3`() {
         whenever(repository.saveAndFlush(any<JobExecution>())).thenAnswer { it.arguments[0] as JobExecution }
 
         // One run → 1 attempt

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/sync/listener/CalendarSyncListenerTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/sync/listener/CalendarSyncListenerTest.kt
@@ -1,0 +1,25 @@
+package net.blueshell.api.platform.integration.sync.listener
+
+import net.blueshell.api.domain.event.application.event.EventChange
+import net.blueshell.api.domain.event.application.event.EventChanged
+import net.blueshell.api.shared.job.CalendarJobs
+import net.blueshell.api.shared.job.TrackedJobDispatcher
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+
+class CalendarSyncListenerTest {
+
+    private val jobs: TrackedJobDispatcher = mock()
+    private val listener = CalendarSyncListener(jobs)
+
+    @Test
+    fun `EventChanged enqueues a SyncCalendarEvent job`() {
+        listener.on(EventChanged(42L, EventChange.CREATED))
+
+        verify(jobs).enqueue(eq(CalendarJobs.SyncCalendarEvent), eq(CalendarJobs.SyncCalendarEventPayload(42L)))
+        verifyNoMoreInteractions(jobs)
+    }
+}

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/sync/listener/ContactSyncListenerTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/sync/listener/ContactSyncListenerTest.kt
@@ -1,0 +1,42 @@
+package net.blueshell.api.platform.integration.sync.listener
+
+import net.blueshell.api.domain.user.application.event.UserCreated
+import net.blueshell.api.domain.user.application.event.UserDeleted
+import net.blueshell.api.domain.user.application.event.UserUpdated
+import net.blueshell.api.shared.job.ContactJobs
+import net.blueshell.api.shared.job.TrackedJobDispatcher
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+
+class ContactSyncListenerTest {
+
+    private val jobs: TrackedJobDispatcher = mock()
+    private val listener = ContactSyncListener(jobs)
+
+    @Test
+    fun `UserCreated enqueues a SyncContact job`() {
+        listener.on(UserCreated(7L))
+
+        verify(jobs).enqueue(eq(ContactJobs.SyncContact), eq(ContactJobs.SyncContactPayload(7L)))
+        verifyNoMoreInteractions(jobs)
+    }
+
+    @Test
+    fun `UserUpdated enqueues a SyncContact job`() {
+        listener.on(UserUpdated(11L))
+
+        verify(jobs).enqueue(eq(ContactJobs.SyncContact), eq(ContactJobs.SyncContactPayload(11L)))
+        verifyNoMoreInteractions(jobs)
+    }
+
+    @Test
+    fun `UserDeleted enqueues a RemoveContact job`() {
+        listener.on(UserDeleted(13L))
+
+        verify(jobs).enqueue(eq(ContactJobs.RemoveContact), eq(ContactJobs.RemoveContactPayload(13L)))
+        verifyNoMoreInteractions(jobs)
+    }
+}

--- a/services/frontend/src/utils/jobAttempts.ts
+++ b/services/frontend/src/utils/jobAttempts.ts
@@ -1,12 +1,11 @@
 /**
  * Human label for a job's attempt counter.
  *
- * The server-side `attempts` field is the number of attempts that have already
- * been made (incremented by `JobExecutionService.requeue` and `markRetryScheduled`).
- * The label reflects that number directly — a job that has failed four times shows
- * "4 attempts", a job that has never run shows "0 attempts". The previous
- * implementation added `+ 1`, which made server `attempts=0` show as "1 attempt"
- * and made successful retries look like the counter regressed.
+ * The server-side `attempts` field is the 1-indexed counter of the run that
+ * is currently happening (or about to happen): a freshly enqueued job shows
+ * "1 attempt", a job that has run three times shows "3 attempts", and the
+ * counter ticks up the moment the admin presses retry. The frontend reflects
+ * that value directly.
  */
 export const attemptsLabel = (attempts?: number): string => {
   const count = attempts ?? 0


### PR DESCRIPTION
## Why
Two related shapes were doing external-system pushes outside the job
queue:

1. `DispatchContactSyncsJob` walked every user and called
   `ContactSyncService.sync(id)` inline in one transaction. The
   nightly run showed up as a single `JobExecution` row that
   collapsed the moment one user failed — the same rollback-only
   incident this PR was originally opened for.
2. `ContactSyncListener` (UserCreated / Updated / Deleted),
   `CalendarSyncListener` (EventChanged) and
   `ProcessListMembershipJob` called the sync services inline as
   well. Per-user / per-event work was real per-row work, but the
   HTTP push to Brevo / Google Calendar ran inside the publishing
   transaction with no retry visibility and no row in the Job
   Manager.

In both cases a flaky external call could only surface in api logs,
not in the Job Manager, and there was no retry isolation between
the publishing work and the external push.

## What this achieves
- Every external push is its own queued `JobExecution` row with its
  own retry schedule, exactly like `SyncListMembershipToSystem`.
- The nightly `DispatchContactSyncs` fans out into ~N user-sized
  rows so a single bad user can't take down the batch, and the
  Job Manager shows the fan-out shape ("ton of jobs") that the
  daily refresh actually performs.
- Modulith listeners stay cheap: the listener body is just an
  `enqueue` call, so the listener's own transaction returns
  quickly and Modulith stops being the retry boundary for
  third-party HTTP failures — the job queue's exponential backoff
  is.

## How
**New job definitions** in `JobDefinitions.kt`:
- `ContactJobs.SyncContact(userId)` — push current contact state
- `ContactJobs.RemoveContact(userId)` — soft-delete + push null
- `CalendarJobs.SyncCalendarEvent(eventId)` — push current event

**New handlers** that delegate to the existing services:
- `SyncContactJob` → `ContactSyncService.sync`
- `RemoveContactJob` → `ContactSyncService.remove`
- `SyncCalendarEventJob` → `CalendarSyncService.sync`

**Call sites flipped from inline to enqueue**:
- `DispatchContactSyncsJob` — no more `ContactSyncService` /
  `PlatformTransactionManager` dependency; loops users and enqueues
  one `SyncContact` per user with `runCatching` around the enqueue
  itself. The REQUIRES_NEW workaround from 0d7f01cf is removed
  because there is no shared per-user transaction any more.
- `ContactSyncListener` — UserCreated / Updated enqueue
  `SyncContact`; UserDeleted enqueues `RemoveContact`. No more
  `ContactSyncService` dependency on the listener.
- `CalendarSyncListener` — EventChanged enqueues
  `SyncCalendarEvent`. No more `CalendarSyncService` dependency.
- `ProcessListMembershipJob` — the inline `contactSync.sync` call
  in the has-contribution branch is replaced by an enqueued
  `SyncContact` so the per-adapter list jobs and the contact
  sync all retry independently.

Tests added for every new handler and every flipped listener;
`ProcessListMembershipJobTest` now asserts the SyncContact enqueue
instead of a direct service call.