### PR TITLE
fix(frontend): start event calendar weeks on Monday

### DIFF
--- a/services/frontend/src/components/base/EventCalendar.vue
+++ b/services/frontend/src/components/base/EventCalendar.vue
@@ -60,7 +60,7 @@
     v-model="displayedMonth"
     :events="calendarEvents"
     :show-adjacent-months="true"
-    :weekdays="[1, 2, 3, 4, 5, 6, 0]"
+    :first-day-of-week="1"
     type="month"
     @click:event="showEvent"
   />


### PR DESCRIPTION
## Why
The event calendar rendered its weeks starting on Friday instead of Monday. The `:weekdays` array reorders the displayed columns but does not change which day Vuetify treats as the first day of the week, so the month grid laid out adjacent-month days and weekday headers against the wrong anchor.

## What this achieves
The month view now begins each week on Monday, matching the expected European weekday layout.

## How
`services/frontend/src/components/base/EventCalendar.vue` now passes `:first-day-of-week="1"` to the Vuetify calendar instead of the custom `:weekdays="[1, 2, 3, 4, 5, 6, 0]"` ordering. `first-day-of-week` is the property Vuetify uses to anchor the grid, so weekday headers and adjacent-month fills align correctly.