### PR TITLE
ci: block out-of-order and tampered Flyway migrations pre-merge

### DIFF
--- a/scripts/check-migration-order.sh
+++ b/scripts/check-migration-order.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# check-migration-order.sh — fail loudly when a Flyway migration on this
+# branch would deploy badly against the current `main`.
+#
+# Catches the failure mode that bit #243 / #245: two open PRs each add
+# a migration; whichever lands second uses a version number ≤ the head
+# Flyway has already applied, Spring Boot's Flyway refuses to migrate
+# ("Detected resolved migration not applied to database: <n>"), the
+# new pod fails its readiness probe, and the rolling deploy stalls
+# behind the still-healthy old replica.
+#
+# Rules enforced:
+#   1. No two migration files on this branch share a version number.
+#   2. Every migration file *added* on this branch (incl. renamed-to)
+#      must have a version strictly greater than the highest version
+#      currently on ${BASE_REF}.
+#   3. No migration file already on ${BASE_REF} may be *modified* by
+#      this branch — once a migration is applied, its content is
+#      effectively immutable.
+#
+# Usage:
+#   scripts/check-migration-order.sh                 # vs origin/main
+#   BASE_REF=origin/develop scripts/check-migration-order.sh
+#
+# Exit codes: 0 ok, 1 rule violated, 2 script can't run.
+set -euo pipefail
+
+MIGRATION_DIR="services/api/src/main/resources/db/migration"
+BASE_REF="${BASE_REF:-origin/main}"
+
+if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
+  echo "error: base ref '$BASE_REF' is not available locally." >&2
+  echo "       Run 'git fetch origin main' first or set BASE_REF." >&2
+  exit 2
+fi
+
+version_of() {
+  # Extract the version number from a Flyway filename. Echoes nothing
+  # for non-Flyway paths so the caller can skip them with a simple test.
+  sed -nE 's|.*/V([0-9]+)__.*\.sql$|\1|p' <<< "$1"
+}
+
+versions_on() {
+  # Print one numeric version per migration tracked at the given ref.
+  git ls-tree -r --name-only "$1" -- "$MIGRATION_DIR" 2>/dev/null \
+    | grep -E "/V[0-9]+__.*\.sql$" \
+    | sed -nE 's|.*/V([0-9]+)__.*\.sql$|\1|p' \
+    | sort -n
+}
+
+base_max="$(versions_on "$BASE_REF" | tail -1)"
+base_max="${base_max:-0}"
+echo "Highest Flyway migration version on $BASE_REF: V$base_max"
+
+violations=()
+
+# ── Rule 1 — duplicate version number on this branch ─────────────────────────
+while IFS= read -r v; do
+  [[ -z "$v" ]] && continue
+  files="$(git ls-tree -r --name-only HEAD -- "$MIGRATION_DIR" \
+            | grep -E "/V${v}__.*\.sql$" | tr '\n' ' ')"
+  violations+=("Duplicate version V${v} on branch: ${files}")
+done < <(versions_on HEAD | uniq -d)
+
+# ── Rules 2 + 3 — diff-driven ────────────────────────────────────────────────
+# `--name-status` prints a status letter (A/M/D/R…) per touched file.
+# Renames carry R<percent> + old + new paths; the new path is what
+# Flyway sees, so that's the version we validate.
+while IFS=$'\t' read -r status path1 path2; do
+  case "$status" in
+    A)
+      file="$path1"
+      v="$(version_of "$file")"
+      [[ -z "$v" ]] && continue
+      if (( v <= base_max )); then
+        violations+=("Out-of-order: ${file} is V${v} but ${BASE_REF} is already at V${base_max} — renumber to V$((base_max + 1)) or later")
+      fi
+      ;;
+    M)
+      file="$path1"
+      v="$(version_of "$file")"
+      [[ -z "$v" ]] && continue
+      # The modified file might be one this branch added in an earlier
+      # commit (v > base_max, not yet on main) — that's fine, the
+      # author is still iterating. Only block edits to files already
+      # on the base ref.
+      if (( v <= base_max )); then
+        violations+=("Modifying applied migration: ${file} (V${v}) is already on ${BASE_REF} — Flyway will reject the checksum change at boot")
+      fi
+      ;;
+    R*)
+      newfile="$path2"
+      v="$(version_of "$newfile")"
+      [[ -z "$v" ]] && continue
+      if (( v <= base_max )); then
+        violations+=("Out-of-order (renamed): ${newfile} is V${v} but ${BASE_REF} is already at V${base_max} — renumber to V$((base_max + 1)) or later")
+      fi
+      ;;
+  esac
+done < <(git diff --name-status "$BASE_REF...HEAD" -- "$MIGRATION_DIR")
+
+if (( ${#violations[@]} > 0 )); then
+  echo
+  echo "❌ Flyway migration check failed:" >&2
+  for msg in "${violations[@]}"; do
+    echo "  - $msg" >&2
+  done
+  echo >&2
+  echo "Why this matters: Spring Boot's Flyway runs in strict-validate mode" >&2
+  echo "by default. A migration with a version ≤ the schema's current head," >&2
+  echo "or any change to an applied migration's content, is rejected at" >&2
+  echo "boot, the new pod fails its readiness probe, and the rolling deploy" >&2
+  echo "never replaces the old pod." >&2
+  exit 1
+fi
+
+touched="$(git diff --name-only "$BASE_REF...HEAD" -- "$MIGRATION_DIR" | wc -l | tr -d ' ')"
+echo "✅ ${touched} migration file(s) touched on this branch, none out-of-order."


### PR DESCRIPTION
## Why

#243 and #245 surfaced a foot-gun: two PRs each adding a Flyway migration go through CI green when authored against the same `main` head. The second one to merge then introduces a version number that's already ≤ the new head Flyway has applied, the api pod's next ReplicaSet rejects the migration at boot ("Detected resolved migration not applied to database: \<n\>"), the readiness probe stays red, and the surge-first rolling deploy leaves the old pod (with the wrong external integrations baked in) serving production traffic until someone notices.

CI didn't catch this because the test database starts blank — out-of-order is invisible when there is no prior schema. The check has to compare the PR branch against the current `main` tree, not against an empty DB.

## What this achieves

PRs that would put the cluster into the #243-style stuck state now fail at the `API compile checks` job before they can merge. The check runs in ~1 second, before the heavy gradle build, so the feedback loop is immediate.

Three rules:

1. **No duplicate version numbers on the branch.** Catches authors who copy a sibling migration and forget to bump the file name.
2. **Every added or renamed-to migration must have a version strictly greater than `main`'s highest.** Catches the #243 / #245 race directly: when `main` advances past the PR's version while the PR is still open, the next push re-validates against the new `main` and surfaces the conflict.
3. **No migration already on `main` may be modified.** Once Flyway has stamped a checksum on a row in `flyway_schema_history`, edits to the SQL produce `FlywayValidateException` at boot.

## How

`scripts/check-migration-order.sh` is the whole check — pure bash, no JVM, ~100 lines, runs against `${BASE_REF:-origin/main}`. The api-static job in `.github/workflows/validate.yml` fetches `origin/main` with `--depth=1` first (the default shallow checkout doesn't have it) and then invokes the script.

The script reads filenames only, never opens the SQL bodies, so it's robust against encoding or whitespace differences. Renames in `git diff --name-status` are handled explicitly so PRs like #245 (V60 → V62) validate the *new* version.

Smoke-tested locally against the current `main` (V61 head):

- clean branch → pass
- bogus V60 → fail (Rule 1 + Rule 2)
- tampered V61 content → fail (Rule 3)
- clean V62 added → pass
- V58 → V63 rename → pass
- V61 → V60 rename → fail (Rule 2 on the renamed-to)

The script exits 1 on any rule violation, 2 if it can't run (missing ref, etc.), 0 on success.