### PR TITLE
fix(gatus): probe stalwart webadmin at /admin/ not /

### DIFF
--- a/platform/cluster/flux/apps/utility-system/gatus/gatus-endpoints-configmap.yaml
+++ b/platform/cluster/flux/apps/utility-system/gatus/gatus-endpoints-configmap.yaml
@@ -71,7 +71,11 @@ data:
       - "[RESPONSE_TIME] < 500"
     - name: "Stalwart Admin"
       group: "admin"
-      url: "http://stalwart.mail-system.svc.cluster.local:8080/"
+      # Stalwart v0.16 serves the webadmin at /admin/ and 404s the root.
+      # The probe runs internally against the Service DNS, which bypasses
+      # forward-auth at the edge (an external probe of an SSO-gated host
+      # only ever sees 302, telling us nothing about the backing app).
+      url: "http://stalwart.mail-system.svc.cluster.local:8080/admin/"
       interval: "60s"
       conditions:
       - "[STATUS] == 200"


### PR DESCRIPTION
## Summary

PR 5 of 5. One-liner: the Stalwart Admin gatus probe targets the root path, which v0.16 returns 404 for. Once #260 ships the v0.16 cutover, the status page will start reporting Stalwart DOWN even when it's healthy. Probe `/admin/` instead.

## Why this is enough

The mail-port TCP probes already in this file (`Stalwart SMTP` :25, `Stalwart STARTTLS` :587, `Stalwart SMTPS` :465, `Stalwart IMAP` :993) cover the listener-bind failure mode and need no change.

The probe runs internally against `stalwart.mail-system.svc.cluster.local:8080/admin/`, bypassing forward-auth at the edge. An external probe of the SSO-gated host would only ever see 302 to the auth page, which says nothing about whether the backing app is serving.

## Dependency

Should land **after** #260 (the v0.16 cutover). Until v0.16 actually runs, the current v0.15 still serves the webadmin at the root and `/admin/` would 404. Merge order: **#258 → #260 → this PR**. (Or just merge after #260 has reconciled.)

## Test plan

- [x] YAML syntax check (`kubectl kustomize` builds the gatus directory).
- [ ] After #260 + this PR reconcile: status page `Stalwart Admin` endpoint shows green; all `mail`-group probes stay green.