### PR TITLE
Adopt existing Brevo contact on duplicate create

### DIFF
--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/ContactData.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/ContactData.kt
@@ -31,7 +31,7 @@ fun User.toContactData(): ContactData = ContactData(
  * Domain exception for contact operations.
  * Thrown when contact adapter operations fail.
  */
-class ContactServiceException(
+open class ContactServiceException(
     message: String,
     cause: Throwable? = null
 ) : RuntimeException(message, cause)

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoClientConfig.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoClientConfig.kt
@@ -1,0 +1,36 @@
+package net.blueshell.api.platform.integration.contact.adapter.brevo
+
+import net.blueshell.clients.brevo.ApiClient
+import net.blueshell.clients.brevo.api.ContactsApi
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter
+import org.springframework.web.client.RestClient
+import tools.jackson.databind.json.JsonMapper
+
+/**
+ * Wires the Brevo [ContactsApi] client. Kept separate from [BrevoContactAdapter]
+ * so the adapter holds no HTTP-setup concerns and can be unit-tested with a mock
+ * client. Active in production only (test/dev use MockContactAdapter).
+ */
+@Configuration
+@Profile("!test & !dev")
+class BrevoClientConfig {
+    @Bean
+    fun brevoContactsApi(
+        restClientBuilder: RestClient.Builder,
+        jsonMapper: JsonMapper,
+        @Value($$"${brevo.apiKey:}") apiKey: String,
+        @Value($$"${brevo.baseUrl:https://api.brevo.com/v3}") baseUrl: String,
+    ): ContactsApi =
+        ContactsApi(
+            ApiClient(
+                restClientBuilder.baseUrl(baseUrl).defaultHeader("api-key", apiKey)
+                    .configureMessageConverters {
+                        it.addCustomConverter(JacksonJsonHttpMessageConverter(jsonMapper))
+                    }.build()
+            )
+        )
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoContactAdapter.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoContactAdapter.kt
@@ -1,59 +1,34 @@
 package net.blueshell.api.platform.integration.contact.adapter.brevo
 
-import jakarta.validation.Valid
 import net.blueshell.api.platform.integration.contact.adapter.ContactAdapter
 import net.blueshell.api.platform.integration.contact.adapter.ContactData
-import net.blueshell.api.platform.integration.contact.adapter.ContactServiceException
 import net.blueshell.api.shared.enums.ContactSystem
-import net.blueshell.clients.brevo.ApiClient
 import net.blueshell.clients.brevo.api.ContactsApi
 import net.blueshell.clients.brevo.model.CreateContactRequest
 import net.blueshell.clients.brevo.model.CreateContactRequestAttributesValue
 import net.blueshell.clients.brevo.model.UpdateContactRequest
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Profile
-import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter
 import org.springframework.stereotype.Service
-import org.springframework.web.client.RestClient
 import org.springframework.web.client.RestClientResponseException
 import tools.jackson.databind.json.JsonMapper
 
 /**
  * Brevo Anti-Corruption Layer (ADR-019)
  *
- * Implements [ContactSystemAdapter] against the Brevo Contacts API.
- * Active in production only (test/dev use MockContactAdapter).
- *
- * [contributionPeriodsFolder] is the Brevo folder ID under which all contribution-period
- * lists are created; the domain-level [folderName] hint is intentionally ignored because
- * Brevo organises lists by numeric folder ID, not by name.
+ * Implements [ContactAdapter] against the Brevo Contacts API.
+ * Active in production only (test/dev use MockContactAdapter). The [ContactsApi]
+ * client is wired by [BrevoClientConfig] so this class stays free of HTTP setup
+ * and can be unit-tested with a mock client.
  */
 @Service
 @Profile("!test & !dev")
 class BrevoContactAdapter(
-    restClientBuilder: RestClient.Builder,
-    jsonMapper: JsonMapper,
-    // `contactsApi` below is a class-level property initializer that
-    // runs during the constructor, *before* Spring's field injection.
-    // Using `@field:Value lateinit var` for these values crashed the
-    // pod with `UninitializedPropertyAccessException` at startup
-    // because the initializer read `brevoBaseUrl` before it had been
-    // set. `@param:Value` resolves at constructor-argument time and
-    // is in scope for the initializer below.
-    @param:Value($$"${brevo.apiKey:}") private val apiKey: String,
-    @param:Value($$"${brevo.baseUrl:https://api.brevo.com/v3}") private val brevoBaseUrl: String,
+    private val contactsApi: ContactsApi,
+    private val jsonMapper: JsonMapper,
 ) : ContactAdapter {
 
     override val system = ContactSystem.BREVO
-
-    private val contactsApi: ContactsApi =
-        ContactsApi(
-            ApiClient(
-                restClientBuilder.baseUrl(brevoBaseUrl).defaultHeader("api-key", apiKey)
-                .configureMessageConverters {
-                    it.addCustomConverter(JacksonJsonHttpMessageConverter(jsonMapper))
-                }.build()))
 
     // ── Contact operations ─────────────────────────────────────────────────────
 
@@ -70,8 +45,12 @@ class BrevoContactAdapter(
             log.info("Created Brevo contact id={} for {}", response.id, data.email)
             response.id!!
         } catch (e: RestClientResponseException) {
+            val error = parseBrevoError(e)
+            if (error?.code == DUPLICATE_PARAMETER) {
+                return adoptExistingContact(data, error, e)
+            }
             log.error("Failed to create Brevo contact for {}", data.email, e)
-            throw ContactServiceException("Failed to create contact", e)
+            throw BrevoApiException(e.statusCode.value(), error?.code, error?.message, "createContact", e)
         }
     }
 
@@ -87,7 +66,8 @@ class BrevoContactAdapter(
             log.info("Updated Brevo contact id={}", externalId)
         } catch (e: RestClientResponseException) {
             log.error("Failed to update Brevo contact id={}", externalId, e)
-            throw ContactServiceException("Failed to update contact", e)
+            val error = parseBrevoError(e)
+            throw BrevoApiException(e.statusCode.value(), error?.code, error?.message, "updateContact", e)
         }
     }
 
@@ -97,7 +77,67 @@ class BrevoContactAdapter(
             contactsApi.deleteContact(externalId.toString(), "contact_id")
         } catch (e: RestClientResponseException) {
             log.error("Failed to delete Brevo contact id={}", externalId, e)
-            throw ContactServiceException("Failed to delete contact", e)
+            val error = parseBrevoError(e)
+            throw BrevoApiException(e.statusCode.value(), error?.code, error?.message, "deleteContact", e)
+        }
+    }
+
+    /**
+     * Brevo rejected the create because the contact already exists. Look the
+     * existing contact up by the duplicated identifier, push the intended
+     * attributes onto it, and adopt its id so the sync records the mapping and
+     * future runs take the update path.
+     */
+    private fun adoptExistingContact(
+        data: ContactData,
+        error: BrevoError,
+        cause: RestClientResponseException,
+    ): Long {
+        val duplicates = error.duplicateIdentifiers.map { BrevoDuplicateIdentifier.from(it) }.toSet()
+        log.warn("Brevo reports duplicate {} for {}; adopting existing contact", duplicates, data.email)
+        val existingId = resolveExistingId(data, duplicates)
+            ?: throw BrevoDuplicateContactException(duplicates, data.email, data.phoneNumber, cause)
+        updateContact(existingId, data)
+        log.info("Adopted existing Brevo contact id={} for {}", existingId, data.email)
+        return existingId
+    }
+
+    private fun resolveExistingId(data: ContactData, duplicates: Set<BrevoDuplicateIdentifier>): Long? {
+        if (BrevoDuplicateIdentifier.EMAIL in duplicates) {
+            lookupContactId(data.email, "email_id")?.let { return it }
+        }
+        if (BrevoDuplicateIdentifier.SMS in duplicates) {
+            data.phoneNumber?.let { phone -> lookupContactId(phone, "phone_id")?.let { return it } }
+        }
+        // Best-effort fallback: the email is our stable identifier, try it even
+        // when Brevo flagged a different (or unknown) field.
+        return lookupContactId(data.email, "email_id")
+    }
+
+    private fun lookupContactId(identifier: String, identifierType: String): Long? =
+        try {
+            contactsApi.getContactInfo(identifier, identifierType, null, null).id
+        } catch (e: RestClientResponseException) {
+            log.warn("Brevo lookup by {}={} failed: {}", identifierType, identifier, e.statusCode)
+            null
+        }
+
+    private fun parseBrevoError(e: RestClientResponseException): BrevoError? {
+        val body = e.responseBodyAsString.takeIf { it.isNotBlank() } ?: return null
+        return try {
+            val map = jsonMapper.readValue(body, Map::class.java)
+            val metadata = map["metadata"] as? Map<*, *>
+            val ids = (metadata?.get("duplicate_identifiers") as? List<*>)
+                ?.mapNotNull { it as? String }
+                ?: emptyList()
+            BrevoError(
+                code = map["code"] as? String,
+                message = map["message"] as? String,
+                duplicateIdentifiers = ids,
+            )
+        } catch (ex: Exception) {
+            log.warn("Could not parse Brevo error body: {}", body, ex)
+            null
         }
     }
 
@@ -117,7 +157,15 @@ class BrevoContactAdapter(
         return attrs
     }
 
+    /** Parsed shape of a Brevo error response body. */
+    private data class BrevoError(
+        val code: String?,
+        val message: String?,
+        val duplicateIdentifiers: List<String>,
+    )
+
     companion object {
         private val log = LoggerFactory.getLogger(BrevoContactAdapter::class.java)
+        private const val DUPLICATE_PARAMETER = "duplicate_parameter"
     }
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoExceptions.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoExceptions.kt
@@ -1,0 +1,58 @@
+package net.blueshell.api.platform.integration.contact.adapter.brevo
+
+import net.blueshell.api.platform.integration.contact.adapter.ContactServiceException
+
+/**
+ * Which Brevo unique identifier collided on a create. Brevo reports these in
+ * the error body under `metadata.duplicate_identifiers` (e.g. `["email"]`).
+ */
+enum class BrevoDuplicateIdentifier {
+    EMAIL,
+    SMS,
+    OTHER;
+
+    companion object {
+        fun from(raw: String): BrevoDuplicateIdentifier = when (raw.trim().lowercase()) {
+            "email" -> EMAIL
+            "sms" -> SMS
+            else -> OTHER
+        }
+    }
+}
+
+/**
+ * A Brevo Contacts API call failed with a structured error we could not recover
+ * from. Carries the parsed HTTP status, Brevo error code and human-readable
+ * message so the cause is visible without digging through the response body.
+ */
+class BrevoApiException(
+    val statusCode: Int,
+    val brevoCode: String?,
+    val brevoMessage: String?,
+    operation: String,
+    cause: Throwable? = null,
+) : ContactServiceException(buildMessage(statusCode, brevoCode, brevoMessage, operation), cause) {
+    companion object {
+        private fun buildMessage(status: Int, code: String?, message: String?, operation: String): String {
+            val codePart = code?.let { " $it" } ?: ""
+            val messagePart = message?.let { " — $it" } ?: ""
+            return "Brevo $operation failed: $status$codePart$messagePart"
+        }
+    }
+}
+
+/**
+ * Brevo rejected a create because the contact already exists, but the existing
+ * contact could not be looked up by any of the duplicated identifiers (so it
+ * could not be adopted). Surfaces exactly which identifiers collided.
+ */
+class BrevoDuplicateContactException(
+    val duplicates: Set<BrevoDuplicateIdentifier>,
+    val email: String?,
+    val phone: String?,
+    cause: Throwable? = null,
+) : ContactServiceException(
+    "Brevo contact already exists (duplicate ${duplicates.joinToString(", ")}) " +
+        "but could not be resolved for email=$email phone=$phone",
+    cause,
+)

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoContactAdapterTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoContactAdapterTest.kt
@@ -1,0 +1,105 @@
+package net.blueshell.api.platform.integration.contact.adapter.brevo
+
+import net.blueshell.api.platform.integration.contact.adapter.ContactData
+import net.blueshell.clients.brevo.api.ContactsApi
+import net.blueshell.clients.brevo.model.CreateContact201Response
+import net.blueshell.clients.brevo.model.CreateContactRequest
+import net.blueshell.clients.brevo.model.GetContactInfo200Response
+import net.blueshell.clients.brevo.model.UpdateContactRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.web.client.RestClientResponseException
+import tools.jackson.databind.json.JsonMapper
+
+class BrevoContactAdapterTest {
+
+    private val contactsApi: ContactsApi = mock()
+    private val adapter = BrevoContactAdapter(contactsApi, JsonMapper.builder().build())
+
+    private val data = ContactData(
+        email = "alice@example.com",
+        firstName = "Alice",
+        lastName = "Smith",
+        phoneNumber = "+31612345678",
+        newsletter = true,
+        isMember = true,
+    )
+
+    @Test
+    fun `createContact returns the new id on success`() {
+        whenever(contactsApi.createContact(any())).thenReturn(CreateContact201Response().id(42L))
+
+        assertThat(adapter.createContact(data)).isEqualTo(42L)
+    }
+
+    @Test
+    fun `duplicate email adopts the existing contact and pushes attributes`() {
+        whenever(contactsApi.createContact(any())).thenThrow(duplicateError("email"))
+        whenever(contactsApi.getContactInfo(eq(data.email), eq("email_id"), anyOrNull(), anyOrNull()))
+            .thenReturn(GetContactInfo200Response().id(99L))
+
+        val id = adapter.createContact(data)
+
+        assertThat(id).isEqualTo(99L)
+        verify(contactsApi).updateContact(eq(data.email), any<UpdateContactRequest>(), eq("email_id"))
+    }
+
+    @Test
+    fun `duplicate SMS adopts the existing contact looked up by phone`() {
+        whenever(contactsApi.createContact(any())).thenThrow(duplicateError("SMS"))
+        whenever(contactsApi.getContactInfo(eq(data.phoneNumber!!), eq("phone_id"), anyOrNull(), anyOrNull()))
+            .thenReturn(GetContactInfo200Response().id(77L))
+
+        assertThat(adapter.createContact(data)).isEqualTo(77L)
+    }
+
+    @Test
+    fun `duplicate that cannot be resolved throws BrevoDuplicateContactException`() {
+        whenever(contactsApi.createContact(any())).thenThrow(duplicateError("email"))
+        whenever(contactsApi.getContactInfo(any(), any(), anyOrNull(), anyOrNull()))
+            .thenThrow(notFound())
+
+        assertThatThrownBy { adapter.createContact(data) }
+            .isInstanceOf(BrevoDuplicateContactException::class.java)
+        verify(contactsApi, never()).updateContact(any(), any<UpdateContactRequest>(), any())
+    }
+
+    @Test
+    fun `non-duplicate error surfaces as BrevoApiException with parsed code`() {
+        whenever(contactsApi.createContact(any())).thenThrow(
+            error(400, """{"code":"invalid_parameter","message":"Invalid email"}"""),
+        )
+
+        assertThatThrownBy { adapter.createContact(data) }
+            .isInstanceOf(BrevoApiException::class.java)
+            .hasMessageContaining("invalid_parameter")
+            .hasMessageContaining("Invalid email")
+    }
+
+    private fun duplicateError(identifier: String): RestClientResponseException =
+        error(
+            400,
+            """{"code":"duplicate_parameter","message":"$identifier is already associated with another Contact",""" +
+                """"metadata":{"duplicate_identifiers":["$identifier"]}}""",
+        )
+
+    private fun notFound(): RestClientResponseException = error(404, """{"code":"document_not_found"}""")
+
+    private fun error(status: Int, body: String): RestClientResponseException =
+        RestClientResponseException(
+            "$status error",
+            status,
+            "error",
+            null,
+            body.toByteArray(),
+            null,
+        )
+}


### PR DESCRIPTION
## Why
Brevo contact sync failed for users who already exist in Brevo. The adapter caught every `RestClientResponseException` and rethrew a flat `ContactServiceException("Failed to create contact", e)`, so the structured Brevo body — `duplicate_parameter` plus `metadata.duplicate_identifiers: ["email"|"SMS"]` — was buried in the cause. A create for an already-known email or phone returns `400 duplicate_parameter`, and the sync job then failed permanently for that user.

## What this achieves
- Users already present in Brevo are reconciled instead of failing: the existing contact is found, updated with the intended attributes, and its id is adopted so the external-id mapping is recorded and subsequent syncs take the update path.
- Failures carry their cause on the surface. `BrevoApiException` reports the HTTP status, Brevo error code and message; an unresolvable duplicate reports which identifiers collided.

## How
- `BrevoContactAdapter.createContact` is now create-or-adopt. On `duplicate_parameter` it resolves the existing contact via `getContactInfo` (`email` → `email_id`, `SMS` → `phone_id`, with an email fallback), calls `updateContact`, and returns the adopted id. `parseBrevoError` reads `code` / `message` / `duplicate_identifiers` from the response body.
- New exceptions in `contact/adapter/brevo/BrevoExceptions.kt`: `BrevoApiException` (status + code + message) and `BrevoDuplicateContactException` (collided identifiers). `ContactServiceException` is now `open` so both extend it and existing catch sites and arch rules still hold.
- `ContactsApi` construction moves to `BrevoClientConfig`, so the adapter carries no HTTP setup and is unit-tested against a mock client (`BrevoContactAdapterTest`, 5 cases covering success, duplicate email, duplicate SMS, unresolvable duplicate, and a non-duplicate error).