### PR TITLE
fix(stalwart): unblock pod with chown initContainer + ghcr pull secret

### DIFF
--- a/platform/cluster/flux/apps/mail/stalwart/deployment.yaml
+++ b/platform/cluster/flux/apps/mail/stalwart/deployment.yaml
@@ -52,6 +52,33 @@ spec:
       # on the public-IP node.
       nodeSelector:
         kubernetes.io/hostname: frankfurt-contabo-1
+      # The stalwart-tools image is published private under
+      # ghcr.io/esa-blueshell/, same as api / frontend. Without this
+      # secret the apply sidecar ImagePullBackOffs, and the pod's
+      # readiness probe never passes because the sidecar is part of the
+      # pod's combined ready state.
+      imagePullSecrets:
+        - name: ghcr-pull-secret
+      # The PVC carries over from the v0.15 deployment, which ran as
+      # root and left every file in /var/lib/stalwart owned by uid 0.
+      # v0.16 runs as uid 2000 and can't write to those files, so the
+      # main container crashes at boot with
+      # `Permission denied: /var/lib/stalwart/data/LOG`. Chown the
+      # mount once per pod start as uid 0 (the init container is its
+      # own securityContext). Cheap on a clean tree, fixes the v0.15
+      # carry-over PVC on the very first boot of v0.16.
+      initContainers:
+        - name: stalwart-data-perms
+          image: busybox:1.37-musl
+          command:
+            - sh
+            - -c
+            - 'chown -R 2000:2000 /var/lib/stalwart'
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: stalwart-data
+              mountPath: /var/lib/stalwart
       containers:
         # Stalwart reads /etc/stalwart/config.json (datastore pointer
         # only) on boot; everything else is reconciled by the apply

--- a/platform/cluster/flux/apps/vso-secrets/ghcr.yaml
+++ b/platform/cluster/flux/apps/vso-secrets/ghcr.yaml
@@ -37,3 +37,29 @@ spec:
             {{- $auth := printf "%s:%s" (get .Secrets "username") (get .Secrets "token") | b64enc -}}
             {"auths":{"ghcr.io":{"username":"{{ get .Secrets "username" }}","password":"{{ get .Secrets "token" }}","auth":"{{ $auth }}"}}}
   refreshAfter: 1h
+---
+# Second mirror: the stalwart-apply sidecar pulls
+# ghcr.io/esa-blueshell/stalwart-tools (private package) into the
+# mail-system namespace. The vault-secrets-operator ServiceAccount in
+# mail-system already exists (created by stalwart-secrets.yaml).
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: ghcr-pull-secret
+  namespace: mail-system
+spec:
+  vaultAuthRef: vso-system/default
+  type: kv-v2
+  mount: secret
+  path: platform/ghcr
+  destination:
+    name: ghcr-pull-secret
+    create: true
+    type: kubernetes.io/dockerconfigjson
+    transformation:
+      templates:
+        .dockerconfigjson:
+          text: |
+            {{- $auth := printf "%s:%s" (get .Secrets "username") (get .Secrets "token") | b64enc -}}
+            {"auths":{"ghcr.io":{"username":"{{ get .Secrets "username" }}","password":"{{ get .Secrets "token" }}","auth":"{{ $auth }}"}}}
+  refreshAfter: 1h


### PR DESCRIPTION
## Why mail is down

The v0.16 pod that #260 deployed is `CrashLoopBackOff` for two distinct reasons; this PR fixes both.

### 1. Main container — `Permission denied`

```
⚠️ Startup failed: Failed to open database: Error { message:
  "IO error: While renaming a file to /var/lib/stalwart/data/LOG.old.1779970662947701:
   /var/lib/stalwart/data/LOG: Permission denied" }
```

The PVC carries over from v0.15.5, which ran the stalwart binary as root. Every file under `/var/lib/stalwart` is owned by uid 0. v0.16 runs as uid 2000 and can't write to those files — and rotating RocksDB's `LOG` file is the first thing the binary does at startup, so the crash is immediate.

A new `stalwart-data-perms` initContainer (busybox 1.37) runs as uid 0 and does `chown -R 2000:2000 /var/lib/stalwart` on every pod start. No-op on an already-correct tree, fixes the v0.15 carry-over on first boot, self-heals if anything else mints a root-owned file later.

### 2. Sidecar — `ErrImagePull` 401

```
Failed to pull image "ghcr.io/esa-blueshell/stalwart-tools:latest":
  failed to authorize: failed to fetch anonymous token:
  unexpected status from GET request to https://ghcr.io/token...: 401 Unauthorized
```

PR #258's build ran successfully (the image is at `:sha-8eccb8b` / `:latest`), but it's published **private** on ghcr.io, same as `api` and `frontend`. Anonymous pulls 401. The fix is the existing `ghcr-pull-secret` pattern those two already use:

- The stalwart Deployment now references `imagePullSecrets: [ghcr-pull-secret]`.
- `apps/vso-secrets/ghcr.yaml` gains a second `VaultStaticSecret` so the same `dockerconfigjson` Secret materialises in `mail-system` (the existing one was scoped to `default`). The vault-secrets-operator SA in mail-system already exists from `stalwart-secrets.yaml`.

## Test plan

- [x] `kubectl kustomize platform/cluster/flux/apps/mail/stalwart` builds; rendered Deployment has `imagePullSecrets` and the chown initContainer.
- [x] `kubectl kustomize platform/cluster/flux/apps/vso-secrets` builds; ghcr-pull-secret renders in both `default` and `mail-system`.
- [ ] After Flux reconciles `apps-vso-secrets` then `apps-mail`:
  - [ ] `kubectl -n mail-system get secret ghcr-pull-secret` exists, `type: kubernetes.io/dockerconfigjson`.
  - [ ] New stalwart pod's `stalwart-data-perms` init container completes.
  - [ ] Main container boots past the `LOG: Permission denied` line and starts serving on `:8080/admin/`.
  - [ ] `stalwart-apply` sidecar logs `apply: reconcile complete`.

## Order of operations on the cluster

```
flux reconcile kustomization apps-vso-secrets   # ghcr-pull-secret now exists in mail-system
flux reconcile kustomization apps-mail          # new pod with init + pull secret rolls
```

Or just `flux reconcile source git flux-system` if you want both in one go; the apps-mail Kustomization will retry the pod schedule once the Secret is present.