### PR TITLE
feat(dns): add mail records (mail.A/AAAA, MX, SPF, DMARC, DKIM placeholder)

### DIFF
--- a/infra/dns/README.md
+++ b/infra/dns/README.md
@@ -21,12 +21,50 @@ Authoritative zone files, one per domain. Imported into Cloudflare via
 
 After import, toggle the orange cloud per record:
 
-| Record                       | Proxy | Reason                                                 |
-| ---------------------------- | ----- | ------------------------------------------------------ |
-| `@`, `www`                   | on    | Public HTTP(S) behind Cloudflare.                      |
-| `@` (MX target)              | off   | Mail cannot be proxied.                                |
-| `minecraft`                  | off   | Game traffic — Cloudflare proxy is HTTP(S) only.       |
-| `ftp`                        | off   | Non-HTTP protocol.                                     |
+| Record                          | Proxy | Reason                                                                       |
+| ------------------------------- | ----- | ---------------------------------------------------------------------------- |
+| `@`, `www`                      | on    | Public HTTP(S) behind Cloudflare.                                            |
+| `stalwart`                      | on    | Webadmin only — pure HTTP, proxy gives cache + DDoS shielding.               |
+| `mail`                          | off   | SMTP/IMAP/POP3 are raw TCP. Cloudflare proxy is HTTP(S)-only.                |
+| `@` (MX target = `mail`)        | off   | Inherits from the `mail` A/AAAA above.                                       |
+| `_dmarc`, `default._domainkey`  | off   | TXT records — proxy status is irrelevant but Cloudflare convention is "off". |
+| `minecraft`                     | off   | Game traffic — Cloudflare proxy is HTTP(S) only.                             |
+| `ftp`                           | off   | Non-HTTP protocol.                                                           |
+
+## Mail records
+
+Outbound mail signing + inbound delivery for `esa-blueshell.nl` use
+five records, all in this zone file:
+
+- **`mail`** A/AAAA — non-proxied, pointing at the Frankfurt VPS public
+  IP. Stalwart binds the mail ports (25/465/587/993) on the host via
+  `hostPort` on this address.
+- **`@` MX → `mail`** — RFC-mandated indirection; the MX target's
+  A/AAAA must be non-proxied so SMTP delivery reaches the pod
+  directly.
+- **`@` SPF** (`v=spf1 mx ~all`) — authorises the MX hosts to send.
+  Soft-fail (`~all`) for the initial rollout; flip to `-all` once
+  DMARC aggregate reports confirm no legitimate sender is being
+  caught by the `mx` mechanism.
+- **`_dmarc` DMARC** (`v=DMARC1; p=none; rua=mailto:postmaster@…`) —
+  monitor-only at first. Promote to `p=quarantine` once outbound
+  mail is fully aligned on both SPF and DKIM.
+- **`default._domainkey` DKIM** — the public key matching the
+  `DkimSignature` Stalwart manages with `default` as the selector.
+  The zone file ships a placeholder (`p=REPLACE_AFTER_FIRST_BOOT`)
+  because the actual public key is derived from the private key in
+  Vault and only becomes visible after the apply sidecar creates the
+  `DkimSignature` object. To populate it:
+
+  ```sh
+  kubectl -n mail-system exec deploy/stalwart -c stalwart-apply -- \
+    stalwart-cli query DkimSignature --fields selector publicKey
+  ```
+
+  Paste the `publicKey` value (without `-----BEGIN PUBLIC KEY-----`
+  markers, on one line) into the `p=` field of the TXT record in
+  Cloudflare. Selector + algorithm are already correct in the
+  zone file.
 
 ## ACME / Let's Encrypt
 
@@ -34,3 +72,18 @@ Wildcard `*.esa-blueshell.nl` is issued via DNS-01. cert-manager writes
 the challenge TXT record at `_acme-challenge.esa-blueshell.nl` through
 the Cloudflare API. The API token needs `Zone:DNS:Edit` scoped to this
 zone.
+
+## Pending cleanups in the zone
+
+These are noted here so a future zone-file PR catches them; this PR
+intentionally only adds mail records:
+
+- `v2.*`, `cname-*.v2.esa-blueshell.nl.` TXT, `a-www.v2.*` — the v2
+  apex was retired (see header note in this README) but the zone
+  file still carries the records and their external-dns ownership
+  markers.
+- `listmonk.esa-blueshell.nl.` A/AAAA + `mail-admin.esa-blueshell.nl.`
+  A/AAAA + the matching `a-listmonk.*` / `aaaa-listmonk.*` and
+  `a-mail-admin.*` / `aaaa-mail-admin.*` TXT markers — Listmonk has
+  been retired in favour of Stalwart relay (#260+). Drop after the
+  Listmonk teardown PR lands cluster-side.

--- a/infra/dns/esa-blueshell.nl.zone
+++ b/infra/dns/esa-blueshell.nl.zone
@@ -36,6 +36,7 @@ esa-blueshell.nl.	1	IN	A	157.173.115.164 ; cf_tags=cf-proxied:true
 headlamp.esa-blueshell.nl.	1	IN	A	157.173.115.164 ; cf_tags=cf-proxied:true
 kube.esa-blueshell.nl.	1	IN	A	157.173.115.164 ; cf_tags=cf-proxied:true
 listmonk.esa-blueshell.nl.	1	IN	A	157.173.115.164 ; cf_tags=cf-proxied:true
+mail.esa-blueshell.nl.	1	IN	A	157.173.115.164 ; cf_tags=cf-proxied:false
 mail-admin.esa-blueshell.nl.	1	IN	A	157.173.115.164 ; cf_tags=cf-proxied:true
 minecraft.event.esa-blueshell.nl.	1	IN	A	193.123.34.253 ; cf_tags=cf-proxied:false
 minecraft.server.esa-blueshell.nl.	1	IN	A	130.89.149.197 ; cf_tags=cf-proxied:false
@@ -51,6 +52,7 @@ esa-blueshell.nl.	1	IN	AAAA	2a02:c207:2316:2642::1 ; cf_tags=cf-proxied:true
 headlamp.esa-blueshell.nl.	1	IN	AAAA	2a02:c207:2316:2642::1 ; cf_tags=cf-proxied:true
 kube.esa-blueshell.nl.	1	IN	AAAA	2a02:c207:2316:2642::1 ; cf_tags=cf-proxied:true
 listmonk.esa-blueshell.nl.	1	IN	AAAA	2a02:c207:2316:2642::1 ; cf_tags=cf-proxied:true
+mail.esa-blueshell.nl.	1	IN	AAAA	2a02:c207:2316:2642::1 ; cf_tags=cf-proxied:false
 mail-admin.esa-blueshell.nl.	1	IN	AAAA	2a02:c207:2316:2642::1 ; cf_tags=cf-proxied:true
 stalwart.esa-blueshell.nl.	1	IN	AAAA	2a02:c207:2316:2642::1 ; cf_tags=cf-proxied:true
 status.esa-blueshell.nl.	1	IN	AAAA	2a02:c207:2316:2642::1 ; cf_tags=cf-proxied:true
@@ -63,9 +65,39 @@ ftp.esa-blueshell.nl.	1	IN	CNAME	esa-blueshell.nl. ; cf_tags=cf-proxied:false
 www.esa-blueshell.nl.	1	IN	CNAME	esa-blueshell.nl. ; cf_tags=cf-proxied:true
 
 ;; MX Records
-esa-blueshell.nl.	1	IN	MX	10 esa-blueshell.nl.
+;; The MX target must NOT be Cloudflare-proxied (mail is raw TCP, not
+;; HTTP) — point it at mail.esa-blueshell.nl, whose A/AAAA are
+;; explicitly cf-proxied:false. Mail flowing to *@esa-blueshell.nl
+;; therefore reaches the Stalwart pod directly on the VPS public IP.
+esa-blueshell.nl.	1	IN	MX	10 mail.esa-blueshell.nl.
 
 ;; TXT Records
+;; SPF — authorise the MX hosts (i.e. mail.esa-blueshell.nl) to send
+;; mail for the domain. `~all` is soft-fail; tighten to `-all` after
+;; a few weeks of DMARC reports confirm no legitimate sender was
+;; missed.
+esa-blueshell.nl.	1	IN	TXT	"v=spf1 mx ~all" ; cf_tags=cf-proxied:false
+
+;; DMARC — start in monitor-only (`p=none`) so misconfigurations don't
+;; drop legitimate mail. Aggregate reports go to postmaster@.
+;; Promote to `p=quarantine` once the rua reports show 100% SPF/DKIM
+;; alignment on outbound mail.
+_dmarc.esa-blueshell.nl.	1	IN	TXT	"v=DMARC1; p=none; rua=mailto:postmaster@esa-blueshell.nl; adkim=r; aspf=r" ; cf_tags=cf-proxied:false
+
+;; DKIM — selector matches Stalwart's DkimSignature.selector
+;; (`default`). The `p=` value is the base64-encoded public key
+;; Stalwart derives from the dkim-private-key stored in Vault. Read
+;; the actual value from the running pod after the apply sidecar
+;; creates the DkimSignature for the first time:
+;;
+;;   kubectl -n mail-system exec deploy/stalwart -c stalwart-apply -- \
+;;     stalwart-cli query DkimSignature --fields selector publicKey
+;;
+;; then paste the public key (without BEGIN/END PEM markers, all on
+;; one line) into the TXT record below.
+default._domainkey.esa-blueshell.nl.	1	IN	TXT	"v=DKIM1; k=rsa; p=REPLACE_AFTER_FIRST_BOOT" ; cf_tags=cf-proxied:false
+
+
 aaaa-auth.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/auth"
 aaaa-headlamp.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/headlamp"
 aaaa-kube.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/headlamp"


### PR DESCRIPTION
## Why

The exported zone file is the v0.15 mail wiring: `stalwart.esa-blueshell.nl` A/AAAA proxied through Cloudflare, MX target = the apex (also proxied). Cloudflare's proxy is HTTP-only, so external SMTP delivery to `*@esa-blueshell.nl` can't get through. After this PR is imported, external mail reaches the pod and outbound mail is auth-ready.

## What changes in the zone

| Record                                | Type   | Proxied | Why                                                              |
|---------------------------------------|--------|---------|------------------------------------------------------------------|
| `mail.esa-blueshell.nl.`              | A/AAAA | **off** | New. Mail clients connect here for SMTP/IMAP — raw TCP, no proxy.|
| `esa-blueshell.nl. MX 10 mail.…`      | MX     | n/a     | Was the apex (proxied). Now points at the new `mail` host.       |
| `esa-blueshell.nl. TXT "v=spf1 …"`    | TXT    | off     | New SPF. `mx ~all` — authorises the MX hosts, soft-fail others.  |
| `_dmarc.esa-blueshell.nl. TXT`        | TXT    | off     | New DMARC. Monitor-only (`p=none`) + rua to postmaster@.         |
| `default._domainkey.esa-blueshell.nl. TXT` | TXT | off  | New DKIM placeholder. Real public key pasted after first boot.   |
| `stalwart.esa-blueshell.nl.` A/AAAA   | A/AAAA | unchanged | Stays proxied — that hostname serves the webadmin only (HTTP). |

## DKIM publish step (one-time, after the cluster-side DKIM PR lands)

The zone ships `p=REPLACE_AFTER_FIRST_BOOT` because the public key is derived from a private key Stalwart holds in its datastore. Once the apply sidecar creates the `DkimSignature`:

```sh
kubectl -n mail-system exec deploy/stalwart -c stalwart-apply -- \
  stalwart-cli query DkimSignature --fields selector publicKey
```

Paste the `publicKey` (one line, without the `-----BEGIN PUBLIC KEY-----` PEM markers) into the `p=` field of the `default._domainkey` TXT record in Cloudflare. Selector + algorithm are already correct in the zone.

## Out of scope (noted in README under "Pending cleanups")

- `v2.*` and `cname-*.v2.*` TXT records — the v2 apex is retired per the README header but the records are still in the zone.
- `listmonk.*` and `mail-admin.*` A/AAAA + their external-dns ownership TXTs — Listmonk is being retired in favour of Stalwart relay; the cluster-side teardown is a separate PR.

Both are unrelated to this PR's goal of enabling mail; collecting them into a single follow-up zone-file PR is the cleaner cut.

## Test plan

- [x] Zone file syntactically valid (BIND-style; existing comments + `cf_tags` markers preserved).
- [ ] After import:
  - [ ] `dig +short MX esa-blueshell.nl` returns `10 mail.esa-blueshell.nl.`
  - [ ] `dig +short A mail.esa-blueshell.nl` returns `157.173.115.164` (not a Cloudflare edge IP).
  - [ ] `dig +short TXT esa-blueshell.nl` includes `v=spf1 mx ~all`.
  - [ ] `dig +short TXT _dmarc.esa-blueshell.nl` returns the DMARC string.
  - [ ] External SMTP test (e.g. swaks from a public host) to a Stalwart mailbox reaches the pod.