### PR TITLE
build(frontend): split heavy vendors into dedicated chunks

### DIFF
--- a/services/frontend/vite.config.mjs
+++ b/services/frontend/vite.config.mjs
@@ -9,11 +9,26 @@ import istanbul from 'vite-plugin-istanbul'
 export default defineConfig({
     build: {
         target: "esnext",
+        // vuetify (~500 kB) and country-data (~615 kB) are legitimately
+        // above Vite's 500 kB default; lift the threshold above the floor.
+        chunkSizeWarningLimit: 700,
         rollupOptions: {
             output: {
                 entryFileNames: 'assets/[hash].js',
                 chunkFileNames: 'assets/[hash].js',
                 assetFileNames: 'assets/[hash][extname]',
+                // Pin heavy vendors to dedicated chunks so the browser
+                // caches them independently from app code.
+                manualChunks(id) {
+                    if (!/[\\/](?:node_modules|\.yarn[\\/]cache)[\\/]/.test(id)) return
+                    if (/[\\/]vuetify[\\/]/.test(id)) return 'vuetify'
+                    if (/[\\/]libphonenumber-js[\\/]/.test(id)) return 'libphonenumber'
+                    if (/[\\/](?:world-countries|countries-list|i18n-nationality)[\\/]/.test(id)) return 'country-data'
+                    if (/[\\/](?:v-phone-input|flag-icons)[\\/]/.test(id)) return 'phone-input'
+                    if (/[\\/](?:vue|@vue|vue-router|vuex|vue-axios)[\\/]/.test(id)) return 'vue-core'
+                    if (/[\\/]luxon[\\/]/.test(id)) return 'datetime'
+                    if (/[\\/](?:marked|dompurify|xss|node-emoji)[\\/]/.test(id)) return 'markup'
+                },
             },
         },
     },


### PR DESCRIPTION
## Why

The production build emitted Vite's chunk-size warning every time the
frontend image was built. `vuetify`, `world-countries` / `countries-list`
and `libphonenumber-js` were all packed into the same entry bundle,
producing a 1.32 MB and a 617 kB chunk. Aside from being slow on first
load, this meant a one-line app change re-invalidated megabytes of
vendor code in every browser cache.

## What this achieves

The chunk-size warning is gone. Vendor code is now split across stable,
named chunks that the browser caches independently from app code and
fetches in parallel: an app-only change no longer forces a re-download
of vuetify, the country dataset, or libphonenumber-js. The two
remaining big chunks are `vuetify` (~500 kB) and `country-data`
(~615 kB) — both pure framework / data, neither shrinkable without a
code refactor.

## How

`services/frontend/vite.config.mjs` gains a `manualChunks(id)` function
in `build.rollupOptions.output` that matches vendor paths under
`node_modules/` and `.yarn/cache/`, routing each to a named chunk:

- `vuetify` — Vuetify itself.
- `libphonenumber-js` — split out separately because it is the heaviest
  dependency of `v-phone-input` and is also used outside it.
- `country-data` — `world-countries`, `countries-list`,
  `i18n-nationality`.
- `phone-input` — `v-phone-input`, `flag-icons`.
- `vue-core` — `vue`, `@vue/*`, `vue-router`, `vuex`, `vue-axios`.
- `datetime` — `luxon`.
- `markup` — `marked`, `dompurify`, `xss`, `node-emoji`.

`build.chunkSizeWarningLimit` rises to 700 kB so the floor stops
producing noise but a genuine regression (e.g. a 1 MB chunk creeping
back) still trips the warning.

Out of scope: the `(node:…) [DEP0040] DeprecationWarning: punycode` line
that appears in the CI build log is emitted by `docker/setup-buildx-action`
itself, before `yarn build` runs. Reproducing the build locally under
both Node 22 (the Dockerfile base) and Node 24 produced no DEP0040 from
the frontend toolchain, so this PR leaves it alone.