### PR TITLE
Supersede sibling jobs matched by payload, not just dedup key

### DIFF
--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/job/web/JobManagementControllerIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/job/web/JobManagementControllerIT.kt
@@ -224,19 +224,25 @@ class JobManagementControllerIT : UserTestSupport() {
         fun `retry supersedes other jobs of the same kind and args`() {
             val admin = createUserWithRole(Role.ADMIN)
 
+            // Payloads track the dedup keys: same args share a payload, different
+            // args differ. (Production never has same payload but different dedup
+            // key, since the dedup key is derived from the payload.)
             val target = createJobExecutionFixture(jobType = "supersede-target")
             target.status = JobExecutionStatus.FAILED
             target.dedupKey = "user-1"
+            target.payload = """{"userId":1}"""
             jobExecutions.saveAndFlush(target)
 
             val sibling = createJobExecutionFixture(jobType = "supersede-target")
             sibling.status = JobExecutionStatus.FAILED
             sibling.dedupKey = "user-1"
+            sibling.payload = """{"userId":1}"""
             jobExecutions.saveAndFlush(sibling)
 
             val differentArgs = createJobExecutionFixture(jobType = "supersede-target")
             differentArgs.status = JobExecutionStatus.FAILED
             differentArgs.dedupKey = "user-2"
+            differentArgs.payload = """{"userId":2}"""
             jobExecutions.saveAndFlush(differentArgs)
 
             mvc.perform(post("/management/jobs/{id}/retry", target.id).with(bearer(admin)))

--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/job/web/JobManagementControllerIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/job/web/JobManagementControllerIT.kt
@@ -250,6 +250,37 @@ class JobManagementControllerIT : UserTestSupport() {
         }
 
         @Test
+        fun `retry supersedes dedup-less siblings matched by payload`() {
+            val admin = createUserWithRole(Role.ADMIN)
+
+            // dedupKey left null on purpose: these must match by payload, which
+            // requires the native LONGTEXT comparison (a derived query never matches).
+            val target = createJobExecutionFixture(jobType = "payload-supersede")
+            target.status = JobExecutionStatus.FAILED
+            target.payload = """{"userId":42}"""
+            jobExecutions.saveAndFlush(target)
+
+            val sibling = createJobExecutionFixture(jobType = "payload-supersede")
+            sibling.status = JobExecutionStatus.FAILED
+            sibling.payload = """{"userId":42}"""
+            jobExecutions.saveAndFlush(sibling)
+
+            val differentArgs = createJobExecutionFixture(jobType = "payload-supersede")
+            differentArgs.status = JobExecutionStatus.FAILED
+            differentArgs.payload = """{"userId":99}"""
+            jobExecutions.saveAndFlush(differentArgs)
+
+            mvc.perform(post("/management/jobs/{id}/retry", target.id).with(bearer(admin)))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.status").value("QUEUED"))
+
+            assertThat(jobExecutions.findById(sibling.id!!).orElseThrow().status)
+                .isEqualTo(JobExecutionStatus.DEAD)
+            assertThat(jobExecutions.findById(differentArgs.id!!).orElseThrow().status)
+                .isEqualTo(JobExecutionStatus.FAILED)
+        }
+
+        @Test
         fun `admin cannot retry queued job`() {
             val admin = createUserWithRole(Role.ADMIN)
             val job = createJobExecutionFixture(jobType = "queued-target")

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/job/application/service/JobExecutionService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/job/application/service/JobExecutionService.kt
@@ -176,14 +176,17 @@ class JobExecutionService(
     }
 
     private fun supersedeSiblings(execution: JobExecution) {
-        val siblings = when {
-            execution.dedupKey != null ->
-                jobExecutionRepository.findByJobTypeAndDedupKey(execution.jobType, execution.dedupKey!!)
-            execution.payload != null ->
-                jobExecutionRepository.findByJobTypeAndPayload(execution.jobType, execution.payload!!)
-            else -> emptyList()
-        }
-        siblings
+        // Match on both keys and union: a sibling counts as the same kind+args if
+        // it shares the dedup key OR the payload. Jobs that opt out of dedup
+        // (dedupKey == null) are only reachable via the payload match.
+        val byDedup = execution.dedupKey
+            ?.let { jobExecutionRepository.findByJobTypeAndDedupKey(execution.jobType, it) }
+            ?: emptyList()
+        val byPayload = execution.payload
+            ?.let { jobExecutionRepository.findByJobTypeAndPayload(execution.jobType, it) }
+            ?: emptyList()
+        (byDedup + byPayload)
+            .distinctBy { it.id }
             .filter { it.id != execution.id && it.status != JobExecutionStatus.DEAD }
             .forEach {
                 markDead(it, "SupersededByRetry", "Superseded by manual retry of job ${execution.id}")

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/job/persistence/repository/JobExecutionRepository.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/job/persistence/repository/JobExecutionRepository.kt
@@ -4,6 +4,8 @@ import net.blueshell.api.platform.integration.job.persistence.JobExecution
 import net.blueshell.api.shared.enums.JobExecutionStatus
 import net.blueshell.api.shared.repository.BaseRepository
 import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.time.Instant
 
 interface JobExecutionRepository : BaseRepository<JobExecution, Long> {
@@ -13,7 +15,22 @@ interface JobExecutionRepository : BaseRepository<JobExecution, Long> {
 
     fun findByJobTypeAndDedupKey(jobType: String, dedupKey: String): List<JobExecution>
 
-    fun findByJobTypeAndPayload(jobType: String, payload: String): List<JobExecution>
+    /**
+     * Native equality match on [JobExecution.payload]. A derived query binds the
+     * `@Lob` payload as a CLOB, which MariaDB never matches against the LONGTEXT
+     * column, so the comparison must run as native SQL with a plain string bind.
+     * Mirrors the soft-delete `@SQLRestriction` since native SQL bypasses it.
+     */
+    @Query(
+        value = "SELECT * FROM job_executions " +
+            "WHERE job_type = :jobType AND payload = :payload " +
+            "AND deleted_at = '9999-12-31 23:59:59'",
+        nativeQuery = true,
+    )
+    fun findByJobTypeAndPayload(
+        @Param("jobType") jobType: String,
+        @Param("payload") payload: String,
+    ): List<JobExecution>
 
     fun existsByJobTypeAndDedupKeyAndStatusIn(
         jobType: String,

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/job/application/service/JobExecutionServiceTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/job/application/service/JobExecutionServiceTest.kt
@@ -195,6 +195,26 @@ class JobExecutionServiceTest {
         assertThat(target.status).isEqualTo(JobExecutionStatus.QUEUED)
     }
 
+    @Test
+    fun `retryWithSupersede unions dedup and payload matches without double-marking`() {
+        val target = jobExecution(1L, dedupKey = "k", payload = """{"userId":9}""", status = JobExecutionStatus.FAILED)
+        val dedupSibling = jobExecution(2L, dedupKey = "k", payload = """{"userId":9}""", status = JobExecutionStatus.FAILED)
+        // Same args but enqueued without a dedup key: only reachable via payload match.
+        val payloadOnlySibling = jobExecution(3L, dedupKey = null, payload = """{"userId":9}""", status = JobExecutionStatus.FAILED)
+        whenever(repository.findByJobTypeAndDedupKey("contact.sync", "k"))
+            .thenReturn(listOf(target, dedupSibling))
+        whenever(repository.findByJobTypeAndPayload("contact.sync", """{"userId":9}"""))
+            .thenReturn(listOf(target, dedupSibling, payloadOnlySibling))
+        whenever(repository.existsById(any())).thenReturn(true)
+        whenever(repository.saveAndFlush(any<JobExecution>())).thenAnswer { it.arguments[0] }
+
+        service.retryWithSupersede(target)
+
+        assertThat(dedupSibling.status).isEqualTo(JobExecutionStatus.DEAD)
+        assertThat(payloadOnlySibling.status).isEqualTo(JobExecutionStatus.DEAD)
+        assertThat(target.status).isEqualTo(JobExecutionStatus.QUEUED)
+    }
+
     private fun jobExecution(
         id: Long,
         dedupKey: String?,


### PR DESCRIPTION
## Why
Retrying a job was meant to mark every other execution of the same kind and arguments DEAD, collapsing the list to one canonical job. It only worked for jobs that share a dedup key. Jobs enqueued without a dedup key (anything whose definition opts out of deduplication) fell back to matching siblings by payload equality — but that ran as a Spring Data derived query against the `@Lob` payload column. Hibernate binds an `@Lob` String parameter as a CLOB, which MariaDB never matches against the `LONGTEXT` column, so the query returned nothing and no siblings were superseded. Raw SQL equality on the same column matches fine, confirming the binding (not the data) was the problem.

## What this achieves
Retrying a job now reliably marks its same-args siblings DEAD whether they were enqueued with a dedup key, without one, or a mix of both.

## How
- `JobExecutionRepository.findByJobTypeAndPayload` becomes a native query so the payload is bound as a plain string and compared correctly against `LONGTEXT`; it also re-applies the soft-delete sentinel that native SQL would otherwise bypass.
- `JobExecutionService.supersedeSiblings` queries by dedup key and by payload and unions the results (deduplicated by id), so a sibling counts as the same kind+args via either identifier.
- Tests: a unit test covers the union path (a payload-only sibling is superseded alongside dedup-key siblings, with no double-marking); an integration test retries a job whose siblings share only a payload (null dedup key) and asserts they go DEAD while a different-payload job stays untouched — exercising the native LONGTEXT comparison end to end.