### PR TITLE
fix(api): trust the Stalwart cert at the cluster-internal SMTP host

### DIFF
--- a/services/api/src/main/resources/application.yaml
+++ b/services/api/src/main/resources/application.yaml
@@ -173,6 +173,22 @@ spring.mail:
     mail.smtp.auth: ${SMTP_AUTH:true}
     mail.smtp.starttls.enable: ${SMTP_STARTTLS:true}
     mail.smtp.starttls.required: ${SMTP_STARTTLS_REQUIRED:false}
+    # Stalwart's TLS cert is ACME-issued for the public mail hostname
+    # (`stalwart.esa-blueshell.nl`) — public CAs can't sign certs for
+    # `*.svc.cluster.local`, so STARTTLS to `stalwart.mail-system.svc`
+    # failed strict-hostname-verify with
+    #   "(certificate_unknown) No subject alternative DNS name matching
+    #   stalwart.mail-system.svc.cluster.local found"
+    # and every Recovery / Activation / Reminder job died with
+    # MailSendException.
+    #
+    # `mail.smtp.ssl.trust=<host>` tells JavaMail to trust whatever cert
+    # the configured SMTP host presents, skipping the SAN check for that
+    # one host. Encryption still happens (STARTTLS); the client just
+    # doesn't insist the cert's CN/SANs include the internal hostname.
+    # Acceptable because the traffic is intra-cluster — the pod overlay
+    # network is the trust boundary.
+    mail.smtp.ssl.trust: ${SMTP_SSL_TRUST:${SMTP_HOST:stalwart}}
     mail.smtp.connectiontimeout: 10000
     mail.smtp.timeout: 30000
     mail.smtp.writetimeout: 30000


### PR DESCRIPTION
## Why mail is failing

Every Recovery / Activation / Reminder job (`RecoveryEmailJob`, etc.) has been dying on retry with:

```
java.lang.RuntimeException: Failed to send email
  ...
Caused by: org.springframework.mail.MailSendException: Mail server connection failed
  ...
Caused by: jakarta.mail.MessagingException: Could not convert socket to TLS
  ...
Caused by: javax.net.ssl.SSLHandshakeException: (certificate_unknown)
  No subject alternative DNS name matching
  stalwart.mail-system.svc.cluster.local found.
```

The api connects to `stalwart.mail-system.svc.cluster.local:587` and does STARTTLS. Stalwart presents its TLS cert — ACME-issued (Let's Encrypt via DNS-01) for `stalwart.esa-blueshell.nl`. Public CAs cannot sign certs for `*.svc.cluster.local`, so no amount of SAN editing on Stalwart's side will make strict hostname verification pass on the api side.

## What this PR does

Adds one Spring property:

```yaml
mail.smtp.ssl.trust: ${SMTP_SSL_TRUST:${SMTP_HOST:stalwart}}
```

`mail.smtp.ssl.trust=<host>` is JavaMail's per-host trust override — the SMTP client trusts whatever cert the configured host presents and skips the SAN check **for that one host**. Encryption still happens (STARTTLS upgrade is unchanged); the client just doesn't insist the cert identifies itself as the internal hostname.

This is safe in our setup because the traffic is intra-cluster: the pod overlay network is the trust boundary, and there's no way for a non-Stalwart pod in the same cluster to MITM the SMTP connection without also having a CNI-level network breach. Wider attack surface than a CA-signed cert chain, but a reasonable trade given the alternative is "no mail at all".

The default uses the SMTP host as the trusted name. If the operator ever points the api at a public SMTP relay with a properly-issued cert, they unset `SMTP_HOST` from the cluster-internal value and the strict-verify path resumes — or they can set `SMTP_SSL_TRUST=` explicitly to an empty string.

## Test plan

- [x] YAML valid (`python3 -c 'yaml.safe_load(...)'`).
- [ ] After merge + image rebuild + Keel roll: retry any of the currently-Failed Recovery email jobs from the Job Manager; expect them to succeed (or fail on a fresh error — but not the cert one).