### PR TITLE
feat(edge): redirect stalwart.esa-blueshell.nl/ to /admin/

### DIFF
--- a/platform/cluster/flux/apps/edge/ingressroutes/stalwart-admin.yaml
+++ b/platform/cluster/flux/apps/edge/ingressroutes/stalwart-admin.yaml
@@ -19,7 +19,13 @@ spec:
     # land on its default UI without remembering the suffix.
     - kind: Rule
       match: Host(`stalwart.esa-blueshell.nl`)
+      # stalwart-root-to-admin runs first so a bare-host hit becomes
+      # `/admin/` immediately (Stalwart v0.16 404s the root). The
+      # regex matches only the exact root, so `/admin/` itself does
+      # not loop. forward-auth then SSO-gates `/admin/`.
       middlewares:
+        - name: stalwart-root-to-admin
+          namespace: edge-system
         - name: forward-auth
           namespace: edge-system
       services:

--- a/platform/cluster/flux/apps/edge/kustomization.yaml
+++ b/platform/cluster/flux/apps/edge/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - cluster-issuer-cloudflare.yaml
   - traefik-default-tls.yaml
   - traefik-forward-auth-middleware.yaml
+  - traefik-stalwart-root-redirect-middleware.yaml
   - ingressroutes

--- a/platform/cluster/flux/apps/edge/traefik-stalwart-root-redirect-middleware.yaml
+++ b/platform/cluster/flux/apps/edge/traefik-stalwart-root-redirect-middleware.yaml
@@ -1,0 +1,15 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: stalwart-root-to-admin
+  namespace: edge-system
+spec:
+  # Stalwart v0.16 serves the webadmin under /admin/ and returns 404 at
+  # the bare root, so visiting the host root lands on a 404. Redirect
+  # only the exact root ("/" or no path) to /admin/; /admin/ itself
+  # does not match this regex, so there is no loop. 302 (not permanent)
+  # keeps the redirect uncached in case the landing path changes.
+  redirectRegex:
+    regex: ^https?://([^/]+)/?$
+    replacement: https://${1}/admin/
+    permanent: false


### PR DESCRIPTION
## Summary

PR 3 of 5. Adds a Traefik `redirectRegex` Middleware so the bare host `stalwart.esa-blueshell.nl/` lands on the webadmin instead of a 404.

Stalwart v0.16 serves its webadmin under `/admin/` and 404s the root. The middleware regex `^https?://([^/]+)/?$` matches only the exact host root (with optional trailing slash); `/admin/` does not match, so there is no loop. A 302 (not permanent) keeps the redirect uncached should the landing path change.

The middleware is attached **ahead of forward-auth** in the `stalwart-admin` IngressRoute. The chain for an authenticated session becomes:

```
GET /       → 302 /admin/    (stalwart-root-to-admin)
GET /admin/ → 200 webadmin   (forward-auth passes the cookie through)
```

For an unauthenticated session:
```
GET /       → 302 /admin/    (stalwart-root-to-admin runs first; no auth check yet)
GET /admin/ → 302 auth login (forward-auth)
```

Neither flow loops; `/admin/` simply doesn't match the redirect regex.

## Dependency

This PR is independent of #258 / #260 in the Kubernetes manifest sense — it just adds an edge middleware. But the redirect is only useful **after** #260 lands, because v0.15 (current main) still serves `/webadmin/`, not `/admin/`. If you merge this before #260, the redirect points users at a 404. Merge order: **#258 → #260 → this PR**.

## Test plan

- [x] `kubectl kustomize platform/cluster/flux/apps/edge` builds; the stalwart-admin IngressRoute renders with `stalwart-root-to-admin` ahead of `forward-auth`.
- [ ] After merge: `curl -I https://stalwart.esa-blueshell.nl/` → 302 with `Location: https://stalwart.esa-blueshell.nl/admin/`.
- [ ] `curl -I https://stalwart.esa-blueshell.nl/admin/` → 302 to the auth login.
- [ ] In a browser (authenticated): typing the bare host lands on the webadmin.

## What's next

- PR 4 — `accounts.json` populated with role mailboxes + Vault password keys.
- PR 5 — gatus probes for `/admin/` HTTP + mail-port TCP.