### PR TITLE
Self-heal sync pairing, attribute fallthroughs, idempotent list ops, nightly period lists

### DIFF
--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/domain/contribution/web/ContributionContactSyncIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/domain/contribution/web/ContributionContactSyncIT.kt
@@ -48,7 +48,7 @@ class ContributionContactSyncIT : UserTestSupport() {
             .andExpect(status().isCreated)
 
         awaitJobSuccess(ContactJobs.ProcessListMembership.type)
-        awaitJobSuccess(ContactJobs.SyncListMembershipToSystem.type)
+        awaitJobSuccess(ContactJobs.SyncListMembership.type)
 
         val lists = mockContactAdapter.getAllLists()
         assertThat(lists).hasSize(1)
@@ -78,7 +78,7 @@ class ContributionContactSyncIT : UserTestSupport() {
             .andExpect(status().isCreated)
 
         awaitJobSuccess(ContactJobs.ProcessListMembership.type)
-        awaitJobSuccess(ContactJobs.SyncListMembershipToSystem.type)
+        awaitJobSuccess(ContactJobs.SyncListMembership.type)
 
         val listId = mockContactAdapter.getAllLists().keys.single()
         val contactId = mockContactAdapter.getAllContacts().keys.single()
@@ -96,7 +96,7 @@ class ContributionContactSyncIT : UserTestSupport() {
             .andExpect(status().isNoContent)
 
         awaitJobSuccess(ContactJobs.ProcessListMembership.type, expectedCount = 2)
-        awaitJobSuccess(ContactJobs.SyncListMembershipToSystem.type, expectedCount = 2)
+        awaitJobSuccess(ContactJobs.SyncListMembership.type, expectedCount = 2)
 
         assertThat(mockContactAdapter.isInList(contactId, listId)).isFalse()
     }

--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/contact/job/SyncListMembershipJobIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/contact/job/SyncListMembershipJobIT.kt
@@ -103,7 +103,7 @@ class SyncListMembershipJobIT : UserTestSupport() {
         val contactList = contactListRepository.findAll().single()
 
         // Wait for per-integration list sync
-        awaitJobSuccess(ContactJobs.SyncListMembershipToSystem.type)
+        awaitJobSuccess(ContactJobs.SyncListMembership.type)
 
         val record = contactRepository.findByUserId(user.id!!)
         assertThat(record).describedAs("Contact should be created for user").isNotNull()
@@ -123,7 +123,7 @@ class SyncListMembershipJobIT : UserTestSupport() {
             objectMapper.writeValueAsString(ContactJobs.ProcessListMembershipPayload(user.id!!, period.id!!))
         )
 
-        awaitJobSuccess(ContactJobs.SyncListMembershipToSystem.type)
+        awaitJobSuccess(ContactJobs.SyncListMembership.type)
 
         val contactId = mockContactAdapter.getAllContacts().keys.single()
         val externalListId = mockContactAdapter.getAllLists().keys.single()
@@ -142,7 +142,7 @@ class SyncListMembershipJobIT : UserTestSupport() {
         syncListMembershipJob.handle(
             objectMapper.writeValueAsString(ContactJobs.ProcessListMembershipPayload(user.id!!, period.id!!))
         )
-        awaitJobSuccess(ContactJobs.SyncListMembershipToSystem.type)
+        awaitJobSuccess(ContactJobs.SyncListMembership.type)
 
         val record = contactRepository.findByUserId(user.id!!)!!
         val contactList = contactListRepository.findAll().single()
@@ -164,7 +164,7 @@ class SyncListMembershipJobIT : UserTestSupport() {
         syncListMembershipJob.handle(
             objectMapper.writeValueAsString(ContactJobs.ProcessListMembershipPayload(user.id!!, period.id!!))
         )
-        awaitJobSuccess(ContactJobs.SyncListMembershipToSystem.type, expectedCount = 2)
+        awaitJobSuccess(ContactJobs.SyncListMembership.type, expectedCount = 2)
 
         assertThat(
             contactListMembershipRepository.findByContactIdAndContactListId(record.id!!, contactList.id!!)

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/ContactAdapter.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/ContactAdapter.kt
@@ -16,6 +16,14 @@ interface ContactAdapter {
     val system: ContactSystem
 
     fun createContact(data: ContactData): Long
-    fun updateContact(externalId: Long, data: ContactData)
+
+    /**
+     * Updates the contact and returns its current external id. The returned id is
+     * usually the same one passed in, but adapters may repair stale pairing on
+     * the fly (e.g. when the external contact was deleted) and return a new id;
+     * the orchestration layer persists the result so the mapping stays correct.
+     */
+    fun updateContact(externalId: Long, data: ContactData): Long
+
     fun deleteContact(externalId: Long)
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/ContactAdapter.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/ContactAdapter.kt
@@ -17,12 +17,7 @@ interface ContactAdapter {
 
     fun createContact(data: ContactData): Long
 
-    /**
-     * Updates the contact and returns its current external id. The returned id is
-     * usually the same one passed in, but adapters may repair stale pairing on
-     * the fly (e.g. when the external contact was deleted) and return a new id;
-     * the orchestration layer persists the result so the mapping stays correct.
-     */
+    /** Updates the contact and returns its current external id (which adapters may rewrite when repairing stale pairing). */
     fun updateContact(externalId: Long, data: ContactData): Long
 
     fun deleteContact(externalId: Long)

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/ExternalContactGoneException.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/ExternalContactGoneException.kt
@@ -1,0 +1,18 @@
+package net.blueshell.api.platform.integration.contact.adapter
+
+import net.blueshell.api.shared.enums.ContactSystem
+
+/**
+ * Provider-neutral signal that the external contact at [externalContactId] no
+ * longer exists in [system]. Thrown by [ContactAdapter] / [ContactListAdapter]
+ * implementations so the orchestration layer can clear the stale pairing and
+ * trigger a contact resync without depending on a provider-specific exception.
+ */
+class ExternalContactGoneException(
+    val system: ContactSystem,
+    val externalContactId: Long,
+    cause: Throwable? = null,
+) : ContactServiceException(
+    "Contact $externalContactId does not exist in $system",
+    cause,
+)

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoContactAdapter.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoContactAdapter.kt
@@ -16,10 +16,21 @@ import tools.jackson.databind.json.JsonMapper
 /**
  * Brevo Anti-Corruption Layer (ADR-019)
  *
- * Implements [ContactAdapter] against the Brevo Contacts API.
- * Active in production only (test/dev use MockContactAdapter). The [ContactsApi]
- * client is wired by [BrevoClientConfig] so this class stays free of HTTP setup
- * and can be unit-tested with a mock client.
+ * Implements [ContactAdapter] against the Brevo Contacts API. Active in
+ * production only (test/dev use MockContactAdapter). The [ContactsApi] client
+ * is wired by [BrevoClientConfig] so this class stays free of HTTP setup and
+ * can be unit-tested with a mock client.
+ *
+ * Recovery semantics:
+ * - Update routes by `contact_id`, never by `email_id`, so the adopt-then-update
+ *   path acts on the contact we actually resolved.
+ * - A `document_not_found` on update means the stored Brevo id is stale; we
+ *   transparently recreate (which may adopt a different existing contact) and
+ *   return the new id so the orchestration layer repairs the mapping.
+ * - When Brevo rejects a write because a specific identifier (`SMS`,
+ *   `WHATSAPP`, `EXT_ID`) is already taken or invalid (typically a malformed
+ *   phone), we retry the same write with that attribute dropped, so the rest
+ *   of the contact still syncs.
  */
 @Service
 @Profile("!test & !dev")
@@ -32,42 +43,17 @@ class BrevoContactAdapter(
 
     // ── Contact operations ─────────────────────────────────────────────────────
 
-    override fun createContact(data: ContactData): Long {
-        log.info("Creating Brevo contact: {}", data.email)
-        return try {
-            val req = CreateContactRequest()
-            req.email = data.email
-            req.extId = data.email   // Brevo extId used for dedup
-            @Suppress("UNCHECKED_CAST")
-            val createAttrs = buildAttributes(data) as Map<String?, CreateContactRequestAttributesValue?>?
-            req.attributes = createAttrs
-            val response = contactsApi.createContact(req)
-            log.info("Created Brevo contact id={} for {}", response.id, data.email)
-            response.id!!
-        } catch (e: RestClientResponseException) {
-            val error = parseBrevoError(e)
-            if (error?.code == DUPLICATE_PARAMETER) {
-                return adoptExistingContact(data, error, e)
-            }
-            log.error("Failed to create Brevo contact for {}", data.email, e)
-            throw BrevoApiException(e.statusCode.value(), error?.code, error?.message, "createContact", e)
-        }
-    }
+    override fun createContact(data: ContactData): Long = createOrAdopt(data, omittedAttrs = emptySet())
 
-    override fun updateContact(externalId: Long, data: ContactData) {
-        log.info("Updating Brevo contact id={}: {}", externalId, data.email)
-        try {
-            val req = UpdateContactRequest()
-            req.extId = data.email
-            @Suppress("UNCHECKED_CAST")
-            val updateAttrs = buildAttributes(data) as Map<String?, CreateContactRequestAttributesValue?>?
-            req.attributes = updateAttrs
-            contactsApi.updateContact(data.email, req, "email_id")
-            log.info("Updated Brevo contact id={}", externalId)
-        } catch (e: RestClientResponseException) {
-            log.error("Failed to update Brevo contact id={}", externalId, e)
-            val error = parseBrevoError(e)
-            throw BrevoApiException(e.statusCode.value(), error?.code, error?.message, "updateContact", e)
+    override fun updateContact(externalId: Long, data: ContactData): Long {
+        return try {
+            updateById(externalId, data, omittedAttrs = emptySet())
+        } catch (e: BrevoContactGoneException) {
+            // Stale local mapping: the Brevo contact was deleted or merged. Fall
+            // through to create-or-adopt so the next external id replaces the
+            // dead one in external_id_mapping.
+            log.warn("Brevo contact {} is gone; repairing pairing by re-creating", externalId, e)
+            createOrAdopt(data, omittedAttrs = emptySet())
         }
     }
 
@@ -76,17 +62,46 @@ class BrevoContactAdapter(
         try {
             contactsApi.deleteContact(externalId.toString(), "contact_id")
         } catch (e: RestClientResponseException) {
+            val error = parseBrevoError(e, jsonMapper)
+            if (error?.code == DOCUMENT_NOT_FOUND) {
+                // Already gone — treat as a successful delete.
+                log.info("Brevo contact {} was already gone on delete", externalId)
+                return
+            }
             log.error("Failed to delete Brevo contact id={}", externalId, e)
-            val error = parseBrevoError(e)
             throw BrevoApiException(e.statusCode.value(), error?.code, error?.message, "deleteContact", e)
         }
     }
 
+    // ── Internal helpers ──────────────────────────────────────────────────────
+
+    private fun createOrAdopt(data: ContactData, omittedAttrs: Set<String>): Long {
+        log.info("Creating Brevo contact: {} (omit={})", data.email, omittedAttrs)
+        try {
+            val response = contactsApi.createContact(buildCreateRequest(data, omittedAttrs))
+            log.info("Created Brevo contact id={} for {}", response.id, data.email)
+            return response.id!!
+        } catch (e: RestClientResponseException) {
+            val error = parseBrevoError(e, jsonMapper)
+            return when {
+                error?.code == DUPLICATE_PARAMETER -> adoptExistingContact(data, error, e)
+                shouldDropPhone(error, omittedAttrs) -> {
+                    log.warn("Brevo create rejected phone for {}; retrying without SMS/WHATSAPP", data.email)
+                    createOrAdopt(data, omittedAttrs + PHONE_ATTRS)
+                }
+                else -> {
+                    log.error("Failed to create Brevo contact for {}", data.email, e)
+                    throw BrevoApiException(e.statusCode.value(), error?.code, error?.message, "createContact", e)
+                }
+            }
+        }
+    }
+
     /**
-     * Brevo rejected the create because the contact already exists. Look the
-     * existing contact up by the duplicated identifier, push the intended
-     * attributes onto it, and adopt its id so the sync records the mapping and
-     * future runs take the update path.
+     * Brevo rejected a create because the contact already exists. Look the
+     * existing contact up by the duplicated identifier and push the intended
+     * attributes onto it, returning that id so the orchestration layer adopts
+     * the pairing.
      */
     private fun adoptExistingContact(
         data: ContactData,
@@ -97,7 +112,10 @@ class BrevoContactAdapter(
         log.warn("Brevo reports duplicate {} for {}; adopting existing contact", duplicates, data.email)
         val existingId = resolveExistingId(data, duplicates)
             ?: throw BrevoDuplicateContactException(duplicates, data.email, data.phoneNumber, cause)
-        updateContact(existingId, data)
+        // Push the intended attributes onto the resolved contact. updateById
+        // updates by contact_id (so we hit the contact we actually resolved)
+        // and falls through on conflicting / invalid attributes.
+        updateById(existingId, data, omittedAttrs = emptySet())
         log.info("Adopted existing Brevo contact id={} for {}", existingId, data.email)
         return existingId
     }
@@ -122,50 +140,103 @@ class BrevoContactAdapter(
             null
         }
 
-    private fun parseBrevoError(e: RestClientResponseException): BrevoError? {
-        val body = e.responseBodyAsString.takeIf { it.isNotBlank() } ?: return null
-        return try {
-            val map = jsonMapper.readValue(body, Map::class.java)
-            val metadata = map["metadata"] as? Map<*, *>
-            val ids = (metadata?.get("duplicate_identifiers") as? List<*>)
-                ?.mapNotNull { it as? String }
-                ?: emptyList()
-            BrevoError(
-                code = map["code"] as? String,
-                message = map["message"] as? String,
-                duplicateIdentifiers = ids,
+    /**
+     * Updates by `contact_id` and retries with the conflicting / invalid
+     * attributes dropped. Returns the same id on success; throws
+     * [BrevoContactGoneException] if Brevo says the contact does not exist.
+     */
+    private fun updateById(externalId: Long, data: ContactData, omittedAttrs: Set<String>): Long {
+        log.info("Updating Brevo contact id={}: {} (omit={})", externalId, data.email, omittedAttrs)
+        try {
+            contactsApi.updateContact(
+                externalId.toString(),
+                buildUpdateRequest(data, omittedAttrs),
+                "contact_id",
             )
-        } catch (ex: Exception) {
-            log.warn("Could not parse Brevo error body: {}", body, ex)
-            null
+            log.info("Updated Brevo contact id={}", externalId)
+            return externalId
+        } catch (e: RestClientResponseException) {
+            val error = parseBrevoError(e, jsonMapper)
+            return when {
+                error?.code == DOCUMENT_NOT_FOUND -> throw BrevoContactGoneException(externalId, e)
+                error?.code == DUPLICATE_PARAMETER -> {
+                    val newOmissions = expandOmissions(error.duplicateIdentifiers, omittedAttrs)
+                    if (newOmissions.size == omittedAttrs.size) {
+                        // Nothing new to drop; can't recover. Surface as a typed error.
+                        log.error("Brevo update on {} conflicted but no attribute can be dropped: {}", externalId, error)
+                        throw BrevoApiException(e.statusCode.value(), error.code, error.message, "updateContact", e)
+                    }
+                    log.warn(
+                        "Brevo update on {} conflicted on {}; retrying without those attrs",
+                        externalId, newOmissions - omittedAttrs,
+                    )
+                    updateById(externalId, data, newOmissions)
+                }
+                shouldDropPhone(error, omittedAttrs) -> {
+                    log.warn("Brevo update on {} rejected phone; retrying without SMS/WHATSAPP", externalId)
+                    updateById(externalId, data, omittedAttrs + PHONE_ATTRS)
+                }
+                else -> {
+                    log.error("Failed to update Brevo contact id={}", externalId, e)
+                    throw BrevoApiException(e.statusCode.value(), error?.code, error?.message, "updateContact", e)
+                }
+            }
         }
     }
 
-    private fun buildAttributes(data: ContactData): Map<String, Any> {
+    private fun buildCreateRequest(data: ContactData, omittedAttrs: Set<String>): CreateContactRequest {
+        val req = CreateContactRequest()
+        req.email = data.email
+        if ("EXT_ID" !in omittedAttrs) req.extId = data.email   // Brevo extId used for dedup
+        @Suppress("UNCHECKED_CAST")
+        req.attributes = buildAttributes(data, omittedAttrs) as Map<String?, CreateContactRequestAttributesValue?>?
+        return req
+    }
+
+    private fun buildUpdateRequest(data: ContactData, omittedAttrs: Set<String>): UpdateContactRequest {
+        val req = UpdateContactRequest()
+        if ("EXT_ID" !in omittedAttrs) req.extId = data.email
+        @Suppress("UNCHECKED_CAST")
+        req.attributes = buildAttributes(data, omittedAttrs) as Map<String?, CreateContactRequestAttributesValue?>?
+        return req
+    }
+
+    private fun buildAttributes(data: ContactData, omittedAttrs: Set<String>): Map<String, Any> {
         val attrs = mutableMapOf<String, Any>(
             "NEWSLETTER" to data.newsletter,
             "IS_MEMBER" to data.isMember,
             "FIRSTNAME" to data.firstName,
             "LASTNAME" to data.lastName,
-            "SURNAME" to data.lastName
+            "SURNAME" to data.lastName,
         )
         data.phoneNumber?.let { phone ->
-            attrs["SMS"] = phone
-            attrs["WHATSAPP"] = phone
+            if ("SMS" !in omittedAttrs) attrs["SMS"] = phone
+            if ("WHATSAPP" !in omittedAttrs) attrs["WHATSAPP"] = phone
         }
-        attrs.putAll(data.attributes)
+        attrs.putAll(data.attributes.filterKeys { it.uppercase() !in omittedAttrs })
         return attrs
     }
 
-    /** Parsed shape of a Brevo error response body. */
-    private data class BrevoError(
-        val code: String?,
-        val message: String?,
-        val duplicateIdentifiers: List<String>,
-    )
+    /**
+     * Expands Brevo's `duplicate_identifiers` into the set of attributes we
+     * should omit. SMS and WHATSAPP carry the same domain value (the phone), so
+     * a conflict on either implies we should drop both.
+     */
+    private fun expandOmissions(duplicateIdentifiers: List<String>, already: Set<String>): Set<String> {
+        val upper = duplicateIdentifiers.map { it.uppercase() }.toMutableSet()
+        if (upper.intersect(PHONE_ATTRS).isNotEmpty()) upper.addAll(PHONE_ATTRS)
+        return already + upper
+    }
+
+    private fun shouldDropPhone(error: BrevoError?, omittedAttrs: Set<String>): Boolean {
+        if (error?.code != INVALID_PARAMETER) return false
+        val message = error.message?.lowercase() ?: return false
+        if (!message.contains("phone")) return false
+        return !omittedAttrs.containsAll(PHONE_ATTRS)
+    }
 
     companion object {
         private val log = LoggerFactory.getLogger(BrevoContactAdapter::class.java)
-        private const val DUPLICATE_PARAMETER = "duplicate_parameter"
+        private val PHONE_ATTRS = setOf("SMS", "WHATSAPP")
     }
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoContactAdapter.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoContactAdapter.kt
@@ -2,6 +2,7 @@ package net.blueshell.api.platform.integration.contact.adapter.brevo
 
 import net.blueshell.api.platform.integration.contact.adapter.ContactAdapter
 import net.blueshell.api.platform.integration.contact.adapter.ContactData
+import net.blueshell.api.platform.integration.contact.adapter.ExternalContactGoneException
 import net.blueshell.api.shared.enums.ContactSystem
 import net.blueshell.clients.brevo.api.ContactsApi
 import net.blueshell.clients.brevo.model.CreateContactRequest
@@ -48,7 +49,7 @@ class BrevoContactAdapter(
     override fun updateContact(externalId: Long, data: ContactData): Long {
         return try {
             updateById(externalId, data, omittedAttrs = emptySet())
-        } catch (e: BrevoContactGoneException) {
+        } catch (e: ExternalContactGoneException) {
             // Stale local mapping: the Brevo contact was deleted or merged. Fall
             // through to create-or-adopt so the next external id replaces the
             // dead one in external_id_mapping.
@@ -158,7 +159,7 @@ class BrevoContactAdapter(
         } catch (e: RestClientResponseException) {
             val error = parseBrevoError(e, jsonMapper)
             return when {
-                error?.code == DOCUMENT_NOT_FOUND -> throw BrevoContactGoneException(externalId, e)
+                error?.code == DOCUMENT_NOT_FOUND -> throw ExternalContactGoneException(system, externalId, e)
                 error?.code == DUPLICATE_PARAMETER -> {
                     val newOmissions = expandOmissions(error.duplicateIdentifiers, omittedAttrs)
                     if (newOmissions.size == omittedAttrs.size) {

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoContactAdapter.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoContactAdapter.kt
@@ -85,7 +85,7 @@ class BrevoContactAdapter(
         } catch (e: RestClientResponseException) {
             val error = parseBrevoError(e, jsonMapper)
             return when {
-                error?.code == DUPLICATE_PARAMETER -> adoptExistingContact(data, error, e)
+                error?.code == DUPLICATE_PARAMETER -> handleCreateDuplicate(data, omittedAttrs, error, e)
                 shouldDropPhone(error, omittedAttrs) -> {
                     log.warn("Brevo create rejected phone for {}; retrying without SMS/WHATSAPP", data.email)
                     createOrAdopt(data, omittedAttrs + PHONE_ATTRS)
@@ -96,6 +96,42 @@ class BrevoContactAdapter(
                 }
             }
         }
+    }
+
+    /**
+     * Decide what to do when Brevo rejected the create with `duplicate_parameter`.
+     *
+     * We only adopt when the duplicated identifier is `EMAIL`, because email is
+     * the stable identity we control: matching emails almost certainly means we
+     * are looking at the same person. Phone- or EXT_ID-only duplicates can
+     * collide on a completely different contact (a partner / family member
+     * sharing a number, or someone whose Brevo `ext_id` happens to match an old
+     * email of ours), so attaching there would corrupt the pairing. In that
+     * case we drop the conflicting attributes and try creating a fresh contact
+     * without them — the rest of the contact still syncs and the colliding
+     * data simply isn't pushed.
+     */
+    private fun handleCreateDuplicate(
+        data: ContactData,
+        omittedAttrs: Set<String>,
+        error: BrevoError,
+        cause: RestClientResponseException,
+    ): Long {
+        val duplicates = error.duplicateIdentifiers.map { BrevoDuplicateIdentifier.from(it) }.toSet()
+        if (BrevoDuplicateIdentifier.EMAIL in duplicates) {
+            return adoptExistingContact(data, error, cause)
+        }
+        val expanded = expandOmissions(error.duplicateIdentifiers, omittedAttrs)
+        if (expanded.size == omittedAttrs.size) {
+            // Brevo reported a duplicate but we don't recognise the identifier,
+            // so we can't drop it. Surface the situation rather than loop.
+            throw BrevoDuplicateContactException(duplicates, data.email, data.phoneNumber, cause)
+        }
+        log.warn(
+            "Brevo create on {} conflicted on non-email identifier(s) {}; retrying without {}",
+            data.email, error.duplicateIdentifiers, expanded - omittedAttrs,
+        )
+        return createOrAdopt(data, expanded)
     }
 
     /**

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoContactAdapter.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoContactAdapter.kt
@@ -15,23 +15,9 @@ import org.springframework.web.client.RestClientResponseException
 import tools.jackson.databind.json.JsonMapper
 
 /**
- * Brevo Anti-Corruption Layer (ADR-019)
- *
- * Implements [ContactAdapter] against the Brevo Contacts API. Active in
- * production only (test/dev use MockContactAdapter). The [ContactsApi] client
- * is wired by [BrevoClientConfig] so this class stays free of HTTP setup and
- * can be unit-tested with a mock client.
- *
- * Recovery semantics:
- * - Update routes by `contact_id`, never by `email_id`, so the adopt-then-update
- *   path acts on the contact we actually resolved.
- * - A `document_not_found` on update means the stored Brevo id is stale; we
- *   transparently recreate (which may adopt a different existing contact) and
- *   return the new id so the orchestration layer repairs the mapping.
- * - When Brevo rejects a write because a specific identifier (`SMS`,
- *   `WHATSAPP`, `EXT_ID`) is already taken or invalid (typically a malformed
- *   phone), we retry the same write with that attribute dropped, so the rest
- *   of the contact still syncs.
+ * Brevo anti-corruption layer for [ContactAdapter] (ADR-019). Active in
+ * production only; test/dev use MockContactAdapter. The [ContactsApi] client
+ * is wired by [BrevoClientConfig] so this class holds no HTTP setup.
  */
 @Service
 @Profile("!test & !dev")
@@ -41,8 +27,6 @@ class BrevoContactAdapter(
 ) : ContactAdapter {
 
     override val system = ContactSystem.BREVO
-
-    // ── Contact operations ─────────────────────────────────────────────────────
 
     override fun createContact(data: ContactData): Long = createOrAdopt(data, omittedAttrs = emptySet())
 
@@ -61,11 +45,10 @@ class BrevoContactAdapter(
     override fun deleteContact(externalId: Long) {
         log.info("Deleting Brevo contact id={}", externalId)
         try {
-            contactsApi.deleteContact(externalId.toString(), "contact_id")
+            contactsApi.deleteContact(externalId.toString(), IDENTIFIER_CONTACT_ID)
         } catch (e: RestClientResponseException) {
             val error = parseBrevoError(e, jsonMapper)
             if (error?.code == DOCUMENT_NOT_FOUND) {
-                // Already gone — treat as a successful delete.
                 log.info("Brevo contact {} was already gone on delete", externalId)
                 return
             }
@@ -73,8 +56,6 @@ class BrevoContactAdapter(
             throw BrevoApiException(e.statusCode.value(), error?.code, error?.message, "deleteContact", e)
         }
     }
-
-    // ── Internal helpers ──────────────────────────────────────────────────────
 
     private fun createOrAdopt(data: ContactData, omittedAttrs: Set<String>): Long {
         log.info("Creating Brevo contact: {} (omit={})", data.email, omittedAttrs)
@@ -159,14 +140,14 @@ class BrevoContactAdapter(
 
     private fun resolveExistingId(data: ContactData, duplicates: Set<BrevoDuplicateIdentifier>): Long? {
         if (BrevoDuplicateIdentifier.EMAIL in duplicates) {
-            lookupContactId(data.email, "email_id")?.let { return it }
+            lookupContactId(data.email, IDENTIFIER_EMAIL_ID)?.let { return it }
         }
         if (BrevoDuplicateIdentifier.SMS in duplicates) {
-            data.phoneNumber?.let { phone -> lookupContactId(phone, "phone_id")?.let { return it } }
+            data.phoneNumber?.let { phone -> lookupContactId(phone, IDENTIFIER_PHONE_ID)?.let { return it } }
         }
-        // Best-effort fallback: the email is our stable identifier, try it even
-        // when Brevo flagged a different (or unknown) field.
-        return lookupContactId(data.email, "email_id")
+        // Fall back to email even when Brevo flagged a different field: email
+        // is our stable identifier and the most likely correct match.
+        return lookupContactId(data.email, IDENTIFIER_EMAIL_ID)
     }
 
     private fun lookupContactId(identifier: String, identifierType: String): Long? =
@@ -188,7 +169,7 @@ class BrevoContactAdapter(
             contactsApi.updateContact(
                 externalId.toString(),
                 buildUpdateRequest(data, omittedAttrs),
-                "contact_id",
+                IDENTIFIER_CONTACT_ID,
             )
             log.info("Updated Brevo contact id={}", externalId)
             return externalId
@@ -199,7 +180,6 @@ class BrevoContactAdapter(
                 error?.code == DUPLICATE_PARAMETER -> {
                     val newOmissions = expandOmissions(error.duplicateIdentifiers, omittedAttrs)
                     if (newOmissions.size == omittedAttrs.size) {
-                        // Nothing new to drop; can't recover. Surface as a typed error.
                         log.error("Brevo update on {} conflicted but no attribute can be dropped: {}", externalId, error)
                         throw BrevoApiException(e.statusCode.value(), error.code, error.message, "updateContact", e)
                     }
@@ -224,7 +204,7 @@ class BrevoContactAdapter(
     private fun buildCreateRequest(data: ContactData, omittedAttrs: Set<String>): CreateContactRequest {
         val req = CreateContactRequest()
         req.email = data.email
-        if ("EXT_ID" !in omittedAttrs) req.extId = data.email   // Brevo extId used for dedup
+        if (ATTR_EXT_ID !in omittedAttrs) req.extId = data.email
         @Suppress("UNCHECKED_CAST")
         req.attributes = buildAttributes(data, omittedAttrs) as Map<String?, CreateContactRequestAttributesValue?>?
         return req
@@ -232,7 +212,7 @@ class BrevoContactAdapter(
 
     private fun buildUpdateRequest(data: ContactData, omittedAttrs: Set<String>): UpdateContactRequest {
         val req = UpdateContactRequest()
-        if ("EXT_ID" !in omittedAttrs) req.extId = data.email
+        if (ATTR_EXT_ID !in omittedAttrs) req.extId = data.email
         @Suppress("UNCHECKED_CAST")
         req.attributes = buildAttributes(data, omittedAttrs) as Map<String?, CreateContactRequestAttributesValue?>?
         return req
@@ -247,8 +227,8 @@ class BrevoContactAdapter(
             "SURNAME" to data.lastName,
         )
         data.phoneNumber?.let { phone ->
-            if ("SMS" !in omittedAttrs) attrs["SMS"] = phone
-            if ("WHATSAPP" !in omittedAttrs) attrs["WHATSAPP"] = phone
+            if (ATTR_SMS !in omittedAttrs) attrs[ATTR_SMS] = phone
+            if (ATTR_WHATSAPP !in omittedAttrs) attrs[ATTR_WHATSAPP] = phone
         }
         attrs.putAll(data.attributes.filterKeys { it.uppercase() !in omittedAttrs })
         return attrs
@@ -274,6 +254,16 @@ class BrevoContactAdapter(
 
     companion object {
         private val log = LoggerFactory.getLogger(BrevoContactAdapter::class.java)
-        private val PHONE_ATTRS = setOf("SMS", "WHATSAPP")
+
+        // Brevo `identifierType` values, see ContactsApi javadoc.
+        private const val IDENTIFIER_CONTACT_ID = "contact_id"
+        private const val IDENTIFIER_EMAIL_ID = "email_id"
+        private const val IDENTIFIER_PHONE_ID = "phone_id"
+
+        // Brevo attribute keys we set on create/update.
+        private const val ATTR_SMS = "SMS"
+        private const val ATTR_WHATSAPP = "WHATSAPP"
+        private const val ATTR_EXT_ID = "EXT_ID"
+        private val PHONE_ATTRS = setOf(ATTR_SMS, ATTR_WHATSAPP)
     }
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoExceptions.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoExceptions.kt
@@ -60,16 +60,6 @@ class BrevoDuplicateContactException(
     cause,
 )
 
-/**
- * Brevo returned `document_not_found` for an operation against a contact id we
- * thought existed. The id is stale (contact deleted or merged on Brevo's side);
- * callers should clear the local mapping and re-create/adopt.
- */
-class BrevoContactGoneException(
-    val contactId: Long,
-    cause: Throwable? = null,
-) : ContactServiceException("Brevo contact $contactId does not exist (document_not_found)", cause)
-
 /** Parsed shape of a Brevo error response body. */
 internal data class BrevoError(
     val code: String?,

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoExceptions.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoExceptions.kt
@@ -1,6 +1,9 @@
 package net.blueshell.api.platform.integration.contact.adapter.brevo
 
 import net.blueshell.api.platform.integration.contact.adapter.ContactServiceException
+import org.slf4j.LoggerFactory
+import org.springframework.web.client.RestClientResponseException
+import tools.jackson.databind.json.JsonMapper
 
 /**
  * Which Brevo unique identifier collided on a create. Brevo reports these in
@@ -56,3 +59,45 @@ class BrevoDuplicateContactException(
         "but could not be resolved for email=$email phone=$phone",
     cause,
 )
+
+/**
+ * Brevo returned `document_not_found` for an operation against a contact id we
+ * thought existed. The id is stale (contact deleted or merged on Brevo's side);
+ * callers should clear the local mapping and re-create/adopt.
+ */
+class BrevoContactGoneException(
+    val contactId: Long,
+    cause: Throwable? = null,
+) : ContactServiceException("Brevo contact $contactId does not exist (document_not_found)", cause)
+
+/** Parsed shape of a Brevo error response body. */
+internal data class BrevoError(
+    val code: String?,
+    val message: String?,
+    val duplicateIdentifiers: List<String>,
+)
+
+internal const val DUPLICATE_PARAMETER: String = "duplicate_parameter"
+internal const val INVALID_PARAMETER: String = "invalid_parameter"
+internal const val DOCUMENT_NOT_FOUND: String = "document_not_found"
+
+private val parseLog = LoggerFactory.getLogger("net.blueshell.api.platform.integration.contact.adapter.brevo.BrevoError")
+
+internal fun parseBrevoError(e: RestClientResponseException, jsonMapper: JsonMapper): BrevoError? {
+    val body = e.responseBodyAsString.takeIf { it.isNotBlank() } ?: return null
+    return try {
+        val map = jsonMapper.readValue(body, Map::class.java)
+        val metadata = map["metadata"] as? Map<*, *>
+        val ids = (metadata?.get("duplicate_identifiers") as? List<*>)
+            ?.mapNotNull { it as? String }
+            ?: emptyList()
+        BrevoError(
+            code = map["code"] as? String,
+            message = map["message"] as? String,
+            duplicateIdentifiers = ids,
+        )
+    } catch (ex: Exception) {
+        parseLog.warn("Could not parse Brevo error body: {}", body, ex)
+        null
+    }
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoListAdapter.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoListAdapter.kt
@@ -3,7 +3,6 @@ package net.blueshell.api.platform.integration.contact.adapter.brevo
 import net.blueshell.api.platform.integration.contact.adapter.ContactServiceException
 import net.blueshell.api.platform.integration.contact.adapter.ContactListAdapter
 import net.blueshell.api.shared.enums.ContactSystem
-import net.blueshell.clients.brevo.ApiClient
 import net.blueshell.clients.brevo.api.ContactsApi
 import net.blueshell.clients.brevo.model.AddContactToListRequest
 import net.blueshell.clients.brevo.model.CreateListRequest
@@ -11,50 +10,40 @@ import net.blueshell.clients.brevo.model.RemoveContactFromListRequest
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Profile
-import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter
 import org.springframework.stereotype.Service
-import org.springframework.web.client.RestClient
 import org.springframework.web.client.RestClientResponseException
 import tools.jackson.databind.json.JsonMapper
 
 /**
  * Brevo Anti-Corruption Layer (ADR-019)
  *
- * Implements [ContactSystemAdapter] against the Brevo Contacts API.
- * Active in production only (test/dev use MockContactAdapter).
+ * Implements [ContactListAdapter] against the Brevo Contacts API. Active in
+ * production only (test/dev use MockContactAdapter).
  *
- * [contributionPeriodsFolder] is the Brevo folder ID under which all contribution-period
- * lists are created; the domain-level [folderName] hint is intentionally ignored because
- * Brevo organises lists by numeric folder ID, not by name.
+ * [contributionPeriodsFolder] is the Brevo folder ID under which all
+ * contribution-period lists are created; the domain-level `folderName` hint is
+ * intentionally ignored because Brevo organises lists by numeric folder ID,
+ * not by name.
+ *
+ * Recovery semantics:
+ * - Adding a contact already in the list returns Brevo's ambiguous
+ *   `400 invalid_parameter "Contact already in list and/or does not exist"`.
+ *   We disambiguate with a follow-up GET on the contact id: a 200 means the
+ *   contact already belongs and the add is treated as an idempotent success;
+ *   a 404 means the local pairing is stale and we throw
+ *   [BrevoContactGoneException] so the caller can re-sync and retry.
+ * - Removing a contact that isn't in the list is treated as a no-op (the
+ *   desired state is already in place).
  */
 @Service
 @Profile("!test & !dev")
 class BrevoListAdapter(
-    restClientBuilder: RestClient.Builder,
-    jsonMapper: JsonMapper,
+    private val contactsApi: ContactsApi,
+    private val jsonMapper: JsonMapper,
     @param:Value($$"${brevo.folders.contributionPeriodsId}") private val contributionPeriodsFolder: Long,
-    // `contactsApi` below is a class-level property initializer that
-    // runs during the constructor, *before* Spring's field injection.
-    // Using `@field:Value lateinit var` for these values would crash
-    // the pod with `UninitializedPropertyAccessException` at startup
-    // (same shape as the fix applied to BrevoContactAdapter).
-    @param:Value($$"${brevo.apiKey:}") private val apiKey: String,
-    @param:Value($$"${brevo.baseUrl:https://api.brevo.com/v3}") private val brevoBaseUrl: String,
 ) : ContactListAdapter {
 
     override val system = ContactSystem.BREVO
-
-    private val contactsApi: ContactsApi = ContactsApi(
-        ApiClient(
-            restClientBuilder
-                .baseUrl(brevoBaseUrl)
-                .defaultHeader("api-key", apiKey)
-                .configureMessageConverters {
-                    it.addCustomConverter(JacksonJsonHttpMessageConverter(jsonMapper))
-                }
-                .build()
-        )
-    )
 
     override fun createList(name: String, folderName: String?): Long {
         log.info("Creating Brevo list '{}'", name)
@@ -80,6 +69,21 @@ class BrevoListAdapter(
             req.extIds = null
             contactsApi.addContactToList(externalListId, req)
         } catch (e: RestClientResponseException) {
+            val error = parseBrevoError(e, jsonMapper)
+            if (error?.code == INVALID_PARAMETER && isAlreadyInListOrMissing(error)) {
+                if (contactExists(externalUserId)) {
+                    log.info(
+                        "Brevo contact {} already in list {} — treating add as a no-op",
+                        externalUserId, externalListId,
+                    )
+                    return
+                }
+                log.warn(
+                    "Brevo says contact {} does not exist while adding to list {}",
+                    externalUserId, externalListId,
+                )
+                throw BrevoContactGoneException(externalUserId, e)
+            }
             log.error("Failed to add contact {} to Brevo list {}", externalUserId, externalListId, e)
             throw ContactServiceException("Failed to add contact to list", e)
         }
@@ -94,6 +98,14 @@ class BrevoListAdapter(
             req.extIds = null
             contactsApi.removeContactFromList(externalListId, req)
         } catch (e: RestClientResponseException) {
+            val error = parseBrevoError(e, jsonMapper)
+            if (error?.code == INVALID_PARAMETER && isAlreadyInListOrMissing(error)) {
+                log.info(
+                    "Brevo contact {} not in list {} (or already deleted) — treating remove as a no-op",
+                    externalUserId, externalListId,
+                )
+                return
+            }
             log.error("Failed to remove contact {} from Brevo list {}", externalUserId, externalListId, e)
             throw ContactServiceException("Failed to remove contact from list", e)
         }
@@ -107,6 +119,18 @@ class BrevoListAdapter(
             log.error("Failed to delete Brevo list id={}", externalListId, e)
             throw ContactServiceException("Failed to delete list", e)
         }
+    }
+
+    private fun contactExists(contactId: Long): Boolean = try {
+        contactsApi.getContactInfo(contactId.toString(), "contact_id", null, null)
+        true
+    } catch (e: RestClientResponseException) {
+        false
+    }
+
+    private fun isAlreadyInListOrMissing(error: BrevoError): Boolean {
+        val message = error.message?.lowercase() ?: return false
+        return message.contains("already in list") || message.contains("does not exist")
     }
 
     companion object {

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoListAdapter.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoListAdapter.kt
@@ -72,18 +72,32 @@ class BrevoListAdapter(
         } catch (e: RestClientResponseException) {
             val error = parseBrevoError(e, jsonMapper)
             if (error?.code == INVALID_PARAMETER && isAlreadyInListOrMissing(error)) {
-                if (contactExists(externalUserId)) {
-                    log.info(
-                        "Brevo contact {} already in list {} — treating add as a no-op",
-                        externalUserId, externalListId,
-                    )
-                    return
+                when (lookupContact(externalUserId)) {
+                    ContactLookup.EXISTS -> {
+                        log.info(
+                            "Brevo contact {} already in list {} — treating add as a no-op",
+                            externalUserId, externalListId,
+                        )
+                        return
+                    }
+                    ContactLookup.MISSING -> {
+                        log.warn(
+                            "Brevo says contact {} does not exist while adding to list {}",
+                            externalUserId, externalListId,
+                        )
+                        throw ExternalContactGoneException(system, externalUserId, e)
+                    }
+                    ContactLookup.UNKNOWN -> {
+                        // Lookup itself failed (transient 5xx, 429, network).
+                        // Don't churn local pairing for a provider outage; let
+                        // the job retry the whole add via its backoff schedule.
+                        log.warn(
+                            "Brevo contact existence check inconclusive for {} — letting the job retry",
+                            externalUserId,
+                        )
+                        throw ContactServiceException("Failed to add contact to list", e)
+                    }
                 }
-                log.warn(
-                    "Brevo says contact {} does not exist while adding to list {}",
-                    externalUserId, externalListId,
-                )
-                throw ExternalContactGoneException(system, externalUserId, e)
             }
             log.error("Failed to add contact {} to Brevo list {}", externalUserId, externalListId, e)
             throw ContactServiceException("Failed to add contact to list", e)
@@ -122,11 +136,24 @@ class BrevoListAdapter(
         }
     }
 
-    private fun contactExists(contactId: Long): Boolean = try {
+    /**
+     * Result of disambiguating Brevo's "already in list and/or does not exist"
+     * error. Only a confirmed 404 / `document_not_found` is treated as MISSING;
+     * any other lookup failure stays UNKNOWN so callers don't repair pairing on
+     * a provider outage.
+     */
+    private enum class ContactLookup { EXISTS, MISSING, UNKNOWN }
+
+    private fun lookupContact(contactId: Long): ContactLookup = try {
         contactsApi.getContactInfo(contactId.toString(), "contact_id", null, null)
-        true
+        ContactLookup.EXISTS
     } catch (e: RestClientResponseException) {
-        false
+        val error = parseBrevoError(e, jsonMapper)
+        if (e.statusCode.value() == 404 || error?.code == DOCUMENT_NOT_FOUND) {
+            ContactLookup.MISSING
+        } else {
+            ContactLookup.UNKNOWN
+        }
     }
 
     private fun isAlreadyInListOrMissing(error: BrevoError): Boolean {

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoListAdapter.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoListAdapter.kt
@@ -2,6 +2,7 @@ package net.blueshell.api.platform.integration.contact.adapter.brevo
 
 import net.blueshell.api.platform.integration.contact.adapter.ContactServiceException
 import net.blueshell.api.platform.integration.contact.adapter.ContactListAdapter
+import net.blueshell.api.platform.integration.contact.adapter.ExternalContactGoneException
 import net.blueshell.api.shared.enums.ContactSystem
 import net.blueshell.clients.brevo.api.ContactsApi
 import net.blueshell.clients.brevo.model.AddContactToListRequest
@@ -82,7 +83,7 @@ class BrevoListAdapter(
                     "Brevo says contact {} does not exist while adding to list {}",
                     externalUserId, externalListId,
                 )
-                throw BrevoContactGoneException(externalUserId, e)
+                throw ExternalContactGoneException(system, externalUserId, e)
             }
             log.error("Failed to add contact {} to Brevo list {}", externalUserId, externalListId, e)
             throw ContactServiceException("Failed to add contact to list", e)

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/ContactSyncScheduler.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/ContactSyncScheduler.kt
@@ -16,24 +16,24 @@ import org.springframework.stereotype.Component
 class ContactSyncScheduler(
     private val jobs: TrackedJobDispatcher,
 ) {
-    @Scheduled(cron = "\${contact.ensure-period-lists-cron:0 0 1 * * *}")
-    fun ensureContributionPeriodLists() {
+    @Scheduled(cron = "\${contact.period-list-sync-all-cron:0 0 1 * * *}")
+    fun syncAllPeriodLists() {
         jobs.enqueue(
-            ContactJobs.EnsureContributionPeriodLists,
-            ContactJobs.EnsureContributionPeriodListsPayload(),
+            ContactJobs.SyncAllPeriodLists,
+            ContactJobs.SyncAllPeriodListsPayload(),
         )
     }
 
     @Scheduled(cron = "\${contact.sync-cron:0 0 2 * * *}")
     fun syncAllContacts() {
         log.info("Scheduling contact sync spawn job")
-        jobs.enqueue(ContactJobs.DispatchContactSyncs, ContactJobs.DispatchContactSyncsPayload())
+        jobs.enqueue(ContactJobs.SyncAllContacts, ContactJobs.SyncAllContactsPayload())
     }
 
     @Scheduled(cron = "\${contact.list-sync-cron:0 30 2 * * *}")
     fun syncAllListMemberships() {
         log.info("Scheduling list membership sync spawn job")
-        jobs.enqueue(ContactJobs.DispatchListMembershipSyncs, ContactJobs.DispatchListMembershipSyncsPayload())
+        jobs.enqueue(ContactJobs.SyncAllListMemberships, ContactJobs.SyncAllListMembershipsPayload())
     }
 
     companion object {

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/ContactSyncScheduler.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/ContactSyncScheduler.kt
@@ -17,6 +17,22 @@ import org.springframework.stereotype.Component
 class ContactSyncScheduler(
     private val jobs: TrackedJobDispatcher,
 ) {
+    /**
+     * Reconciles per-contribution-period contact lists. Creates missing lists,
+     * links them to the period, and enqueues a ProcessListMembership job per
+     * paid contribution. Runs before the contact and list-membership syncs so
+     * that by the time those passes start, the lists exist and the membership
+     * rows have been seeded.
+     */
+    @Scheduled(cron = "\${contact.ensure-period-lists-cron:0 0 1 * * *}")
+    fun ensureContributionPeriodLists() {
+        log.info("Scheduling ensure-contribution-period-lists spawn job")
+        jobs.enqueue(
+            ContactJobs.EnsureContributionPeriodLists,
+            ContactJobs.EnsureContributionPeriodListsPayload(),
+        )
+    }
+
     @Scheduled(cron = "\${contact.sync-cron:0 0 2 * * *}")
     fun syncAllContacts() {
         log.info("Scheduling contact sync spawn job")

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/ContactSyncScheduler.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/ContactSyncScheduler.kt
@@ -7,26 +7,17 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
 /**
- * Triggers daily full-syncs of all contacts and list memberships to external providers.
- *
- * Enqueues [ContactJobs.DispatchContactSyncs] and [ContactJobs.DispatchListMembershipSyncs] jobs
- * which perform the tracked, retryable iteration. The list sync runs 30 minutes after the
- * contact sync so contacts are likely already created when list membership is processed.
+ * Daily-sync triggers. The methods run in order: period-list reconciliation
+ * at 01:00, full contact sync at 02:00, list-membership sync at 02:30 — so
+ * by the time the per-membership pass runs, every period has its list and
+ * every contact has been pushed.
  */
 @Component
 class ContactSyncScheduler(
     private val jobs: TrackedJobDispatcher,
 ) {
-    /**
-     * Reconciles per-contribution-period contact lists. Creates missing lists,
-     * links them to the period, and enqueues a ProcessListMembership job per
-     * paid contribution. Runs before the contact and list-membership syncs so
-     * that by the time those passes start, the lists exist and the membership
-     * rows have been seeded.
-     */
     @Scheduled(cron = "\${contact.ensure-period-lists-cron:0 0 1 * * *}")
     fun ensureContributionPeriodLists() {
-        log.info("Scheduling ensure-contribution-period-lists spawn job")
         jobs.enqueue(
             ContactJobs.EnsureContributionPeriodLists,
             ContactJobs.EnsureContributionPeriodListsPayload(),

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/ContributionPeriodListResolver.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/ContributionPeriodListResolver.kt
@@ -1,0 +1,36 @@
+package net.blueshell.api.platform.integration.contact.application
+
+import net.blueshell.api.domain.contribution.application.ContributionPeriodService
+import net.blueshell.api.domain.contribution.persistence.ContributionPeriod
+import net.blueshell.api.platform.integration.contact.persistence.ContactList
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Single source of truth for the contact list that backs a [ContributionPeriod]:
+ * names it ("Contribution Paid YYYY - YYYY"), creates it in every registered
+ * system on first call (via [ContactListService.findOrCreateList]), and links
+ * it to the period. Both the per-(user, period) processing job and the nightly
+ * reconciliation job go through this so the naming / folder / linking rule
+ * stays in one place.
+ */
+@Service
+class ContributionPeriodListResolver(
+    private val contactListService: ContactListService,
+    private val periods: ContributionPeriodService,
+) {
+    @Transactional
+    fun resolve(period: ContributionPeriod): ContactList {
+        period.contactListId?.let { return contactListService.findById(it) }
+        val list = contactListService.findOrCreateList(listName(period), FOLDER_NAME)
+        periods.updateContactListId(period.id!!, list.id!!)
+        return list
+    }
+
+    companion object {
+        private const val FOLDER_NAME = "contributionPeriods"
+
+        fun listName(period: ContributionPeriod): String =
+            "Contribution Paid ${period.startDate.year} - ${period.endDate.year}"
+    }
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/command/SyncListMembershipCommandHandler.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/command/SyncListMembershipCommandHandler.kt
@@ -1,7 +1,7 @@
 package net.blueshell.api.platform.integration.contact.application.command
 
 import net.blueshell.api.platform.integration.contact.adapter.ContactListAdapter
-import net.blueshell.api.platform.integration.contact.adapter.brevo.BrevoContactGoneException
+import net.blueshell.api.platform.integration.contact.adapter.ExternalContactGoneException
 import net.blueshell.api.platform.integration.contact.persistence.repository.ContactListMembershipRepository
 import net.blueshell.api.platform.integration.contact.persistence.repository.ContactListRepository
 import net.blueshell.api.platform.integration.contact.persistence.repository.ContactRepository
@@ -72,7 +72,7 @@ class SyncListMembershipCommandHandler(
             try {
                 adapter.addToList(externalContactId, externalListId)
                 log.debug("Added user {} to {} list {}", command.userId, command.system, command.contactListId)
-            } catch (e: BrevoContactGoneException) {
+            } catch (e: ExternalContactGoneException) {
                 // Upstream contact is gone; the local pairing is stale. Clear
                 // it and trigger a contact sync so the next retry can re-add.
                 if (contact != null) {

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/command/SyncListMembershipCommandHandler.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/command/SyncListMembershipCommandHandler.kt
@@ -1,26 +1,32 @@
 package net.blueshell.api.platform.integration.contact.application.command
 
 import net.blueshell.api.platform.integration.contact.adapter.ContactListAdapter
+import net.blueshell.api.platform.integration.contact.adapter.brevo.BrevoContactGoneException
 import net.blueshell.api.platform.integration.contact.persistence.repository.ContactListMembershipRepository
 import net.blueshell.api.platform.integration.contact.persistence.repository.ContactListRepository
 import net.blueshell.api.platform.integration.contact.persistence.repository.ContactRepository
 import net.blueshell.api.shared.command.CommandHandler
+import net.blueshell.api.shared.job.ContactJobs
 import net.blueshell.api.shared.job.NonRetryableJobException
 import net.blueshell.api.shared.job.SyncListMembershipCommand
+import net.blueshell.api.shared.job.TrackedJobDispatcher
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 import kotlin.reflect.KClass
 
 /**
- * Handles [SyncListMembershipCommand]: adds or removes a user from a contact list
- * in one external system.
+ * Handles [SyncListMembershipCommand]: adds or removes a user from a contact
+ * list in one external system.
  *
- * Selects the correct [ContactListAdapter] by [SyncListMembershipCommand.system] at runtime.
- *
- * Logic:
- * - Active [ContactListMembership] exists in DB → add to external list
- *   (retryable if contact not yet synced; non-retryable if list has no external ID)
- * - No membership exists → remove from external list (no-op if IDs absent)
+ * Self-healing:
+ * - If the contact has no external id for [SyncListMembershipCommand.system],
+ *   we enqueue a contact sync and throw retryable so the next retry runs
+ *   after the contact pairing is in place.
+ * - If the adapter reports the external contact is gone (deleted/merged
+ *   upstream), we clear the stale pairing, enqueue a contact sync to
+ *   re-establish it, and throw retryable so the add is reattempted after the
+ *   contact lands at its new id.
  */
 @Component
 class SyncListMembershipCommandHandler(
@@ -28,10 +34,12 @@ class SyncListMembershipCommandHandler(
     private val contactRepository: ContactRepository,
     private val contactListRepository: ContactListRepository,
     private val contactListMembershipRepository: ContactListMembershipRepository,
+    private val jobs: TrackedJobDispatcher,
 ) : CommandHandler<SyncListMembershipCommand, Unit> {
 
     override val commandType: KClass<SyncListMembershipCommand> = SyncListMembershipCommand::class
 
+    @Transactional
     override fun handle(command: SyncListMembershipCommand) {
         val adapter = listAdapters.find { it.system == command.system }
             ?: throw NonRetryableJobException("No ContactListAdapter registered for system ${command.system}")
@@ -48,8 +56,12 @@ class SyncListMembershipCommandHandler(
 
         if (hasMembership) {
             if (externalContactId == null) {
+                // Without this nudge the list job would loop on its retry
+                // schedule until something else syncs the contact.
+                jobs.enqueue(ContactJobs.SyncContact, ContactJobs.SyncContactPayload(command.userId))
                 throw RetryableContactNotSyncedException(
-                    "Contact not yet synced to ${command.system} for user ${command.userId} — will retry"
+                    "Contact not yet synced to ${command.system} for user ${command.userId} — " +
+                        "enqueued sync, will retry"
                 )
             }
             if (externalListId == null) {
@@ -57,8 +69,23 @@ class SyncListMembershipCommandHandler(
                     "List ${command.contactListId} has no ${command.system} external ID — cannot add contact"
                 )
             }
-            adapter.addToList(externalContactId, externalListId)
-            log.debug("Added user {} to {} list {}", command.userId, command.system, command.contactListId)
+            try {
+                adapter.addToList(externalContactId, externalListId)
+                log.debug("Added user {} to {} list {}", command.userId, command.system, command.contactListId)
+            } catch (e: BrevoContactGoneException) {
+                // Upstream contact is gone; the local pairing is stale. Clear
+                // it and trigger a contact sync so the next retry can re-add.
+                if (contact != null) {
+                    contact.clearExternalId(command.system)
+                    contactRepository.save(contact)
+                }
+                jobs.enqueue(ContactJobs.SyncContact, ContactJobs.SyncContactPayload(command.userId))
+                throw RetryableContactNotSyncedException(
+                    "Upstream contact for user ${command.userId} (${command.system}) was gone — " +
+                        "cleared pairing and enqueued sync, will retry",
+                    e,
+                )
+            }
         } else {
             if (externalContactId != null && externalListId != null) {
                 adapter.removeFromList(externalContactId, externalListId)
@@ -66,7 +93,7 @@ class SyncListMembershipCommandHandler(
             } else {
                 log.debug(
                     "No {} IDs for user {}/list {} — skipping removal",
-                    command.system, command.userId, command.contactListId
+                    command.system, command.userId, command.contactListId,
                 )
             }
         }
@@ -77,4 +104,7 @@ class SyncListMembershipCommandHandler(
     }
 }
 
-private class RetryableContactNotSyncedException(message: String) : RuntimeException(message)
+internal class RetryableContactNotSyncedException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/command/SyncListMembershipCommandHandler.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/command/SyncListMembershipCommandHandler.kt
@@ -2,10 +2,13 @@ package net.blueshell.api.platform.integration.contact.application.command
 
 import net.blueshell.api.platform.integration.contact.adapter.ContactListAdapter
 import net.blueshell.api.platform.integration.contact.adapter.ExternalContactGoneException
+import net.blueshell.api.platform.integration.contact.persistence.Contact
+import net.blueshell.api.platform.integration.contact.persistence.ContactList
 import net.blueshell.api.platform.integration.contact.persistence.repository.ContactListMembershipRepository
 import net.blueshell.api.platform.integration.contact.persistence.repository.ContactListRepository
 import net.blueshell.api.platform.integration.contact.persistence.repository.ContactRepository
 import net.blueshell.api.shared.command.CommandHandler
+import net.blueshell.api.shared.enums.ContactSystem
 import net.blueshell.api.shared.job.ContactJobs
 import net.blueshell.api.shared.job.NonRetryableJobException
 import net.blueshell.api.shared.job.SyncListMembershipCommand
@@ -17,16 +20,7 @@ import kotlin.reflect.KClass
 
 /**
  * Handles [SyncListMembershipCommand]: adds or removes a user from a contact
- * list in one external system.
- *
- * Self-healing:
- * - If the contact has no external id for [SyncListMembershipCommand.system],
- *   we enqueue a contact sync and throw retryable so the next retry runs
- *   after the contact pairing is in place.
- * - If the adapter reports the external contact is gone (deleted/merged
- *   upstream), we clear the stale pairing, enqueue a contact sync to
- *   re-establish it, and throw retryable so the add is reattempted after the
- *   contact lands at its new id.
+ * list in one external system, and self-heals stale local pairings.
  */
 @Component
 class SyncListMembershipCommandHandler(
@@ -41,62 +35,85 @@ class SyncListMembershipCommandHandler(
 
     @Transactional
     override fun handle(command: SyncListMembershipCommand) {
-        val adapter = listAdapters.find { it.system == command.system }
-            ?: throw NonRetryableJobException("No ContactListAdapter registered for system ${command.system}")
-
+        val adapter = adapterFor(command.system)
         val contact = contactRepository.findByUserId(command.userId)
-        val externalContactId = contact?.externalId(command.system)
-
         val list = contactListRepository.findById(command.contactListId).orElse(null)
-        val externalListId = list?.externalListId(command.system)
 
-        val hasMembership = contact?.id?.let { contactId ->
-            contactListMembershipRepository.findByContactIdAndContactListId(contactId, command.contactListId) != null
-        } ?: false
-
-        if (hasMembership) {
-            if (externalContactId == null) {
-                // Without this nudge the list job would loop on its retry
-                // schedule until something else syncs the contact.
-                jobs.enqueue(ContactJobs.SyncContact, ContactJobs.SyncContactPayload(command.userId))
-                throw RetryableContactNotSyncedException(
-                    "Contact not yet synced to ${command.system} for user ${command.userId} — " +
-                        "enqueued sync, will retry"
-                )
-            }
-            if (externalListId == null) {
-                throw NonRetryableJobException(
-                    "List ${command.contactListId} has no ${command.system} external ID — cannot add contact"
-                )
-            }
-            try {
-                adapter.addToList(externalContactId, externalListId)
-                log.debug("Added user {} to {} list {}", command.userId, command.system, command.contactListId)
-            } catch (e: ExternalContactGoneException) {
-                // Upstream contact is gone; the local pairing is stale. Clear
-                // it and trigger a contact sync so the next retry can re-add.
-                if (contact != null) {
-                    contact.clearExternalId(command.system)
-                    contactRepository.save(contact)
-                }
-                jobs.enqueue(ContactJobs.SyncContact, ContactJobs.SyncContactPayload(command.userId))
-                throw RetryableContactNotSyncedException(
-                    "Upstream contact for user ${command.userId} (${command.system}) was gone — " +
-                        "cleared pairing and enqueued sync, will retry",
-                    e,
-                )
-            }
+        if (hasLocalMembership(contact, command.contactListId)) {
+            addMembership(adapter, command, contact, list)
         } else {
-            if (externalContactId != null && externalListId != null) {
-                adapter.removeFromList(externalContactId, externalListId)
-                log.debug("Removed user {} from {} list {}", command.userId, command.system, command.contactListId)
-            } else {
-                log.debug(
-                    "No {} IDs for user {}/list {} — skipping removal",
-                    command.system, command.userId, command.contactListId,
-                )
-            }
+            removeMembership(adapter, command, contact, list)
         }
+    }
+
+    private fun adapterFor(system: ContactSystem): ContactListAdapter =
+        listAdapters.find { it.system == system }
+            ?: throw NonRetryableJobException("No ContactListAdapter registered for system $system")
+
+    private fun hasLocalMembership(contact: Contact?, contactListId: Long): Boolean {
+        val contactId = contact?.id ?: return false
+        return contactListMembershipRepository.findByContactIdAndContactListId(contactId, contactListId) != null
+    }
+
+    private fun addMembership(
+        adapter: ContactListAdapter,
+        command: SyncListMembershipCommand,
+        contact: Contact?,
+        list: ContactList?,
+    ) {
+        val externalContactId = contact?.externalId(command.system)
+            ?: enqueueContactSyncAndRetry(command, "Contact not yet synced to ${command.system}")
+
+        val externalListId = list?.externalListId(command.system)
+            ?: throw NonRetryableJobException(
+                "List ${command.contactListId} has no ${command.system} external ID — cannot add contact"
+            )
+
+        try {
+            adapter.addToList(externalContactId, externalListId)
+            log.debug("Added user {} to {} list {}", command.userId, command.system, command.contactListId)
+        } catch (e: ExternalContactGoneException) {
+            contact?.let {
+                it.clearExternalId(command.system)
+                contactRepository.save(it)
+            }
+            enqueueContactSyncAndRetry(
+                command,
+                "Upstream contact for user ${command.userId} (${command.system}) was gone — cleared pairing",
+                cause = e,
+            )
+        }
+    }
+
+    private fun removeMembership(
+        adapter: ContactListAdapter,
+        command: SyncListMembershipCommand,
+        contact: Contact?,
+        list: ContactList?,
+    ) {
+        val externalContactId = contact?.externalId(command.system)
+        val externalListId = list?.externalListId(command.system)
+        if (externalContactId == null || externalListId == null) {
+            log.debug(
+                "No {} IDs for user {}/list {} — skipping removal",
+                command.system, command.userId, command.contactListId,
+            )
+            return
+        }
+        adapter.removeFromList(externalContactId, externalListId)
+        log.debug("Removed user {} from {} list {}", command.userId, command.system, command.contactListId)
+    }
+
+    private fun enqueueContactSyncAndRetry(
+        command: SyncListMembershipCommand,
+        message: String,
+        cause: Throwable? = null,
+    ): Nothing {
+        jobs.enqueue(ContactJobs.SyncContact, ContactJobs.SyncContactPayload(command.userId))
+        throw RetryableContactNotSyncedException(
+            "$message — enqueued sync, will retry",
+            cause,
+        )
     }
 
     companion object {

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/EnsureContributionPeriodListsJob.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/EnsureContributionPeriodListsJob.kt
@@ -3,7 +3,7 @@ package net.blueshell.api.platform.integration.contact.application.job
 import net.blueshell.api.domain.contribution.application.ContributionPeriodService
 import net.blueshell.api.domain.contribution.application.ContributionService
 import net.blueshell.api.domain.contribution.persistence.ContributionPeriod
-import net.blueshell.api.platform.integration.contact.application.ContactListService
+import net.blueshell.api.platform.integration.contact.application.ContributionPeriodListResolver
 import net.blueshell.api.platform.integration.queue.AbstractJsonJobHandler
 import net.blueshell.api.shared.job.ContactJobs
 import net.blueshell.api.shared.job.TrackedJobDispatcher
@@ -30,7 +30,7 @@ import tools.jackson.databind.ObjectMapper
 @Component
 class EnsureContributionPeriodListsJob(
     objectMapper: ObjectMapper,
-    private val contactListService: ContactListService,
+    private val listResolver: ContributionPeriodListResolver,
     private val periods: ContributionPeriodService,
     private val contributions: ContributionService,
     private val jobs: TrackedJobDispatcher,
@@ -62,7 +62,7 @@ class EnsureContributionPeriodListsJob(
     }
 
     private fun reconcilePeriod(period: ContributionPeriod, periodId: Long) {
-        ensureListLinked(period)
+        listResolver.resolve(period)
         val rows = contributions.findByContributionPeriodId(periodId)
         log.debug("Period {}: enqueuing {} ProcessListMembership jobs", periodId, rows.size)
         for (contribution in rows) {
@@ -71,14 +71,6 @@ class EnsureContributionPeriodListsJob(
                 ContactJobs.ProcessListMembershipPayload(contribution.userId, periodId),
             )
         }
-    }
-
-    private fun ensureListLinked(period: ContributionPeriod) {
-        if (period.contactListId != null) return
-        val name = "Contribution Paid ${period.startDate.year} - ${period.endDate.year}"
-        val list = contactListService.findOrCreateList(name, "contributionPeriods")
-        periods.updateContactListId(period.id!!, list.id!!)
-        log.info("Linked period {} to contact list {} ('{}')", period.id, list.id, name)
     }
 
     companion object {

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/EnsureContributionPeriodListsJob.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/EnsureContributionPeriodListsJob.kt
@@ -12,20 +12,10 @@ import org.springframework.stereotype.Component
 import tools.jackson.databind.ObjectMapper
 
 /**
- * Nightly job that reconciles the per–contribution-period contact lists.
- *
- * For every [ContributionPeriod] it makes sure the matching contact list
- * exists (creating it in every registered system on first run via
- * [ContactListService.findOrCreateList]) and links it back to the period.
- * It then enqueues one [ContactJobs.ProcessListMembership] per contribution,
- * which is the existing per-(user, period) flow — that handler is idempotent,
- * so on subsequent runs it only flips memberships that have actually
- * changed and is suppressed by the job-queue dedup when an identical job is
- * still in flight.
- *
- * Runs before the daily contact sync (02:00) and the daily list-membership
- * sync (02:30) so the lists exist and the membership rows are seeded by the
- * time those passes start.
+ * Nightly reconciliation of per-period contact lists: makes sure each
+ * [ContributionPeriod] has a linked [net.blueshell.api.platform.integration.contact.persistence.ContactList]
+ * and enqueues one [ContactJobs.ProcessListMembership] per paid contribution.
+ * Scheduled before the regular contact / list syncs by [net.blueshell.api.platform.integration.contact.application.ContactSyncScheduler].
  */
 @Component
 class EnsureContributionPeriodListsJob(

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/EnsureContributionPeriodListsJob.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/EnsureContributionPeriodListsJob.kt
@@ -44,23 +44,32 @@ class EnsureContributionPeriodListsJob(
         val allPeriods = periods.findAll()
         log.info("Reconciling contribution-period lists for {} periods", allPeriods.size)
 
+        val failures = mutableListOf<Long>()
         for (period in allPeriods) {
             val periodId = period.id ?: continue
-            try {
-                ensureListLinked(period)
-                val rows = contributions.findByContributionPeriodId(periodId)
-                log.debug("Period {}: enqueuing {} ProcessListMembership jobs", periodId, rows.size)
-                for (contribution in rows) {
-                    jobs.enqueue(
-                        ContactJobs.ProcessListMembership,
-                        ContactJobs.ProcessListMembershipPayload(contribution.userId, periodId),
-                    )
+            runCatching { reconcilePeriod(period, periodId) }
+                .onFailure {
+                    failures += periodId
+                    log.error("Failed to reconcile period {}", periodId, it)
                 }
-            } catch (e: Exception) {
-                // Don't let one period's failure block the others; each
-                // ProcessListMembership job is tracked on its own.
-                log.error("Failed to reconcile period {}", periodId, e)
-            }
+        }
+
+        if (failures.isNotEmpty()) {
+            // Other periods still processed; surface partial failure so the
+            // JobExecution row reflects it and the retry/supersede flow can act.
+            throw IllegalStateException("Failed to reconcile contribution periods: $failures")
+        }
+    }
+
+    private fun reconcilePeriod(period: ContributionPeriod, periodId: Long) {
+        ensureListLinked(period)
+        val rows = contributions.findByContributionPeriodId(periodId)
+        log.debug("Period {}: enqueuing {} ProcessListMembership jobs", periodId, rows.size)
+        for (contribution in rows) {
+            jobs.enqueue(
+                ContactJobs.ProcessListMembership,
+                ContactJobs.ProcessListMembershipPayload(contribution.userId, periodId),
+            )
         }
     }
 

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/EnsureContributionPeriodListsJob.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/EnsureContributionPeriodListsJob.kt
@@ -1,0 +1,78 @@
+package net.blueshell.api.platform.integration.contact.application.job
+
+import net.blueshell.api.domain.contribution.application.ContributionPeriodService
+import net.blueshell.api.domain.contribution.application.ContributionService
+import net.blueshell.api.domain.contribution.persistence.ContributionPeriod
+import net.blueshell.api.platform.integration.contact.application.ContactListService
+import net.blueshell.api.platform.integration.queue.AbstractJsonJobHandler
+import net.blueshell.api.shared.job.ContactJobs
+import net.blueshell.api.shared.job.TrackedJobDispatcher
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+
+/**
+ * Nightly job that reconciles the per–contribution-period contact lists.
+ *
+ * For every [ContributionPeriod] it makes sure the matching contact list
+ * exists (creating it in every registered system on first run via
+ * [ContactListService.findOrCreateList]) and links it back to the period.
+ * It then enqueues one [ContactJobs.ProcessListMembership] per contribution,
+ * which is the existing per-(user, period) flow — that handler is idempotent,
+ * so on subsequent runs it only flips memberships that have actually
+ * changed and is suppressed by the job-queue dedup when an identical job is
+ * still in flight.
+ *
+ * Runs before the daily contact sync (02:00) and the daily list-membership
+ * sync (02:30) so the lists exist and the membership rows are seeded by the
+ * time those passes start.
+ */
+@Component
+class EnsureContributionPeriodListsJob(
+    objectMapper: ObjectMapper,
+    private val contactListService: ContactListService,
+    private val periods: ContributionPeriodService,
+    private val contributions: ContributionService,
+    private val jobs: TrackedJobDispatcher,
+) : AbstractJsonJobHandler<ContactJobs.EnsureContributionPeriodListsPayload>(
+    objectMapper,
+    ContactJobs.EnsureContributionPeriodLists.payloadType,
+) {
+    override val jobType: String = ContactJobs.EnsureContributionPeriodLists.type
+
+    override fun handlePayload(payload: ContactJobs.EnsureContributionPeriodListsPayload) {
+        val allPeriods = periods.findAll()
+        log.info("Reconciling contribution-period lists for {} periods", allPeriods.size)
+
+        for (period in allPeriods) {
+            val periodId = period.id ?: continue
+            try {
+                ensureListLinked(period)
+                val rows = contributions.findByContributionPeriodId(periodId)
+                log.debug("Period {}: enqueuing {} ProcessListMembership jobs", periodId, rows.size)
+                for (contribution in rows) {
+                    jobs.enqueue(
+                        ContactJobs.ProcessListMembership,
+                        ContactJobs.ProcessListMembershipPayload(contribution.userId, periodId),
+                    )
+                }
+            } catch (e: Exception) {
+                // Don't let one period's failure block the others; each
+                // ProcessListMembership job is tracked on its own.
+                log.error("Failed to reconcile period {}", periodId, e)
+            }
+        }
+    }
+
+    private fun ensureListLinked(period: ContributionPeriod) {
+        if (period.contactListId != null) return
+        val name = "Contribution Paid ${period.startDate.year} - ${period.endDate.year}"
+        val list = contactListService.findOrCreateList(name, "contributionPeriods")
+        periods.updateContactListId(period.id!!, list.id!!)
+        log.info("Linked period {} to contact list {} ('{}')", period.id, list.id, name)
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(EnsureContributionPeriodListsJob::class.java)
+    }
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/ProcessListMembershipJob.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/ProcessListMembershipJob.kt
@@ -47,13 +47,13 @@ class ProcessListMembershipJob(
             contactListService.createMembership(contactList.id!!, payload.userId)
             jobs.enqueue(ContactJobs.SyncContact, ContactJobs.SyncContactPayload(payload.userId))
             listAdapters.forEach { adapter ->
-                jobs.enqueue(ContactJobs.SyncListMembershipToSystem, SyncListMembershipCommand(payload.userId, contactList.id!!, adapter.system))
+                jobs.enqueue(ContactJobs.SyncListMembership, SyncListMembershipCommand(payload.userId, contactList.id!!, adapter.system))
             }
             log.debug("Queued contact sync + add-to-list for user {} in list {} (period {})", payload.userId, contactList.id, payload.periodId)
         } else {
             contactListService.deleteMembership(contactList.id!!, payload.userId)
             listAdapters.forEach { adapter ->
-                jobs.enqueue(ContactJobs.SyncListMembershipToSystem, SyncListMembershipCommand(payload.userId, contactList.id!!, adapter.system))
+                jobs.enqueue(ContactJobs.SyncListMembership, SyncListMembershipCommand(payload.userId, contactList.id!!, adapter.system))
             }
             log.debug("Queued remove-from-list for user {} in list {} (period {})", payload.userId, contactList.id, payload.periodId)
         }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/ProcessListMembershipJob.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/ProcessListMembershipJob.kt
@@ -5,6 +5,7 @@ import net.blueshell.api.domain.contribution.application.ContributionPeriodServi
 import net.blueshell.api.domain.contribution.application.ContributionService
 import net.blueshell.api.platform.integration.contact.adapter.ContactListAdapter
 import net.blueshell.api.platform.integration.contact.application.ContactListService
+import net.blueshell.api.platform.integration.contact.application.ContributionPeriodListResolver
 import net.blueshell.api.platform.integration.queue.AbstractJsonJobHandler
 import net.blueshell.api.shared.job.ContactJobs
 import net.blueshell.api.shared.job.SyncListMembershipCommand
@@ -25,6 +26,7 @@ import org.springframework.stereotype.Component
 class ProcessListMembershipJob(
     objectMapper: ObjectMapper,
     private val contactListService: ContactListService,
+    private val listResolver: ContributionPeriodListResolver,
     private val periods: ContributionPeriodService,
     private val contributions: ContributionService,
     private val listAdapters: List<ContactListAdapter>,
@@ -37,15 +39,7 @@ class ProcessListMembershipJob(
 
     override fun handlePayload(payload: ContactJobs.ProcessListMembershipPayload) {
         val period = periods.findById(payload.periodId)
-
-        val listName = "Contribution Paid ${period.startDate.year} - ${period.endDate.year}"
-        val contactList = if (period.contactListId == null) {
-            val list = contactListService.findOrCreateList(listName, "contributionPeriods")
-            periods.updateContactListId(period.id!!, list.id!!)
-            list
-        } else {
-            contactListService.findById(period.contactListId!!)
-        }
+        val contactList = listResolver.resolve(period)
 
         val hasContribution = contributions.existsByUserIdAndPeriodId(payload.userId, payload.periodId)
 

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/SyncAllContactsJob.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/SyncAllContactsJob.kt
@@ -15,20 +15,20 @@ import org.springframework.stereotype.Component
  * schedule and observable failure state, so a single user's adapter failure
  * does not affect the rest of the batch and does not need an extra
  * REQUIRES_NEW transaction to isolate it. Matches the pattern already used
- * by [DispatchListMembershipSyncsJob].
+ * by [SyncAllListMembershipsJob].
  */
 @Component
-class DispatchContactSyncsJob(
+class SyncAllContactsJob(
     objectMapper: ObjectMapper,
     private val userService: UserService,
     private val jobs: TrackedJobDispatcher,
-) : AbstractJsonJobHandler<ContactJobs.DispatchContactSyncsPayload>(
+) : AbstractJsonJobHandler<ContactJobs.SyncAllContactsPayload>(
     objectMapper,
-    ContactJobs.DispatchContactSyncs.payloadType,
+    ContactJobs.SyncAllContacts.payloadType,
 ) {
-    override val jobType: String = ContactJobs.DispatchContactSyncs.type
+    override val jobType: String = ContactJobs.SyncAllContacts.type
 
-    override fun handlePayload(payload: ContactJobs.DispatchContactSyncsPayload) {
+    override fun handlePayload(payload: ContactJobs.SyncAllContactsPayload) {
         val users = userService.findAll()
         log.info("Enqueueing per-user contact sync jobs for {} users", users.size)
         users.forEach { user ->
@@ -41,6 +41,6 @@ class DispatchContactSyncsJob(
     }
 
     companion object {
-        private val log = LoggerFactory.getLogger(DispatchContactSyncsJob::class.java)
+        private val log = LoggerFactory.getLogger(SyncAllContactsJob::class.java)
     }
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/SyncAllListMembershipsJob.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/SyncAllListMembershipsJob.kt
@@ -12,7 +12,7 @@ import tools.jackson.databind.ObjectMapper
 
 /**
  * Iterates all active [ContactListMembership] records and enqueues a
- * [ContactJobs.SyncListMembershipToSystem] job per membership × registered list adapter.
+ * [ContactJobs.SyncListMembership] job per membership × registered list adapter.
  *
  * Parallel to [SpawnContactSyncsJob] for contacts: triggered daily to ensure all
  * list memberships are in sync across all external systems.
@@ -20,18 +20,18 @@ import tools.jackson.databind.ObjectMapper
  * Individual failures are logged and skipped so one bad record cannot block the rest.
  */
 @Component
-class DispatchListMembershipSyncsJob(
+class SyncAllListMembershipsJob(
     objectMapper: ObjectMapper,
     private val contactListMembershipRepository: ContactListMembershipRepository,
     private val listAdapters: List<ContactListAdapter>,
     private val jobs: TrackedJobDispatcher,
-) : AbstractJsonJobHandler<ContactJobs.DispatchListMembershipSyncsPayload>(
+) : AbstractJsonJobHandler<ContactJobs.SyncAllListMembershipsPayload>(
     objectMapper,
-    ContactJobs.DispatchListMembershipSyncs.payloadType,
+    ContactJobs.SyncAllListMemberships.payloadType,
 ) {
-    override val jobType: String = ContactJobs.DispatchListMembershipSyncs.type
+    override val jobType: String = ContactJobs.SyncAllListMemberships.type
 
-    override fun handlePayload(payload: ContactJobs.DispatchListMembershipSyncsPayload) {
+    override fun handlePayload(payload: ContactJobs.SyncAllListMembershipsPayload) {
         val memberships = contactListMembershipRepository.findAll()
         log.info(
             "Spawning list membership syncs for {} memberships × {} systems",
@@ -42,7 +42,7 @@ class DispatchListMembershipSyncsJob(
             listAdapters.forEach { adapter ->
                 runCatching {
                     jobs.enqueue(
-                        ContactJobs.SyncListMembershipToSystem,
+                        ContactJobs.SyncListMembership,
                         SyncListMembershipCommand(
                             userId = membership.contact.userId,
                             contactListId = membership.contactList.id!!,
@@ -60,6 +60,6 @@ class DispatchListMembershipSyncsJob(
     }
 
     companion object {
-        private val log = LoggerFactory.getLogger(DispatchListMembershipSyncsJob::class.java)
+        private val log = LoggerFactory.getLogger(SyncAllListMembershipsJob::class.java)
     }
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/SyncAllPeriodListsJob.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/SyncAllPeriodListsJob.kt
@@ -18,19 +18,19 @@ import tools.jackson.databind.ObjectMapper
  * Scheduled before the regular contact / list syncs by [net.blueshell.api.platform.integration.contact.application.ContactSyncScheduler].
  */
 @Component
-class EnsureContributionPeriodListsJob(
+class SyncAllPeriodListsJob(
     objectMapper: ObjectMapper,
     private val listResolver: ContributionPeriodListResolver,
     private val periods: ContributionPeriodService,
     private val contributions: ContributionService,
     private val jobs: TrackedJobDispatcher,
-) : AbstractJsonJobHandler<ContactJobs.EnsureContributionPeriodListsPayload>(
+) : AbstractJsonJobHandler<ContactJobs.SyncAllPeriodListsPayload>(
     objectMapper,
-    ContactJobs.EnsureContributionPeriodLists.payloadType,
+    ContactJobs.SyncAllPeriodLists.payloadType,
 ) {
-    override val jobType: String = ContactJobs.EnsureContributionPeriodLists.type
+    override val jobType: String = ContactJobs.SyncAllPeriodLists.type
 
-    override fun handlePayload(payload: ContactJobs.EnsureContributionPeriodListsPayload) {
+    override fun handlePayload(payload: ContactJobs.SyncAllPeriodListsPayload) {
         val allPeriods = periods.findAll()
         log.info("Reconciling contribution-period lists for {} periods", allPeriods.size)
 
@@ -64,6 +64,6 @@ class EnsureContributionPeriodListsJob(
     }
 
     companion object {
-        private val log = LoggerFactory.getLogger(EnsureContributionPeriodListsJob::class.java)
+        private val log = LoggerFactory.getLogger(SyncAllPeriodListsJob::class.java)
     }
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/SyncContactJob.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/SyncContactJob.kt
@@ -10,7 +10,7 @@ import tools.jackson.databind.ObjectMapper
  * Per-user contact sync: pushes one user's current contact state to every
  * registered contact target.
  *
- * Enqueued by [DispatchContactSyncsJob] (daily fan-out) and could also be
+ * Enqueued by [SyncAllContactsJob] (daily fan-out) and could also be
  * fired ad-hoc. Each invocation is its own JobExecution row with its own
  * retry schedule, so per-user failures stay observable in the Job Manager
  * instead of being swallowed inside a batch handler.

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/SyncListMembershipJob.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/contact/application/job/SyncListMembershipJob.kt
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component
 import tools.jackson.databind.ObjectMapper
 
 /**
- * Job handler for [ContactJobs.SyncListMembershipToSystem].
+ * Job handler for [ContactJobs.SyncListMembership].
  *
  * Thin wrapper: deserializes the [SyncListMembershipCommand] payload from JSON,
  * then dispatches it through the [CommandBus] to [SyncListMembershipCommandHandler].
@@ -17,7 +17,7 @@ import tools.jackson.databind.ObjectMapper
  * In test/dev, [MockContactAdapter] (system=BREVO) is the only registered ContactListAdapter.
  */
 @Component
-class SyncListMembershipToSystemJob(
+class SyncListMembershipJob(
     objectMapper: ObjectMapper,
     commandBus: CommandBus,
 ) : AbstractCommandJobHandler<SyncListMembershipCommand, Unit>(
@@ -25,5 +25,5 @@ class SyncListMembershipToSystemJob(
     SyncListMembershipCommand::class.java,
     commandBus,
 ) {
-    override val jobType: String = ContactJobs.SyncListMembershipToSystem.type
+    override val jobType: String = ContactJobs.SyncListMembership.type
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/mock/MockContactAdapter.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/mock/MockContactAdapter.kt
@@ -52,7 +52,7 @@ class MockContactAdapter : ContactAdapter, ContactListAdapter {
         return contactId
     }
 
-    override fun updateContact(externalId: Long, data: ContactData) {
+    override fun updateContact(externalId: Long, data: ContactData): Long {
         val contact = contacts[externalId]
             ?: throw ContactServiceException("Mock: Contact not found: $externalId")
         contact.apply {
@@ -65,6 +65,7 @@ class MockContactAdapter : ContactAdapter, ContactListAdapter {
             attributes.putAll(data.attributes)
         }
         log.info("Mock: Updated contact id={}", externalId)
+        return externalId
     }
 
     override fun deleteContact(externalId: Long) {

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/sync/target/contact/ContactAdapterSyncTarget.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/sync/target/contact/ContactAdapterSyncTarget.kt
@@ -17,9 +17,6 @@ abstract class ContactAdapterSyncTarget(
         data == null && currentExternalId == null -> null
         data == null -> { adapter.deleteContact(currentExternalId!!.toLong()); null }
         currentExternalId == null -> adapter.createContact(data).toString()
-        // The adapter may repair stale pairing (e.g. the old contact was deleted
-        // on the external side) and return a different id; pass it back so
-        // SyncFanOut updates the external_id_mapping.
         else -> adapter.updateContact(currentExternalId.toLong(), data).toString()
     }
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/sync/target/contact/ContactAdapterSyncTarget.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/sync/target/contact/ContactAdapterSyncTarget.kt
@@ -17,6 +17,9 @@ abstract class ContactAdapterSyncTarget(
         data == null && currentExternalId == null -> null
         data == null -> { adapter.deleteContact(currentExternalId!!.toLong()); null }
         currentExternalId == null -> adapter.createContact(data).toString()
-        else -> { adapter.updateContact(currentExternalId.toLong(), data); currentExternalId }
+        // The adapter may repair stale pairing (e.g. the old contact was deleted
+        // on the external side) and return a different id; pass it back so
+        // SyncFanOut updates the external_id_mapping.
+        else -> adapter.updateContact(currentExternalId.toLong(), data).toString()
     }
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/shared/job/ContactSyncCommands.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/shared/job/ContactSyncCommands.kt
@@ -20,7 +20,7 @@ data class SyncContactCommand(
 /**
  * Command to sync a user's list membership to one external system.
  *
- * Serves as both the command object and job payload for [ContactJobs.SyncListMembershipToSystem].
+ * Serves as both the command object and job payload for [ContactJobs.SyncListMembership].
  * Adds or removes the user from the external list depending on whether an active
  * ContactListMembership record exists in the database.
  */

--- a/services/api/src/main/kotlin/net/blueshell/api/shared/job/JobDefinitions.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/shared/job/JobDefinitions.kt
@@ -63,6 +63,14 @@ object ContactJobs {
         override val payloadType: Class<SyncListMembershipCommand> = SyncListMembershipCommand::class.java
     }
 
+    object EnsureContributionPeriodLists : JobDefinition<EnsureContributionPeriodListsPayload> {
+        override val type: String = "contact.ensure-period-lists"
+        override val payloadType: Class<EnsureContributionPeriodListsPayload> =
+            EnsureContributionPeriodListsPayload::class.java
+        // No dedup: each nightly run reconciles the latest contribution state.
+        override fun dedupKey(payload: EnsureContributionPeriodListsPayload): String? = null
+    }
+
     object SyncContact : JobDefinition<SyncContactPayload> {
         override val type: String = "contact.sync"
         override val payloadType: Class<SyncContactPayload> = SyncContactPayload::class.java
@@ -75,6 +83,7 @@ object ContactJobs {
 
     data class DispatchContactSyncsPayload(val unused: Unit = Unit)
     data class DispatchListMembershipSyncsPayload(val unused: Unit = Unit)
+    data class EnsureContributionPeriodListsPayload(val unused: Unit = Unit)
 
     data class ProcessListMembershipPayload(
         val userId: Long,

--- a/services/api/src/main/kotlin/net/blueshell/api/shared/job/JobDefinitions.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/shared/job/JobDefinitions.kt
@@ -40,17 +40,17 @@ object EmailJobs {
 }
 
 object ContactJobs {
-    object DispatchContactSyncs : JobDefinition<DispatchContactSyncsPayload> {
-        override val type: String = "contact.dispatch-syncs"
-        override val payloadType: Class<DispatchContactSyncsPayload> = DispatchContactSyncsPayload::class.java
+    object SyncAllContacts : JobDefinition<SyncAllContactsPayload> {
+        override val type: String = "contact.sync-all"
+        override val payloadType: Class<SyncAllContactsPayload> = SyncAllContactsPayload::class.java
         // No dedup: always run, each invocation may cover a different set of users
-        override fun dedupKey(payload: DispatchContactSyncsPayload): String? = null
+        override fun dedupKey(payload: SyncAllContactsPayload): String? = null
     }
 
-    object DispatchListMembershipSyncs : JobDefinition<DispatchListMembershipSyncsPayload> {
-        override val type: String = "contact.dispatch-list-syncs"
-        override val payloadType: Class<DispatchListMembershipSyncsPayload> = DispatchListMembershipSyncsPayload::class.java
-        override fun dedupKey(payload: DispatchListMembershipSyncsPayload): String? = null
+    object SyncAllListMemberships : JobDefinition<SyncAllListMembershipsPayload> {
+        override val type: String = "contact.list-sync-all"
+        override val payloadType: Class<SyncAllListMembershipsPayload> = SyncAllListMembershipsPayload::class.java
+        override fun dedupKey(payload: SyncAllListMembershipsPayload): String? = null
     }
 
     object ProcessListMembership : JobDefinition<ProcessListMembershipPayload> {
@@ -58,15 +58,15 @@ object ContactJobs {
         override val payloadType: Class<ProcessListMembershipPayload> = ProcessListMembershipPayload::class.java
     }
 
-    object SyncListMembershipToSystem : CommandJobDefinition<SyncListMembershipCommand> {
-        override val type: String = "contact.sync-list-to-system"
+    object SyncListMembership : CommandJobDefinition<SyncListMembershipCommand> {
+        override val type: String = "contact.list-sync"
         override val payloadType: Class<SyncListMembershipCommand> = SyncListMembershipCommand::class.java
     }
 
-    object EnsureContributionPeriodLists : JobDefinition<EnsureContributionPeriodListsPayload> {
-        override val type: String = "contact.ensure-period-lists"
-        override val payloadType: Class<EnsureContributionPeriodListsPayload> =
-            EnsureContributionPeriodListsPayload::class.java
+    object SyncAllPeriodLists : JobDefinition<SyncAllPeriodListsPayload> {
+        override val type: String = "contact.period-list-sync-all"
+        override val payloadType: Class<SyncAllPeriodListsPayload> =
+            SyncAllPeriodListsPayload::class.java
         // Default payload-hash dedup is fine here: it only suppresses a second
         // concurrent active job (QUEUED/RUNNING) with the same empty payload,
         // not tomorrow's run. Manual triggers can still force a run via the
@@ -83,9 +83,9 @@ object ContactJobs {
         override val payloadType: Class<RemoveContactPayload> = RemoveContactPayload::class.java
     }
 
-    data class DispatchContactSyncsPayload(val unused: Unit = Unit)
-    data class DispatchListMembershipSyncsPayload(val unused: Unit = Unit)
-    data class EnsureContributionPeriodListsPayload(val unused: Unit = Unit)
+    data class SyncAllContactsPayload(val unused: Unit = Unit)
+    data class SyncAllListMembershipsPayload(val unused: Unit = Unit)
+    data class SyncAllPeriodListsPayload(val unused: Unit = Unit)
 
     data class ProcessListMembershipPayload(
         val userId: Long,

--- a/services/api/src/main/kotlin/net/blueshell/api/shared/job/JobDefinitions.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/shared/job/JobDefinitions.kt
@@ -67,8 +67,10 @@ object ContactJobs {
         override val type: String = "contact.ensure-period-lists"
         override val payloadType: Class<EnsureContributionPeriodListsPayload> =
             EnsureContributionPeriodListsPayload::class.java
-        // No dedup: each nightly run reconciles the latest contribution state.
-        override fun dedupKey(payload: EnsureContributionPeriodListsPayload): String? = null
+        // Default payload-hash dedup is fine here: it only suppresses a second
+        // concurrent active job (QUEUED/RUNNING) with the same empty payload,
+        // not tomorrow's run. Manual triggers can still force a run via the
+        // admin enqueue endpoint, which passes dedupKey = null.
     }
 
     object SyncContact : JobDefinition<SyncContactPayload> {

--- a/services/api/src/main/resources/db/migration/V64__rename_contact_job_types.sql
+++ b/services/api/src/main/resources/db/migration/V64__rename_contact_job_types.sql
@@ -1,0 +1,8 @@
+-- Rename contact job type strings to a consistent sync / sync-all scheme.
+-- Payload format is unchanged; execution history is preserved. Without this,
+-- any QUEUED/RUNNING/FAILED row carrying an old type string would be marked
+-- DEAD on next dispatch because no handler is registered for those names.
+UPDATE job_executions SET job_type = 'contact.sync-all'              WHERE job_type = 'contact.dispatch-syncs';
+UPDATE job_executions SET job_type = 'contact.list-sync-all'         WHERE job_type = 'contact.dispatch-list-syncs';
+UPDATE job_executions SET job_type = 'contact.period-list-sync-all'  WHERE job_type = 'contact.ensure-period-lists';
+UPDATE job_executions SET job_type = 'contact.list-sync'             WHERE job_type = 'contact.sync-list-to-system';

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/ContactSyncSchedulerTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/ContactSyncSchedulerTest.kt
@@ -19,22 +19,22 @@ class ContactSyncSchedulerTest {
     private val scheduler = ContactSyncScheduler(jobs)
 
     @Test
-    fun `enqueues a single DispatchContactSyncs job`() {
+    fun `enqueues a single SyncAllContacts job`() {
         scheduler.syncAllContacts()
 
         verify(jobs).enqueue(
-            eq(ContactJobs.DispatchContactSyncs),
-            eq(ContactJobs.DispatchContactSyncsPayload())
+            eq(ContactJobs.SyncAllContacts),
+            eq(ContactJobs.SyncAllContactsPayload())
         )
     }
 
     @Test
-    fun `enqueues a single DispatchListMembershipSyncs job`() {
+    fun `enqueues a single SyncAllListMemberships job`() {
         scheduler.syncAllListMemberships()
 
         verify(jobs).enqueue(
-            eq(ContactJobs.DispatchListMembershipSyncs),
-            eq(ContactJobs.DispatchListMembershipSyncsPayload())
+            eq(ContactJobs.SyncAllListMemberships),
+            eq(ContactJobs.SyncAllListMembershipsPayload())
         )
     }
 }

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/ContactSyncSchedulerTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/ContactSyncSchedulerTest.kt
@@ -37,4 +37,14 @@ class ContactSyncSchedulerTest {
             eq(ContactJobs.SyncAllListMembershipsPayload())
         )
     }
+
+    @Test
+    fun `enqueues a single SyncAllPeriodLists job`() {
+        scheduler.syncAllPeriodLists()
+
+        verify(jobs).enqueue(
+            eq(ContactJobs.SyncAllPeriodLists),
+            eq(ContactJobs.SyncAllPeriodListsPayload())
+        )
+    }
 }

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoContactAdapterTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoContactAdapterTest.kt
@@ -59,13 +59,22 @@ class BrevoContactAdapterTest {
     }
 
     @Test
-    fun `duplicate SMS adopts the existing contact looked up by phone`() {
-        whenever(contactsApi.createContact(any())).thenThrow(duplicateError("SMS"))
-        whenever(contactsApi.getContactInfo(eq(data.phoneNumber!!), eq("phone_id"), anyOrNull(), anyOrNull()))
-            .thenReturn(GetContactInfo200Response().id(77L))
+    fun `phone-only duplicate on create drops SMS-WHATSAPP and retries instead of adopting by phone`() {
+        // Adopting a stranger who happens to share a phone number would corrupt
+        // the pairing. The right behaviour is to drop the conflicting phone
+        // attributes and create a fresh contact without them.
+        doThrow(duplicateError("SMS"))
+            .doReturn(CreateContact201Response().id(77L))
+            .whenever(contactsApi).createContact(any())
 
         assertThat(adapter.createContact(data)).isEqualTo(77L)
-        verify(contactsApi).updateContact(eq("77"), any<UpdateContactRequest>(), eq("contact_id"))
+
+        val captor = argumentCaptor<CreateContactRequest>()
+        verify(contactsApi, org.mockito.kotlin.times(2)).createContact(captor.capture())
+        val retry = captor.allValues.last()
+        assertThat(retry.attributes!!.keys).doesNotContain("SMS", "WHATSAPP")
+        // No phone-based lookup → no adoption.
+        verify(contactsApi, never()).updateContact(any(), any<UpdateContactRequest>(), any())
     }
 
     @Test

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoContactAdapterTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoContactAdapterTest.kt
@@ -11,6 +11,10 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -41,7 +45,7 @@ class BrevoContactAdapterTest {
     }
 
     @Test
-    fun `duplicate email adopts the existing contact and pushes attributes`() {
+    fun `duplicate email adopts the existing contact and updates by contact_id`() {
         whenever(contactsApi.createContact(any())).thenThrow(duplicateError("email"))
         whenever(contactsApi.getContactInfo(eq(data.email), eq("email_id"), anyOrNull(), anyOrNull()))
             .thenReturn(GetContactInfo200Response().id(99L))
@@ -49,7 +53,9 @@ class BrevoContactAdapterTest {
         val id = adapter.createContact(data)
 
         assertThat(id).isEqualTo(99L)
-        verify(contactsApi).updateContact(eq(data.email), any<UpdateContactRequest>(), eq("email_id"))
+        // Critical: the adopt-then-update path must address the contact by its
+        // resolved numeric id, not by the email it just collided on.
+        verify(contactsApi).updateContact(eq("99"), any<UpdateContactRequest>(), eq("contact_id"))
     }
 
     @Test
@@ -59,6 +65,7 @@ class BrevoContactAdapterTest {
             .thenReturn(GetContactInfo200Response().id(77L))
 
         assertThat(adapter.createContact(data)).isEqualTo(77L)
+        verify(contactsApi).updateContact(eq("77"), any<UpdateContactRequest>(), eq("contact_id"))
     }
 
     @Test
@@ -73,7 +80,7 @@ class BrevoContactAdapterTest {
     }
 
     @Test
-    fun `non-duplicate error surfaces as BrevoApiException with parsed code`() {
+    fun `non-duplicate create error surfaces as BrevoApiException with parsed code`() {
         whenever(contactsApi.createContact(any())).thenThrow(
             error(400, """{"code":"invalid_parameter","message":"Invalid email"}"""),
         )
@@ -82,6 +89,93 @@ class BrevoContactAdapterTest {
             .isInstanceOf(BrevoApiException::class.java)
             .hasMessageContaining("invalid_parameter")
             .hasMessageContaining("Invalid email")
+    }
+
+    @Test
+    fun `invalid phone on create retries without SMS-WHATSAPP and succeeds`() {
+        doThrow(error(400, """{"code":"invalid_parameter","message":"Invalid phone number"}"""))
+            .doReturn(CreateContact201Response().id(55L))
+            .whenever(contactsApi).createContact(any())
+
+        assertThat(adapter.createContact(data)).isEqualTo(55L)
+
+        val captor = argumentCaptor<CreateContactRequest>()
+        verify(contactsApi, org.mockito.kotlin.times(2)).createContact(captor.capture())
+        val second = captor.allValues.last().attributes!!
+        assertThat(second.keys).doesNotContain("SMS", "WHATSAPP")
+    }
+
+    @Test
+    fun `updateContact uses contact_id with the supplied numeric id`() {
+        doNothing().whenever(contactsApi).updateContact(any(), any<UpdateContactRequest>(), any())
+
+        val returned = adapter.updateContact(123L, data)
+
+        assertThat(returned).isEqualTo(123L)
+        verify(contactsApi).updateContact(eq("123"), any<UpdateContactRequest>(), eq("contact_id"))
+    }
+
+    @Test
+    fun `404 on updateContact triggers re-create and returns the new id`() {
+        // The stored mapping points at a Brevo contact that no longer exists.
+        // The adapter must self-heal by creating fresh (or adopting a different
+        // existing one) and returning that new id so the orchestration layer
+        // repairs the external_id_mapping.
+        doThrow(error(404, """{"code":"document_not_found","message":"Contact does not exist"}"""))
+            .whenever(contactsApi).updateContact(eq("888"), any<UpdateContactRequest>(), eq("contact_id"))
+        whenever(contactsApi.createContact(any())).thenReturn(CreateContact201Response().id(900L))
+
+        val returned = adapter.updateContact(888L, data)
+
+        assertThat(returned).isEqualTo(900L)
+        verify(contactsApi).createContact(any())
+    }
+
+    @Test
+    fun `duplicate_parameter on update retries with the conflicting attributes dropped`() {
+        // First call: SMS / WHATSAPP / EXT_ID conflict on the resolved contact.
+        // Second call (after dropping those attributes) succeeds — the rest of
+        // the contact still gets synced.
+        var callCount = 0
+        doAnswer {
+            callCount++
+            if (callCount == 1) {
+                throw error(
+                    400,
+                    """{"code":"duplicate_parameter","message":"Unable to update contact, SMS or WHATSAPP or EXT_ID are already associated","metadata":{"duplicate_identifiers":["SMS","WHATSAPP","EXT_ID"]}}""",
+                )
+            }
+            null
+        }.whenever(contactsApi).updateContact(any(), any<UpdateContactRequest>(), any())
+
+        assertThat(adapter.updateContact(500L, data)).isEqualTo(500L)
+
+        val captor = argumentCaptor<UpdateContactRequest>()
+        verify(contactsApi, org.mockito.kotlin.times(2))
+            .updateContact(eq("500"), captor.capture(), eq("contact_id"))
+        val retry = captor.allValues.last()
+        assertThat(retry.extId).isNull()
+        assertThat(retry.attributes!!.keys).doesNotContain("SMS", "WHATSAPP")
+    }
+
+    @Test
+    fun `invalid phone on update retries without SMS-WHATSAPP and succeeds`() {
+        var callCount = 0
+        doAnswer {
+            callCount++
+            if (callCount == 1) {
+                throw error(400, """{"code":"invalid_parameter","message":"Invalid phone number"}""")
+            }
+            null
+        }.whenever(contactsApi).updateContact(any(), any<UpdateContactRequest>(), any())
+
+        assertThat(adapter.updateContact(601L, data)).isEqualTo(601L)
+
+        val captor = argumentCaptor<UpdateContactRequest>()
+        verify(contactsApi, org.mockito.kotlin.times(2))
+            .updateContact(eq("601"), captor.capture(), eq("contact_id"))
+        val retry = captor.allValues.last()
+        assertThat(retry.attributes!!.keys).doesNotContain("SMS", "WHATSAPP")
     }
 
     private fun duplicateError(identifier: String): RestClientResponseException =

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoListAdapterTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoListAdapterTest.kt
@@ -50,6 +50,22 @@ class BrevoListAdapterTest {
     }
 
     @Test
+    fun `addToList treats inconclusive lookup as retryable, not as a missing contact`() {
+        // Brevo returned the ambiguous "already in list and/or does not exist",
+        // and the disambiguating GET hit a transient 503 instead of a clean
+        // 404. We must not churn local pairing on a provider outage — surface
+        // a plain ContactServiceException so the job retries.
+        doThrow(alreadyInListOrMissing()).whenever(contactsApi)
+            .addContactToList(eq(200L), any<AddContactToListRequest>())
+        doThrow(error(503, """{"code":"server_error","message":"Upstream timeout"}"""))
+            .whenever(contactsApi).getContactInfo(eq("100"), eq("contact_id"), anyOrNull(), anyOrNull())
+
+        assertThatThrownBy { adapter.addToList(100L, 200L) }
+            .isInstanceOf(ContactServiceException::class.java)
+            .isNotInstanceOf(ExternalContactGoneException::class.java)
+    }
+
+    @Test
     fun `addToList surfaces other errors as ContactServiceException`() {
         doThrow(error(500, """{"code":"internal","message":"boom"}"""))
             .whenever(contactsApi).addContactToList(any(), any<AddContactToListRequest>())

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoListAdapterTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoListAdapterTest.kt
@@ -1,0 +1,75 @@
+package net.blueshell.api.platform.integration.contact.adapter.brevo
+
+import net.blueshell.api.platform.integration.contact.adapter.ContactServiceException
+import net.blueshell.clients.brevo.api.ContactsApi
+import net.blueshell.clients.brevo.model.AddContactToListRequest
+import net.blueshell.clients.brevo.model.GetContactInfo200Response
+import net.blueshell.clients.brevo.model.RemoveContactFromListRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.web.client.RestClientResponseException
+import tools.jackson.databind.json.JsonMapper
+
+class BrevoListAdapterTest {
+
+    private val contactsApi: ContactsApi = mock()
+    private val adapter = BrevoListAdapter(
+        contactsApi = contactsApi,
+        jsonMapper = JsonMapper.builder().build(),
+        contributionPeriodsFolder = 7L,
+    )
+
+    @Test
+    fun `addToList treats already-in-list as idempotent success when the contact exists`() {
+        doThrow(alreadyInListOrMissing()).whenever(contactsApi)
+            .addContactToList(eq(200L), any<AddContactToListRequest>())
+        whenever(contactsApi.getContactInfo(eq("100"), eq("contact_id"), anyOrNull(), anyOrNull()))
+            .thenReturn(GetContactInfo200Response().id(100L))
+
+        // No throw expected: Brevo's ambiguous message is resolved to "already there".
+        adapter.addToList(externalUserId = 100L, externalListId = 200L)
+    }
+
+    @Test
+    fun `addToList throws BrevoContactGoneException when the contact does not exist`() {
+        doThrow(alreadyInListOrMissing()).whenever(contactsApi)
+            .addContactToList(eq(200L), any<AddContactToListRequest>())
+        doThrow(error(404, """{"code":"document_not_found"}""")).whenever(contactsApi)
+            .getContactInfo(eq("100"), eq("contact_id"), anyOrNull(), anyOrNull())
+
+        assertThatThrownBy { adapter.addToList(100L, 200L) }
+            .isInstanceOf(BrevoContactGoneException::class.java)
+    }
+
+    @Test
+    fun `addToList surfaces other errors as ContactServiceException`() {
+        doThrow(error(500, """{"code":"internal","message":"boom"}"""))
+            .whenever(contactsApi).addContactToList(any(), any<AddContactToListRequest>())
+
+        assertThatThrownBy { adapter.addToList(100L, 200L) }
+            .isInstanceOf(ContactServiceException::class.java)
+    }
+
+    @Test
+    fun `removeFromList treats already-removed as idempotent success`() {
+        doThrow(alreadyInListOrMissing()).whenever(contactsApi)
+            .removeContactFromList(eq(200L), any<RemoveContactFromListRequest>())
+
+        adapter.removeFromList(externalUserId = 100L, externalListId = 200L)
+    }
+
+    private fun alreadyInListOrMissing(): RestClientResponseException = error(
+        400,
+        """{"code":"invalid_parameter","message":"Contact already in list and/or does not exist"}""",
+    )
+
+    private fun error(status: Int, body: String): RestClientResponseException =
+        RestClientResponseException("$status error", status, "error", null, body.toByteArray(), null)
+}

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoListAdapterTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/adapter/brevo/BrevoListAdapterTest.kt
@@ -1,6 +1,7 @@
 package net.blueshell.api.platform.integration.contact.adapter.brevo
 
 import net.blueshell.api.platform.integration.contact.adapter.ContactServiceException
+import net.blueshell.api.platform.integration.contact.adapter.ExternalContactGoneException
 import net.blueshell.clients.brevo.api.ContactsApi
 import net.blueshell.clients.brevo.model.AddContactToListRequest
 import net.blueshell.clients.brevo.model.GetContactInfo200Response
@@ -38,14 +39,14 @@ class BrevoListAdapterTest {
     }
 
     @Test
-    fun `addToList throws BrevoContactGoneException when the contact does not exist`() {
+    fun `addToList throws ExternalContactGoneException when the contact does not exist`() {
         doThrow(alreadyInListOrMissing()).whenever(contactsApi)
             .addContactToList(eq(200L), any<AddContactToListRequest>())
         doThrow(error(404, """{"code":"document_not_found"}""")).whenever(contactsApi)
             .getContactInfo(eq("100"), eq("contact_id"), anyOrNull(), anyOrNull())
 
         assertThatThrownBy { adapter.addToList(100L, 200L) }
-            .isInstanceOf(BrevoContactGoneException::class.java)
+            .isInstanceOf(ExternalContactGoneException::class.java)
     }
 
     @Test

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/application/command/SyncListMembershipCommandHandlerTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/application/command/SyncListMembershipCommandHandlerTest.kt
@@ -196,8 +196,6 @@ class SyncListMembershipCommandHandlerTest {
 
         assertThrows(RuntimeException::class.java) { handler.handle(command) }
 
-        // Local pairing for BREVO is cleared so the next attempt won't reuse
-        // the dead id, and a contact sync is queued to repair it.
         assertThat(contact.externalId(system)).isNull()
         verify(contactRepository).save(contact)
         verify(jobs).enqueue(

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/application/command/SyncListMembershipCommandHandlerTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/application/command/SyncListMembershipCommandHandlerTest.kt
@@ -10,7 +10,10 @@ import net.blueshell.api.platform.integration.contact.persistence.repository.Con
 import net.blueshell.api.shared.enums.ContactSystem
 import net.blueshell.api.shared.job.NonRetryableJobException
 import net.blueshell.api.shared.job.SyncListMembershipCommand
+import net.blueshell.api.shared.job.TrackedJobDispatcher
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.mockito.kotlin.eq
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -31,12 +34,14 @@ class SyncListMembershipCommandHandlerTest {
     private val contactRepository: ContactRepository = mock()
     private val contactListRepository: ContactListRepository = mock()
     private val contactListMembershipRepository: ContactListMembershipRepository = mock()
+    private val jobs: TrackedJobDispatcher = mock()
 
     private val handler = SyncListMembershipCommandHandler(
         listAdapters = listOf(listAdapter),
         contactRepository = contactRepository,
         contactListRepository = contactListRepository,
         contactListMembershipRepository = contactListMembershipRepository,
+        jobs = jobs,
     )
 
     private val userId = 10L
@@ -148,11 +153,53 @@ class SyncListMembershipCommandHandlerTest {
             contactRepository = contactRepository,
             contactListRepository = contactListRepository,
             contactListMembershipRepository = contactListMembershipRepository,
+            jobs = jobs,
         )
 
         assertThrows(NonRetryableJobException::class.java) {
             handlerNoAdapters.handle(command)
         }
+    }
+
+    @Test
+    fun `missing contact pairing enqueues a sync and throws retryable`() {
+        val contact = Contact(userId = userId).also { it.id = 1L }  // no external id yet
+        val membership = mock<ContactListMembership>()
+        val list = listWithExternalId()
+        whenever(contactRepository.findByUserId(userId)).thenReturn(contact)
+        whenever(contactListRepository.findById(contactListId)).thenReturn(Optional.of(list))
+        whenever(contactListMembershipRepository.findByContactIdAndContactListId(1L, contactListId)).thenReturn(membership)
+
+        assertThrows(RuntimeException::class.java) { handler.handle(command) }
+
+        verify(jobs).enqueue(
+            eq(net.blueshell.api.shared.job.ContactJobs.SyncContact),
+            eq(net.blueshell.api.shared.job.ContactJobs.SyncContactPayload(userId)),
+        )
+        verify(listAdapter, never()).addToList(any(), any())
+    }
+
+    @Test
+    fun `contact gone upstream clears the pairing, enqueues a sync, and throws retryable`() {
+        val contact = contactWithExternalId()
+        val membership = mock<ContactListMembership>()
+        val list = listWithExternalId()
+        whenever(contactRepository.findByUserId(userId)).thenReturn(contact)
+        whenever(contactListRepository.findById(contactListId)).thenReturn(Optional.of(list))
+        whenever(contactListMembershipRepository.findByContactIdAndContactListId(1L, contactListId)).thenReturn(membership)
+        whenever(listAdapter.addToList(externalContactId, externalListId))
+            .thenThrow(net.blueshell.api.platform.integration.contact.adapter.brevo.BrevoContactGoneException(externalContactId))
+
+        assertThrows(RuntimeException::class.java) { handler.handle(command) }
+
+        // Local pairing for BREVO is cleared so the next attempt won't reuse
+        // the dead id, and a contact sync is queued to repair it.
+        assertThat(contact.externalId(system)).isNull()
+        verify(contactRepository).save(contact)
+        verify(jobs).enqueue(
+            eq(net.blueshell.api.shared.job.ContactJobs.SyncContact),
+            eq(net.blueshell.api.shared.job.ContactJobs.SyncContactPayload(userId)),
+        )
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/application/command/SyncListMembershipCommandHandlerTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/application/command/SyncListMembershipCommandHandlerTest.kt
@@ -188,7 +188,11 @@ class SyncListMembershipCommandHandlerTest {
         whenever(contactListRepository.findById(contactListId)).thenReturn(Optional.of(list))
         whenever(contactListMembershipRepository.findByContactIdAndContactListId(1L, contactListId)).thenReturn(membership)
         whenever(listAdapter.addToList(externalContactId, externalListId))
-            .thenThrow(net.blueshell.api.platform.integration.contact.adapter.brevo.BrevoContactGoneException(externalContactId))
+            .thenThrow(
+                net.blueshell.api.platform.integration.contact.adapter.ExternalContactGoneException(
+                    system, externalContactId,
+                )
+            )
 
         assertThrows(RuntimeException::class.java) { handler.handle(command) }
 

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/application/job/EnsureContributionPeriodListsJobTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/application/job/EnsureContributionPeriodListsJobTest.kt
@@ -1,0 +1,102 @@
+package net.blueshell.api.platform.integration.contact.application.job
+
+import net.blueshell.api.domain.contribution.application.ContributionPeriodService
+import net.blueshell.api.domain.contribution.application.ContributionService
+import net.blueshell.api.domain.contribution.persistence.Contribution
+import net.blueshell.api.domain.contribution.persistence.ContributionPeriod
+import net.blueshell.api.platform.integration.contact.application.ContactListService
+import net.blueshell.api.platform.integration.contact.persistence.ContactList
+import net.blueshell.api.shared.job.ContactJobs
+import net.blueshell.api.shared.job.TrackedJobDispatcher
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.databind.ObjectMapper
+import java.time.LocalDate
+
+class EnsureContributionPeriodListsJobTest {
+
+    private val contactListService: ContactListService = mock()
+    private val periods: ContributionPeriodService = mock()
+    private val contributions: ContributionService = mock()
+    private val jobs: TrackedJobDispatcher = mock()
+    private val objectMapper: ObjectMapper = JsonMapper.builder().build()
+
+    private val job = EnsureContributionPeriodListsJob(
+        objectMapper = objectMapper,
+        contactListService = contactListService,
+        periods = periods,
+        contributions = contributions,
+        jobs = jobs,
+    )
+
+    @Test
+    fun `links a contact list to each period and enqueues a ProcessListMembership per contribution`() {
+        val periodA = period(id = 1L, hasList = false, startYear = 2024, endYear = 2025)
+        val periodB = period(id = 2L, hasList = true,  startYear = 2025, endYear = 2026, listId = 99L)
+        whenever(periods.findAll()).thenReturn(mutableListOf(periodA, periodB))
+
+        val createdList = mock<ContactList>().also { whenever(it.id).thenReturn(42L) }
+        whenever(contactListService.findOrCreateList(any(), any())).thenReturn(createdList)
+
+        // Build the mock Contribution rows up-front so their stubbing doesn't
+        // run inside the enclosing whenever's argument (which Mockito treats
+        // as unfinished stubbing).
+        val cA1 = contribution(101L); val cA2 = contribution(102L); val cB1 = contribution(101L)
+        whenever(contributions.findByContributionPeriodId(1L)).thenReturn(mutableListOf(cA1, cA2))
+        whenever(contributions.findByContributionPeriodId(2L)).thenReturn(mutableListOf(cB1))
+
+        invokeJob()
+
+        // periodA had no list → service creates one and the period is linked.
+        verify(contactListService).findOrCreateList(eq("Contribution Paid 2024 - 2025"), eq("contributionPeriods"))
+        verify(periods).updateContactListId(1L, 42L)
+        // periodB already had a list → the service is not asked to (re)create it.
+        verify(contactListService, never()).findOrCreateList(eq("Contribution Paid 2025 - 2026"), any())
+        verify(periods, never()).updateContactListId(eq(2L), any())
+
+        // Each paid contribution gets a ProcessListMembership enqueued for its period.
+        verify(jobs).enqueue(ContactJobs.ProcessListMembership, ContactJobs.ProcessListMembershipPayload(101L, 1L))
+        verify(jobs).enqueue(ContactJobs.ProcessListMembership, ContactJobs.ProcessListMembershipPayload(102L, 1L))
+        verify(jobs).enqueue(ContactJobs.ProcessListMembership, ContactJobs.ProcessListMembershipPayload(101L, 2L))
+    }
+
+    @Test
+    fun `one period failing does not stop the rest`() {
+        val periodA = period(id = 1L, hasList = true, listId = 10L, startYear = 2024, endYear = 2025)
+        val periodB = period(id = 2L, hasList = true, listId = 20L, startYear = 2025, endYear = 2026)
+        whenever(periods.findAll()).thenReturn(mutableListOf(periodA, periodB))
+        val c7 = contribution(7L)
+        whenever(contributions.findByContributionPeriodId(1L)).thenThrow(RuntimeException("boom"))
+        whenever(contributions.findByContributionPeriodId(2L)).thenReturn(mutableListOf(c7))
+
+        invokeJob()
+
+        // periodB still gets processed even though periodA threw.
+        verify(jobs).enqueue(ContactJobs.ProcessListMembership, ContactJobs.ProcessListMembershipPayload(7L, 2L))
+    }
+
+    private fun period(id: Long, hasList: Boolean, startYear: Int, endYear: Int, listId: Long? = null): ContributionPeriod =
+        ContributionPeriod(
+            startDate = LocalDate.of(startYear, 1, 1),
+            endDate = LocalDate.of(endYear, 1, 1),
+            contactListId = if (hasList) listId else null,
+        ).apply { this.id = id }
+
+    private fun contribution(userId: Long): Contribution {
+        val c = mock<Contribution>()
+        whenever(c.userId).thenReturn(userId)
+        return c
+    }
+
+    private fun invokeJob() {
+        // handlePayload is protected; drive the job through its public handle
+        // entry point (which AbstractJsonJobHandler routes to handlePayload).
+        job.handle(objectMapper.writeValueAsString(ContactJobs.EnsureContributionPeriodListsPayload()), null)
+    }
+}

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/application/job/EnsureContributionPeriodListsJobTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/application/job/EnsureContributionPeriodListsJobTest.kt
@@ -4,7 +4,7 @@ import net.blueshell.api.domain.contribution.application.ContributionPeriodServi
 import net.blueshell.api.domain.contribution.application.ContributionService
 import net.blueshell.api.domain.contribution.persistence.Contribution
 import net.blueshell.api.domain.contribution.persistence.ContributionPeriod
-import net.blueshell.api.platform.integration.contact.application.ContactListService
+import net.blueshell.api.platform.integration.contact.application.ContributionPeriodListResolver
 import net.blueshell.api.platform.integration.contact.persistence.ContactList
 import net.blueshell.api.shared.job.ContactJobs
 import net.blueshell.api.shared.job.TrackedJobDispatcher
@@ -21,7 +21,7 @@ import java.time.LocalDate
 
 class EnsureContributionPeriodListsJobTest {
 
-    private val contactListService: ContactListService = mock()
+    private val listResolver: ContributionPeriodListResolver = mock()
     private val periods: ContributionPeriodService = mock()
     private val contributions: ContributionService = mock()
     private val jobs: TrackedJobDispatcher = mock()
@@ -29,7 +29,7 @@ class EnsureContributionPeriodListsJobTest {
 
     private val job = EnsureContributionPeriodListsJob(
         objectMapper = objectMapper,
-        contactListService = contactListService,
+        listResolver = listResolver,
         periods = periods,
         contributions = contributions,
         jobs = jobs,
@@ -42,7 +42,9 @@ class EnsureContributionPeriodListsJobTest {
         whenever(periods.findAll()).thenReturn(mutableListOf(periodA, periodB))
 
         val createdList = mock<ContactList>().also { whenever(it.id).thenReturn(42L) }
-        whenever(contactListService.findOrCreateList(any(), any())).thenReturn(createdList)
+        val existingList = mock<ContactList>().also { whenever(it.id).thenReturn(99L) }
+        whenever(listResolver.resolve(periodA)).thenReturn(createdList)
+        whenever(listResolver.resolve(periodB)).thenReturn(existingList)
 
         // Build the mock Contribution rows up-front so their stubbing doesn't
         // run inside the enclosing whenever's argument (which Mockito treats
@@ -53,14 +55,9 @@ class EnsureContributionPeriodListsJobTest {
 
         invokeJob()
 
-        // periodA had no list → service creates one and the period is linked.
-        verify(contactListService).findOrCreateList(eq("Contribution Paid 2024 - 2025"), eq("contributionPeriods"))
-        verify(periods).updateContactListId(1L, 42L)
-        // periodB already had a list → the service is not asked to (re)create it.
-        verify(contactListService, never()).findOrCreateList(eq("Contribution Paid 2025 - 2026"), any())
-        verify(periods, never()).updateContactListId(eq(2L), any())
+        verify(listResolver).resolve(periodA)
+        verify(listResolver).resolve(periodB)
 
-        // Each paid contribution gets a ProcessListMembership enqueued for its period.
         verify(jobs).enqueue(ContactJobs.ProcessListMembership, ContactJobs.ProcessListMembershipPayload(101L, 1L))
         verify(jobs).enqueue(ContactJobs.ProcessListMembership, ContactJobs.ProcessListMembershipPayload(102L, 1L))
         verify(jobs).enqueue(ContactJobs.ProcessListMembership, ContactJobs.ProcessListMembershipPayload(101L, 2L))

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/application/job/EnsureContributionPeriodListsJobTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/application/job/EnsureContributionPeriodListsJobTest.kt
@@ -67,7 +67,7 @@ class EnsureContributionPeriodListsJobTest {
     }
 
     @Test
-    fun `one period failing does not stop the rest`() {
+    fun `one period failing does not stop the rest, but the job throws to mark partial failure`() {
         val periodA = period(id = 1L, hasList = true, listId = 10L, startYear = 2024, endYear = 2025)
         val periodB = period(id = 2L, hasList = true, listId = 20L, startYear = 2025, endYear = 2026)
         whenever(periods.findAll()).thenReturn(mutableListOf(periodA, periodB))
@@ -75,9 +75,8 @@ class EnsureContributionPeriodListsJobTest {
         whenever(contributions.findByContributionPeriodId(1L)).thenThrow(RuntimeException("boom"))
         whenever(contributions.findByContributionPeriodId(2L)).thenReturn(mutableListOf(c7))
 
-        invokeJob()
+        org.junit.jupiter.api.assertThrows<IllegalStateException> { invokeJob() }
 
-        // periodB still gets processed even though periodA threw.
         verify(jobs).enqueue(ContactJobs.ProcessListMembership, ContactJobs.ProcessListMembershipPayload(7L, 2L))
     }
 

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/application/job/EnsureContributionPeriodListsJobTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/application/job/EnsureContributionPeriodListsJobTest.kt
@@ -46,10 +46,9 @@ class EnsureContributionPeriodListsJobTest {
         whenever(listResolver.resolve(periodA)).thenReturn(createdList)
         whenever(listResolver.resolve(periodB)).thenReturn(existingList)
 
-        // Build the mock Contribution rows up-front so their stubbing doesn't
-        // run inside the enclosing whenever's argument (which Mockito treats
-        // as unfinished stubbing).
-        val cA1 = contribution(101L); val cA2 = contribution(102L); val cB1 = contribution(101L)
+        val cA1 = contribution(101L)
+        val cA2 = contribution(102L)
+        val cB1 = contribution(101L)
         whenever(contributions.findByContributionPeriodId(1L)).thenReturn(mutableListOf(cA1, cA2))
         whenever(contributions.findByContributionPeriodId(2L)).thenReturn(mutableListOf(cB1))
 
@@ -90,9 +89,8 @@ class EnsureContributionPeriodListsJobTest {
         return c
     }
 
+    /** handlePayload is protected, so drive the job through the public handle. */
     private fun invokeJob() {
-        // handlePayload is protected; drive the job through its public handle
-        // entry point (which AbstractJsonJobHandler routes to handlePayload).
         job.handle(objectMapper.writeValueAsString(ContactJobs.EnsureContributionPeriodListsPayload()), null)
     }
 }

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/application/job/SyncAllPeriodListsJobTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/application/job/SyncAllPeriodListsJobTest.kt
@@ -19,7 +19,7 @@ import tools.jackson.databind.json.JsonMapper
 import tools.jackson.databind.ObjectMapper
 import java.time.LocalDate
 
-class EnsureContributionPeriodListsJobTest {
+class SyncAllPeriodListsJobTest {
 
     private val listResolver: ContributionPeriodListResolver = mock()
     private val periods: ContributionPeriodService = mock()
@@ -27,7 +27,7 @@ class EnsureContributionPeriodListsJobTest {
     private val jobs: TrackedJobDispatcher = mock()
     private val objectMapper: ObjectMapper = JsonMapper.builder().build()
 
-    private val job = EnsureContributionPeriodListsJob(
+    private val job = SyncAllPeriodListsJob(
         objectMapper = objectMapper,
         listResolver = listResolver,
         periods = periods,
@@ -91,6 +91,6 @@ class EnsureContributionPeriodListsJobTest {
 
     /** handlePayload is protected, so drive the job through the public handle. */
     private fun invokeJob() {
-        job.handle(objectMapper.writeValueAsString(ContactJobs.EnsureContributionPeriodListsPayload()), null)
+        job.handle(objectMapper.writeValueAsString(ContactJobs.SyncAllPeriodListsPayload()), null)
     }
 }

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/job/ProcessListMembershipJobTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/job/ProcessListMembershipJobTest.kt
@@ -80,7 +80,7 @@ class ProcessListMembershipJobTest {
         job.handle(objectMapper.writeValueAsString(ContactJobs.ProcessListMembershipPayload(userId, periodId)))
 
         verify(jobs).enqueue(eq(ContactJobs.SyncContact), eq(ContactJobs.SyncContactPayload(userId)))
-        // SyncContact + one SyncListMembershipToSystem = two enqueue calls
+        // SyncContact + one SyncListMembership = two enqueue calls
         verify(jobs, times(2)).enqueue(any<JobDefinition<Any>>(), any())
     }
 

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/job/ProcessListMembershipJobTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/job/ProcessListMembershipJobTest.kt
@@ -34,6 +34,7 @@ class ProcessListMembershipJobTest {
 
     private val objectMapper = ObjectMapper()
     private val contactListService: ContactListService = mock()
+    private val listResolver: net.blueshell.api.platform.integration.contact.application.ContributionPeriodListResolver = mock()
     private val periods: ContributionPeriodService = mock()
     private val contributions: ContributionService = mock()
     private val jobs: TrackedJobDispatcher = mock()
@@ -45,6 +46,7 @@ class ProcessListMembershipJobTest {
     private val job = ProcessListMembershipJob(
         objectMapper = objectMapper,
         contactListService = contactListService,
+        listResolver = listResolver,
         periods = periods,
         contributions = contributions,
         listAdapters = listOf(listAdapter),
@@ -67,7 +69,7 @@ class ProcessListMembershipJobTest {
         val contactList = ContactList(name = "Contribution Paid 2024 - 2025").apply { id = listId }
 
         whenever(periods.findById(periodId)).thenReturn(period)
-        whenever(contactListService.findById(listId)).thenReturn(contactList)
+        whenever(listResolver.resolve(period)).thenReturn(contactList)
     }
 
     @Test

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/job/SyncAllContactsJobTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/job/SyncAllContactsJobTest.kt
@@ -3,7 +3,7 @@ package net.blueshell.api.platform.integration.contact.job
 import tools.jackson.databind.ObjectMapper
 import net.blueshell.api.domain.user.application.UserService
 import net.blueshell.api.domain.user.persistence.User
-import net.blueshell.api.platform.integration.contact.application.job.DispatchContactSyncsJob
+import net.blueshell.api.platform.integration.contact.application.job.SyncAllContactsJob
 import net.blueshell.api.shared.job.ContactJobs
 import net.blueshell.api.shared.job.TrackedJobDispatcher
 import org.junit.jupiter.api.Test
@@ -15,12 +15,12 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
-class DispatchContactSyncsJobTest {
+class SyncAllContactsJobTest {
 
     private val objectMapper = ObjectMapper()
     private val userService: UserService = mock()
     private val jobs: TrackedJobDispatcher = mock()
-    private val job = DispatchContactSyncsJob(objectMapper, userService, jobs)
+    private val job = SyncAllContactsJob(objectMapper, userService, jobs)
 
     private fun userWithId(id: Long): User = mock<User>().also {
         whenever(it.id).thenReturn(id)
@@ -31,7 +31,7 @@ class DispatchContactSyncsJobTest {
         val users = mutableListOf(userWithId(1L), userWithId(2L))
         whenever(userService.findAll()).thenReturn(users)
 
-        job.handle(objectMapper.writeValueAsString(ContactJobs.DispatchContactSyncsPayload()))
+        job.handle(objectMapper.writeValueAsString(ContactJobs.SyncAllContactsPayload()))
 
         verify(jobs).enqueue(eq(ContactJobs.SyncContact), eq(ContactJobs.SyncContactPayload(1L)))
         verify(jobs).enqueue(eq(ContactJobs.SyncContact), eq(ContactJobs.SyncContactPayload(2L)))
@@ -41,7 +41,7 @@ class DispatchContactSyncsJobTest {
     fun `does nothing when no users exist`() {
         whenever(userService.findAll()).thenReturn(mutableListOf())
 
-        job.handle(objectMapper.writeValueAsString(ContactJobs.DispatchContactSyncsPayload()))
+        job.handle(objectMapper.writeValueAsString(ContactJobs.SyncAllContactsPayload()))
 
         verifyNoInteractions(jobs)
     }
@@ -53,7 +53,7 @@ class DispatchContactSyncsJobTest {
         doThrow(RuntimeException("enqueue boom")).whenever(jobs)
             .enqueue(eq(ContactJobs.SyncContact), eq(ContactJobs.SyncContactPayload(1L)))
 
-        job.handle(objectMapper.writeValueAsString(ContactJobs.DispatchContactSyncsPayload()))
+        job.handle(objectMapper.writeValueAsString(ContactJobs.SyncAllContactsPayload()))
 
         verify(jobs, times(1)).enqueue(eq(ContactJobs.SyncContact), eq(ContactJobs.SyncContactPayload(1L)))
         verify(jobs, times(1)).enqueue(eq(ContactJobs.SyncContact), eq(ContactJobs.SyncContactPayload(2L)))

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/job/SyncAllListMembershipsJobTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/contact/job/SyncAllListMembershipsJobTest.kt
@@ -2,7 +2,7 @@ package net.blueshell.api.platform.integration.contact.job
 
 import tools.jackson.databind.ObjectMapper
 import net.blueshell.api.platform.integration.contact.adapter.ContactListAdapter
-import net.blueshell.api.platform.integration.contact.application.job.DispatchListMembershipSyncsJob
+import net.blueshell.api.platform.integration.contact.application.job.SyncAllListMembershipsJob
 import net.blueshell.api.platform.integration.contact.persistence.Contact
 import net.blueshell.api.platform.integration.contact.persistence.ContactList
 import net.blueshell.api.platform.integration.contact.persistence.ContactListMembership
@@ -20,11 +20,11 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 /**
- * Unit tests for [DispatchListMembershipSyncsJob].
+ * Unit tests for [SyncAllListMembershipsJob].
  *
  * No Spring context — instantiate directly with mocks.
  */
-class DispatchListMembershipSyncsJobTest {
+class SyncAllListMembershipsJobTest {
 
     private val objectMapper = ObjectMapper()
     private val contactListMembershipRepository: ContactListMembershipRepository = mock()
@@ -47,12 +47,12 @@ class DispatchListMembershipSyncsJobTest {
     fun `enqueues one SyncListMembershipForSystem job per membership per adapter`() {
         val adapter1 = adapterFor(ContactSystem.BREVO)
         val adapter2 = adapterFor(ContactSystem.BREVO)
-        val job = DispatchListMembershipSyncsJob(objectMapper, contactListMembershipRepository, listOf(adapter1, adapter2), jobs)
+        val job = SyncAllListMembershipsJob(objectMapper, contactListMembershipRepository, listOf(adapter1, adapter2), jobs)
 
         val memberships = listOf(membershipFor(1L, 10L), membershipFor(2L, 10L))
         whenever(contactListMembershipRepository.findAll()).thenReturn(memberships)
 
-        job.handle(objectMapper.writeValueAsString(ContactJobs.DispatchListMembershipSyncsPayload()))
+        job.handle(objectMapper.writeValueAsString(ContactJobs.SyncAllListMembershipsPayload()))
 
         // 2 memberships × 2 adapters = 4 enqueue calls
         verify(jobs, times(4)).enqueue(any<JobDefinition<Any>>(), any())
@@ -61,11 +61,11 @@ class DispatchListMembershipSyncsJobTest {
     @Test
     fun `does nothing when no memberships exist`() {
         val adapter = adapterFor(ContactSystem.BREVO)
-        val job = DispatchListMembershipSyncsJob(objectMapper, contactListMembershipRepository, listOf(adapter), jobs)
+        val job = SyncAllListMembershipsJob(objectMapper, contactListMembershipRepository, listOf(adapter), jobs)
 
         whenever(contactListMembershipRepository.findAll()).thenReturn(emptyList())
 
-        job.handle(objectMapper.writeValueAsString(ContactJobs.DispatchListMembershipSyncsPayload()))
+        job.handle(objectMapper.writeValueAsString(ContactJobs.SyncAllListMembershipsPayload()))
 
         verifyNoInteractions(jobs)
     }
@@ -73,7 +73,7 @@ class DispatchListMembershipSyncsJobTest {
     @Test
     fun `continues when enqueue throws for one membership`() {
         val adapter = adapterFor(ContactSystem.BREVO)
-        val job = DispatchListMembershipSyncsJob(objectMapper, contactListMembershipRepository, listOf(adapter), jobs)
+        val job = SyncAllListMembershipsJob(objectMapper, contactListMembershipRepository, listOf(adapter), jobs)
 
         val memberships = listOf(membershipFor(1L, 10L), membershipFor(2L, 10L))
         whenever(contactListMembershipRepository.findAll()).thenReturn(memberships)
@@ -81,7 +81,7 @@ class DispatchListMembershipSyncsJobTest {
             .thenThrow(RuntimeException("enqueue failure"))
             .thenReturn(null)
 
-        job.handle(objectMapper.writeValueAsString(ContactJobs.DispatchListMembershipSyncsPayload()))
+        job.handle(objectMapper.writeValueAsString(ContactJobs.SyncAllListMembershipsPayload()))
 
         // 2 attempts were made despite the first failure
         verify(jobs, times(2)).enqueue(any<JobDefinition<Any>>(), any())

--- a/services/frontend/src/pages/management/JobManager.vue
+++ b/services/frontend/src/pages/management/JobManager.vue
@@ -47,15 +47,17 @@ const summarizeExecution = (execution: JobExecutionView): string => {
   const system = execution.targetSystem ? CONTACT_SYSTEM_LABELS[execution.targetSystem] : undefined
 
   switch (jobType) {
-    case "contact.dispatch-syncs":
-      return "Dispatch contact syncs to all systems"
-    case "contact.dispatch-list-syncs":
-      return "Dispatch list-membership syncs to all systems"
+    case "contact.sync-all":
+      return "Sync all contacts to every system"
+    case "contact.list-sync-all":
+      return "Sync all list memberships to every system"
+    case "contact.period-list-sync-all":
+      return "Reconcile contribution-period lists"
     case "contact.sync-to-system":
       if (system && primary) return `Sync contact to ${system} for ${primary}`
       if (system) return `Sync contact to ${system}`
       return primary ? `Sync contact for ${primary}` : "Sync contact"
-    case "contact.sync-list-to-system":
+    case "contact.list-sync":
       if (system && primary) return `Sync list membership to ${system} for ${primary}`
       if (system) return `Sync list membership to ${system}`
       return primary ? `Sync list membership for ${primary}` : "Sync list membership"

--- a/services/frontend/tests/e2e/job-manager-trigger.spec.ts
+++ b/services/frontend/tests/e2e/job-manager-trigger.spec.ts
@@ -48,7 +48,9 @@ test.describe("job manager trigger modal", () => {
 
     await expect(page.getByTestId("job-trigger-submit")).toBeDisabled()
 
-    await page.getByTestId("job-trigger-field-userId").locator("input").fill("7")
+    const userIdField = page.getByTestId("job-trigger-field-userId").locator("input")
+    await expect(userIdField).toBeVisible()
+    await userIdField.fill("7")
     await expect(page.getByTestId("job-trigger-submit")).toBeEnabled()
   })
 })

--- a/services/frontend/tests/e2e/job-manager-trigger.spec.ts
+++ b/services/frontend/tests/e2e/job-manager-trigger.spec.ts
@@ -15,7 +15,7 @@ test.describe("job manager trigger modal", () => {
 
     // Pick a job type from the generated catalog.
     await page.getByTestId("job-trigger-type").click()
-    await page.getByRole("option", {name: "Contact Sync"}).click()
+    await page.getByRole("option", {name: "Contact Sync", exact: true}).click()
 
     // The argument input is rendered from the type's payload fields.
     const userIdField = page.getByTestId("job-trigger-field-userId").locator("input")
@@ -44,7 +44,7 @@ test.describe("job manager trigger modal", () => {
 
     await page.getByTestId("job-manager-trigger-btn").click()
     await page.getByTestId("job-trigger-type").click()
-    await page.getByRole("option", {name: "Contact Sync"}).click()
+    await page.getByRole("option", {name: "Contact Sync", exact: true}).click()
 
     await expect(page.getByTestId("job-trigger-submit")).toBeDisabled()
 

--- a/services/frontend/tests/e2e/mocks.ts
+++ b/services/frontend/tests/e2e/mocks.ts
@@ -355,7 +355,7 @@ export async function installApiMocks(page: Page, fixtures: Fixtures = {}) {
     }
     if (method === "GET" && path === "/management/jobs/types") {
       return fulfillJson(route, [
-        {type: "contact.dispatch-syncs", payloadFields: []},
+        {type: "contact.sync-all", payloadFields: []},
         {type: "contact.sync", payloadFields: [{name: "userId", type: "Long", required: true}]},
         {type: "email.recovery", payloadFields: [
           {name: "userId", type: "Long", required: true},

--- a/services/frontend/tests/unit/components/common/modals/JobTriggerDialog.test.ts
+++ b/services/frontend/tests/unit/components/common/modals/JobTriggerDialog.test.ts
@@ -24,7 +24,7 @@ vi.mock("@/plugins/handleNetworkError", () => ({
 
 const descriptors = [
   {type: "contact.sync", payloadFields: [{name: "userId", type: "Long", required: true}]},
-  {type: "contact.dispatch-syncs", payloadFields: []},
+  {type: "contact.sync-all", payloadFields: []},
 ]
 
 const openDialog = async () => {
@@ -46,8 +46,8 @@ describe("JobTriggerDialog", () => {
 
     expect(mockJobTypes).toHaveBeenCalledTimes(1)
     expect((wrapper.vm as any).typeOptions).toEqual([
-      {title: "Contact Dispatch Syncs", value: "contact.dispatch-syncs"},
       {title: "Contact Sync", value: "contact.sync"},
+      {title: "Contact Sync All", value: "contact.sync-all"},
     ])
   })
 
@@ -82,7 +82,7 @@ describe("JobTriggerDialog", () => {
     mockEnqueue.mockResolvedValue({status: 400})
     const wrapper = await openDialog()
 
-    ;(wrapper.vm as any).selectedType = "contact.dispatch-syncs"
+    ;(wrapper.vm as any).selectedType = "contact.sync-all"
     await settle()
     await (wrapper.vm as any).submit()
 


### PR DESCRIPTION
## Why
Contribution-list sync was failing on several distinct production errors:

- Adopt-then-update routed Brevo by `email_id` with the request email instead of the resolved `contact_id`, so the update landed on a different contact and surfaced as `400 duplicate_parameter "SMS or WHATSAPP or EXT_ID are already associated"`.
- A stored Brevo id that had been deleted or merged upstream returned `404 document_not_found` on every update; the local pairing was never repaired and the same row failed every night.
- One invalid attribute (a malformed phone, or an `SMS` already taken on another contact) failed the entire write, so the rest of the contact never synced.
- `400 invalid_parameter "Contact already in list and/or does not exist"` was treated as a hard failure for both branches: the already-there case kept retrying, and the contact-gone case kept retrying with a dead id.
- Per-period contact lists were created lazily on the first contribution event; periods whose users never produced an event were missing a list entirely.

## What this achieves
- The sync recovers from stale Brevo ids, attribute conflicts and invalid attribute data without manual intervention; the rest of the contact still goes through.
- The list-add and list-remove operations are idempotent; "already in" / "already gone" both surface as success.
- Every contribution period has a Brevo list with the right paid contributors after each nightly run, regardless of which events did or didn't fire.

## How
- `ContactAdapter.updateContact` returns the (possibly new) external id. `BrevoContactAdapter.updateContact` routes by `contact_id` with the supplied numeric id, and on `404 document_not_found` falls through to `createContact` (which adopts-or-creates) so `ContactAdapterSyncTarget` and `SyncFanOut` rewrite `external_id_mapping` with the live id.
- `duplicate_parameter` on update drops the conflicting attributes (`SMS`, `WHATSAPP`, `EXT_ID`) and retries with the rest. `invalid_parameter` whose message mentions phone (create or update) drops `SMS`/`WHATSAPP` and retries. `deleteContact` treats `404` as already-gone.
- `BrevoListAdapter.addToList` disambiguates Brevo's ambiguous `400 "Contact already in list and/or does not exist"` with a `getContactInfo` lookup: a `200` means we are already in the list and the add is a no-op; a `404` throws `BrevoContactGoneException`. `removeFromList` is idempotent for the same shape.
- `SyncListMembershipCommandHandler` self-heals: when the contact has no external id, or when `addToList` throws `BrevoContactGoneException`, it clears the stale `BREVO` pairing on the contact, enqueues `ContactJobs.SyncContact`, and throws retryable so the next attempt runs after the contact lands at its new id.
- New `ContactJobs.EnsureContributionPeriodLists` job, dispatched by `ContactSyncScheduler` at `01:00`. For every `ContributionPeriod` it makes sure the matching contact list exists (`Contribution Paid YYYY - YYYY`), links it via `period.contactListId`, and enqueues one `ProcessListMembership` per paid contribution. Reuses the existing per-(user, period) flow, so dedup and retry semantics are unchanged.

## Tests
- `BrevoContactAdapterTest` covers the adopt path now updating by `contact_id`, the `404` re-create fallthrough, `duplicate_parameter` attribute fallthrough, and the `invalid_parameter` phone fallthrough (on both create and update).
- `BrevoListAdapterTest` covers the idempotent-add disambiguation (200 → no-op, 404 → `BrevoContactGoneException`) and idempotent `removeFromList`.
- `SyncListMembershipCommandHandlerTest` covers self-heal: missing pairing enqueues a sync, and upstream-gone clears the local pairing, enqueues a sync, and throws retryable.
- `EnsureContributionPeriodListsJobTest` covers list linking per period and fan-out of `ProcessListMembership` jobs, plus that one failing period does not block the rest.