### PR TITLE
feat(api): split SMTP submission onto a dedicated Stalwart principal

### DIFF
--- a/platform/cluster/flux/apps/stateless/api/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/api/deployment.yaml
@@ -166,17 +166,22 @@ spec:
               value: Blueshell
             - name: EMAIL_REPLY_TO_ADDRESS
               value: sitecie@esa-blueshell.nl
+            # SMTP submission runs as a dedicated Stalwart principal
+            # (`api@esa-blueshell.nl`) authorised to send envelope-from
+            # `no-reply@esa-blueshell.nl`. The bounce-mailbox account
+            # stays on its own keys below — different principal, different
+            # blast radius.
             - name: SMTP_USERNAME
               valueFrom:
                 secretKeyRef:
                   name: stalwart-secrets
-                  key: bounce-mailbox-user
+                  key: api-user
                   optional: true
             - name: SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: stalwart-secrets
-                  key: bounce-mailbox-password
+                  key: api-password
                   optional: true
             # IMAP bounce poller — disabled by default; flip the flag once
             # the bounce mailbox is provisioned.

--- a/platform/docs/vault-bootstrap.md
+++ b/platform/docs/vault-bootstrap.md
@@ -160,14 +160,42 @@ login for operator reference, store it separately as
 
 ### Stalwart mail server
 
+`secret/platform/mail` holds three logically separate identities. They
+share a KV path but they're three different Stalwart principals:
+
+| Key pair                                | Principal                                | Used by                                       |
+|-----------------------------------------|------------------------------------------|-----------------------------------------------|
+| `admin-user` / `admin-password`         | Stalwart fallback-admin                  | Stalwart container only (mail-admin web UI, CLI) |
+| `api-user` / `api-password`             | SMTP submission account (`api@…`)        | api pod — `SMTP_USERNAME` / `SMTP_PASSWORD`   |
+| `bounce-mailbox-user` / `…-password`    | IMAP bounce mailbox (`bounce@…`)         | api pod — `EMAIL_BOUNCE_IMAP_USERNAME` / `…_PASSWORD` |
+
+The admin credential is intentionally not exposed to the api: a
+compromised api token must not yield the mail-server admin. Submission
+and bounce reads run as separate low-privilege principals.
+
 ```bash
 vault kv put secret/platform/mail \
   admin-user=admin \
   admin-password=<stalwart-admin-password> \
   dkim-private-key=<base64-encoded-rsa-2048-pem> \
+  api-user=api@esa-blueshell.nl \
+  api-password=<api-smtp-password> \
   bounce-mailbox-user=bounce@esa-blueshell.nl \
   bounce-mailbox-password=<bounce-mailbox-password>
 ```
+
+To rotate or seed only the SMTP submission keys without touching the
+other fields, use `scripts/seed-api-smtp-user.sh` — it handles the
+Vault port-forward, generates a password if none is provided, patches
+the path (preserving the other keys), forces VSO to refresh both
+mirrored Secrets, and optionally rolls the api pod.
+
+The `api-user` principal must be authorised in Stalwart to send
+envelope-from `no-reply@esa-blueshell.nl` (the only address the api
+code ever uses as `MAIL FROM` — display names and Reply-To vary, but
+the envelope sender is constant). Reply-To headers reference
+`sitecie@esa-blueshell.nl` and `board@blueshell.utwente.nl`; those are
+header values only, no authorisation needed.
 
 ### API third-party secrets
 

--- a/scripts/seed-api-smtp-user.sh
+++ b/scripts/seed-api-smtp-user.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# seed-api-smtp-user.sh — patch `secret/platform/mail` with the dedicated
+# SMTP principal the api uses to submit transactional mail to Stalwart.
+#
+# Two keys are written, both new:
+#   api-user      = api@esa-blueshell.nl
+#   api-password  = generated (or $API_SMTP_PASSWORD if set)
+#
+# The corresponding Stalwart principal must already exist (or be created
+# right after running this script) and must be authorised to send envelope
+# `MAIL FROM: no-reply@esa-blueshell.nl`. See `platform/docs/vault-bootstrap.md`
+# for the full sender-address list.
+#
+# After write:
+#   • Both VaultStaticSecret CRs (`default/stalwart-secrets`,
+#     `mail-system/stalwart-secrets`) get a force-refresh annotation.
+#   • The script waits up to 60s for the `stalwart-secrets` Secret in
+#     `default` to carry the new `api-user` field, mirroring the safety
+#     check `seed-vault-from-env.sh --sync-api` uses.
+#   • Optional `--restart-api` rolls the api pod so it re-reads
+#     /vault/secrets/api.env with the new values.
+#
+# Trusted-input script: this is an operator-run seeding tool, not
+# user-facing automation. Run from a developer machine with `vault` and
+# `kubectl` on $PATH.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/seed-api-smtp-user.sh [--restart-api]
+
+Environment:
+  VAULT_ADDR                Vault address. If unset, the script port-forwards
+                            to svc/vault in data-system and uses
+                            http://127.0.0.1:8200.
+  VAULT_TOKEN               Vault token. If unset, `vault login` is invoked
+                            interactively before the write.
+  KUBECONFIG                Defaults to $HOME/.kube/blueshell.yaml.
+  API_SMTP_USER             Override the user value (default api@esa-blueshell.nl).
+  API_SMTP_PASSWORD         Use this exact password instead of generating one.
+
+Examples:
+  # Fully interactive: prompts for token, generates a password, prints it.
+  scripts/seed-api-smtp-user.sh
+
+  # Reuse a password you already configured in Stalwart, restart api.
+  API_SMTP_PASSWORD='<paste>' scripts/seed-api-smtp-user.sh --restart-api
+EOF
+}
+
+RESTART_API=0
+for arg in "$@"; do
+  case "$arg" in
+    --restart-api) RESTART_API=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $arg" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+API_SMTP_USER="${API_SMTP_USER:-api@esa-blueshell.nl}"
+KUBECONFIG="${KUBECONFIG:-$HOME/.kube/blueshell.yaml}"
+export KUBECONFIG
+
+command -v vault   >/dev/null || { echo "vault CLI not found on PATH"   >&2; exit 1; }
+command -v kubectl >/dev/null || { echo "kubectl not found on PATH"     >&2; exit 1; }
+command -v jq      >/dev/null || { echo "jq not found on PATH"          >&2; exit 1; }
+command -v openssl >/dev/null || { echo "openssl not found on PATH"     >&2; exit 1; }
+
+# Generate a 32-char URL-safe-ish password if the operator didn't pin one.
+# Stripping characters that confuse env-file parsers and SMTP libs.
+if [[ -z "${API_SMTP_PASSWORD:-}" ]]; then
+  API_SMTP_PASSWORD="$(openssl rand -base64 36 | tr -d '/+=\n' | cut -c1-32)"
+  GENERATED=1
+else
+  GENERATED=0
+fi
+
+# ── Port-forward to Vault if VAULT_ADDR isn't set ────────────────────────────
+PF_PID=""
+cleanup() {
+  if [[ -n "$PF_PID" ]]; then
+    kill "$PF_PID" 2>/dev/null || true
+    wait "$PF_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+if [[ -z "${VAULT_ADDR:-}" ]]; then
+  echo "VAULT_ADDR not set — starting port-forward to svc/vault in data-system..."
+  kubectl -n data-system port-forward svc/vault 8200:8200 >/dev/null 2>&1 &
+  PF_PID=$!
+  # Wait briefly for the forwarder to bind.
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    sleep 0.5
+    if curl -fsS -o /dev/null http://127.0.0.1:8200/v1/sys/health 2>/dev/null \
+        || curl -fsS -o /dev/null "http://127.0.0.1:8200/v1/sys/seal-status" 2>/dev/null; then
+      break
+    fi
+  done
+  export VAULT_ADDR=http://127.0.0.1:8200
+fi
+echo "VAULT_ADDR=$VAULT_ADDR"
+
+# ── Authenticate ─────────────────────────────────────────────────────────────
+if [[ -z "${VAULT_TOKEN:-}" ]]; then
+  echo "VAULT_TOKEN not set — running 'vault login' (paste the root token):"
+  vault login >/dev/null
+fi
+
+# Sanity: confirm we can read the mount before writing.
+if ! vault kv get -format=json secret/platform/mail >/dev/null 2>&1; then
+  echo "Cannot read secret/platform/mail — token lacks permission or path missing." >&2
+  exit 1
+fi
+
+# ── Patch the two keys, preserving everything else ───────────────────────────
+echo "Patching secret/platform/mail (api-user, api-password)..."
+vault kv patch secret/platform/mail \
+  api-user="$API_SMTP_USER" \
+  api-password="$API_SMTP_PASSWORD" >/dev/null
+
+# ── Force VSO refresh on both mirrored Secrets ───────────────────────────────
+for ns in default mail-system; do
+  echo "Forcing VSO refresh on $ns/stalwart-secrets..."
+  kubectl -n "$ns" annotate vaultstaticsecret stalwart-secrets \
+    vso.secrets.hashicorp.com/force-refresh="$(date +%s)" \
+    --overwrite >/dev/null
+done
+
+# ── Wait for the api-user key to materialise in default/stalwart-secrets ─────
+echo "Waiting for default/stalwart-secrets to carry api-user (up to 60s)..."
+synced=0
+for i in $(seq 1 12); do
+  current="$(
+    kubectl -n default get secret stalwart-secrets \
+      -o jsonpath="{.data.api-user}" 2>/dev/null \
+      | base64 -d 2>/dev/null || true
+  )"
+  if [[ "$current" == "$API_SMTP_USER" ]]; then
+    echo "  VSO synced (attempt $i)."
+    synced=1
+    break
+  fi
+  sleep 5
+done
+if (( synced != 1 )); then
+  echo "VSO did not surface api-user within 60s." >&2
+  echo "Check: kubectl -n default describe vaultstaticsecret stalwart-secrets" >&2
+  exit 1
+fi
+
+# ── Optional: roll the api pod so Vault Agent renders the new env ────────────
+if (( RESTART_API == 1 )); then
+  echo "Rolling api pod..."
+  kubectl -n default rollout restart deployment/api >/dev/null
+  echo "Watch: kubectl -n default rollout status deployment/api"
+fi
+
+# ── Final report ─────────────────────────────────────────────────────────────
+echo
+echo "─── Stalwart principal to create ────────────────────────────────────────"
+echo "  login:    $API_SMTP_USER"
+if (( GENERATED == 1 )); then
+  echo "  password: $API_SMTP_PASSWORD     (generated; save this — Vault now holds it)"
+else
+  echo "  password: (already known to you; matches the value passed in)"
+fi
+echo
+echo "The principal must be authorised to send envelope-from:"
+echo "  no-reply@esa-blueshell.nl"
+echo
+echo "Full address policy and rationale: platform/docs/vault-bootstrap.md"


### PR DESCRIPTION
## Why

The api authenticates to the in-cluster Stalwart relay using
`bounce-mailbox-user` / `bounce-mailbox-password` from
`secret/platform/mail`. One identity is doing two jobs: outbound SMTP
submission and inbound IMAP bounce reads. A leak of the api's mounted
Secret therefore exposes both sides at once, and the bounce mailbox
account drifts into being an operational submission identity rather
than a focused DSN reader. Sharing the Stalwart admin would be worse —
that account isn't, and shouldn't be, mountable into the api.

## What this achieves

- A new Stalwart principal (`api@esa-blueshell.nl`) owns SMTP
  submission for the api, distinct from the bounce mailbox principal
  and from the Stalwart admin. Compromise of either side now ends at
  that side's blast radius.
- `scripts/seed-api-smtp-user.sh` lets an operator rotate or seed the
  submission credentials end-to-end without touching the other fields
  on `secret/platform/mail`.
- `platform/docs/vault-bootstrap.md` now documents the three Stalwart
  principals living on that KV path, what each one is mounted into,
  and the single envelope-from address the submission principal must
  be authorised for.

## How

- `platform/cluster/flux/apps/stateless/api/deployment.yaml` —
  `SMTP_USERNAME` / `SMTP_PASSWORD` now bind to the new `api-user` /
  `api-password` keys on `stalwart-secrets`. `EMAIL_BOUNCE_IMAP_*`
  still bind to `bounce-mailbox-user` / `bounce-mailbox-password` —
  bounce reads are a different principal. Both SMTP refs keep
  `optional: true`, so the pod boots cleanly between merge and
  seeding.
- `scripts/seed-api-smtp-user.sh` — new operator script. Port-forwards
  to `svc/vault` in `data-system` if `VAULT_ADDR` is unset, prompts for
  `vault login` if no token is in the environment, generates a 32-char
  URL-safe password (or honours `API_SMTP_PASSWORD`), `vault kv patch`s
  the two new keys, annotates both `stalwart-secrets` VaultStaticSecret
  CRs (default + mail-system) to force a VSO refresh, waits up to 60s
  for the new `api-user` value to surface in the k8s Secret, and on
  `--restart-api` rolls the api Deployment so the Vault Agent
  re-renders `/vault/secrets/api.env`. Generated passwords are echoed
  to stdout once so the operator can paste them into Stalwart.
- `platform/docs/vault-bootstrap.md` — the `secret/platform/mail`
  section gains a three-row table mapping each principal to its
  consumer, an updated `vault kv put` example listing the new keys,
  and prose noting which address the api ever uses as `MAIL FROM`
  (just `no-reply@esa-blueshell.nl`) versus header-only Reply-To
  values that need no authorisation.

## Operator follow-up

The api keeps sending mail using the bounce-mailbox identity until
`seed-api-smtp-user.sh` runs and the Stalwart principal it announces
(`api@esa-blueshell.nl`) is created with submission rights for
`no-reply@esa-blueshell.nl`. Order between those two steps doesn't
matter — submission auth only kicks in once both sides agree.