### PR TITLE
build(frontend): exclude dev-only paths from the docker build context

### DIFF
--- a/services/frontend/.dockerignore
+++ b/services/frontend/.dockerignore
@@ -1,4 +1,50 @@
+# Build context for services/frontend/Dockerfile.
+#
+# The Dockerfile's `build` stage runs `yarn install --immutable` followed
+# by `yarn build` (vite build). Anything not consumed by that command
+# chain belongs here, so local-only artefacts cannot bust the COPY layer
+# and the context stays small.
+
+# Image build artefacts and VCS metadata
 Dockerfile
 Dockerfile-dev
-node_modules
+docker-compose.yml
 .git
+.gitignore
+.dockerignore
+
+# Installed modules (regenerated inside the deps stage)
+node_modules
+.yarn/cache
+.yarn/unplugged
+.yarn/install-state.gz
+.yarn/sdks
+
+# Build / test / coverage output
+dist
+coverage
+test-results
+playwright-report
+.vitest
+.playwright-browsers
+
+# Editor and OS metadata
+.idea
+.vscode
+.editorconfig
+*.iml
+.DS_Store
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Tests and test config — not read by `vite build`
+tests
+playwright.config.ts
+vitest.config.ts
+
+# Docs
+README.md


### PR DESCRIPTION
## Why

`services/frontend/.dockerignore` listed only four entries: `Dockerfile`,
`Dockerfile-dev`, `node_modules` and `.git`. Everything else in the
directory — `coverage/`, `dist/`, `test-results/`, `playwright-report/`,
`.DS_Store`, locally-populated `.yarn/cache` and `.yarn/unplugged`, IDE
metadata, log files — was free to enter the Docker build context. On a
developer machine that meant transferring hundreds of MB the build never
reads, and a touch to any of those local paths could invalidate the
`build` stage's `COPY . .` layer.

## What this achieves

The Docker context shrinks to the files `yarn install --immutable` and
`vite build` actually consume. Local cruft (coverage runs, dist
artefacts, IDE state, OS metadata) no longer rides along with image
builds, so the `COPY . .` layer cache survives day-to-day local churn.
CI's effect is smaller because the runner checks out only tracked
files, but excluding tracked-but-build-irrelevant paths
(`.yarn/sdks`, `.yarn/install-state.gz`, `README.md`, `tests/`,
`playwright.config.ts`, `vitest.config.ts`) still removes a few stable
bytes from the transfer.

## How

`services/frontend/.dockerignore` now groups its exclusions:

- Image build artefacts and VCS metadata: `Dockerfile`,
  `Dockerfile-dev`, `docker-compose.yml`, `.git`, `.gitignore`,
  `.dockerignore`.
- Installed modules regenerated by the deps stage: `node_modules`,
  `.yarn/cache`, `.yarn/unplugged`, `.yarn/install-state.gz`,
  `.yarn/sdks`.
- Build / test / coverage output: `dist`, `coverage`, `test-results`,
  `playwright-report`, `.vitest`, `.playwright-browsers`.
- Editor and OS metadata: `.idea`, `.vscode`, `.editorconfig`, `*.iml`,
  `.DS_Store`.
- Log files: `npm-debug.log*`, `yarn-debug.log*`, `yarn-error.log*`,
  `pnpm-debug.log*`.
- Test sources and configs not read by `vite build`: `tests`,
  `playwright.config.ts`, `vitest.config.ts`.
- Docs: `README.md`.

`.pnp.cjs` and `.pnp.loader.mjs` stay in the context — Yarn 4 PnP
resolution at build time depends on both. The end-to-end image build
was run locally against the tightened context and produces the same
`dist/` output as before.