### PR TITLE
style(frontend): give v-btn a 10px border radius globally

### DIFF
--- a/services/frontend/src/styles/housestyle.scss
+++ b/services/frontend/src/styles/housestyle.scss
@@ -9,6 +9,7 @@ $accent: rgb(var(--v-theme-accent));
   transition-property: all;
   transition-duration: 0.15s;
   transition-delay: 0ms;
+  border-radius: settings.$border-radius-root;
 }
 
 .v-theme--dark.v-application {


### PR DESCRIPTION
## Why
Vuetify 3 defines `$button-border-radius` as a fixed 4px and does not derive it from `$border-radius-root`. The project already sets `$border-radius-root` to 10px in `services/frontend/src/styles/settings.scss`, so lists, sheets and `rounded-b` utilities match the intended 10px corner — but every `v-btn` rendered across the app still uses Vuetify's stock 4px corner, breaking visual consistency with the rest of the surface chrome.

## What this achieves
Buttons now share the same 10px corner radius as the other rounded surfaces, so cards, lists and buttons read as one design language instead of two competing radii. The change is global, applied through the existing stylesheet that already customises `v-btn`, so no per-page overrides are needed.

## How
- `services/frontend/src/styles/housestyle.scss`: the existing global `.v-btn` block (which already sets letter-spacing and transitions) now also sets `border-radius: settings.$border-radius-root`, mirroring the pattern already used by `.v-list` and `.rounded-b` in the same file.

Icon buttons keep their circular shape — Vuetify's `.v-btn--icon` rule has higher specificity and continues to win.