### PR TITLE
fix(mail): rewire SMTP/IMAP/admin to account.* Vault keys

### DIFF
--- a/platform/cluster/flux/apps/mail/stalwart/deployment.yaml
+++ b/platform/cluster/flux/apps/mail/stalwart/deployment.yaml
@@ -165,16 +165,17 @@ spec:
               value: stalwart.esa-blueshell.nl
             - name: STALWART_DOMAIN
               value: esa-blueshell.nl
+            # Vault keys follow the `account.<localpart>` convention.
+            # `account.admin` is the password for the fallback admin
+            # principal seeded by STALWART_RECOVERY_ADMIN on the main
+            # container; its username is the literal localPart `admin`.
             - name: STALWART_USER
-              valueFrom:
-                secretKeyRef:
-                  name: stalwart-secrets
-                  key: admin-user
+              value: admin
             - name: STALWART_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: stalwart-secrets
-                  key: admin-password
+                  key: account.admin
             - name: CF_DNS_API_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/platform/cluster/flux/apps/stateless/api/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/api/deployment.yaml
@@ -166,17 +166,20 @@ spec:
               value: Blueshell
             - name: EMAIL_REPLY_TO_ADDRESS
               value: sitecie@esa-blueshell.nl
+            # Mail principal credentials follow the
+            # `account.<localpart>` convention. The username is the
+            # full email derived from the localPart; the password
+            # lives at Vault key `account.<localpart>`.
+            #
+            # SMTP submission auths as api@ (the api's dedicated
+            # principal). IMAP bounce-poll auths as bounce@.
             - name: SMTP_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: stalwart-secrets
-                  key: bounce-mailbox-user
-                  optional: true
+              value: api@esa-blueshell.nl
             - name: SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: stalwart-secrets
-                  key: bounce-mailbox-password
+                  key: account.api
                   optional: true
             # IMAP bounce poller — disabled by default; flip the flag once
             # the bounce mailbox is provisioned.
@@ -191,16 +194,12 @@ spec:
             - name: EMAIL_BOUNCE_IMAP_FOLDER
               value: INBOX
             - name: EMAIL_BOUNCE_IMAP_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: stalwart-secrets
-                  key: bounce-mailbox-user
-                  optional: true
+              value: bounce@esa-blueshell.nl
             - name: EMAIL_BOUNCE_IMAP_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: stalwart-secrets
-                  key: bounce-mailbox-password
+                  key: account.bounce
                   optional: true
             - name: AUTH_TRANSIT_ENABLED
               value: 'true'

--- a/platform/cluster/flux/apps/vso-secrets/stalwart-secrets.yaml
+++ b/platform/cluster/flux/apps/vso-secrets/stalwart-secrets.yaml
@@ -2,9 +2,17 @@
 # mail-system namespace for Stalwart itself and into the default namespace
 # for the api.
 #
-# Follow-ups before mail cutover:
-# - dkim-private-key is seeded in Vault KV but not yet rendered into the
-#   Stalwart config-template; wiring it is pending.
+# Vault key convention (operator-managed): every mail principal has one
+# key `account.<localpart>` whose value is the password. The email is
+# derived: `<localpart>@esa-blueshell.nl`. Today the keys in Vault are
+# `account.admin`, `account.api`, `account.bounce`; the apply sidecar
+# projects them as files under `/etc/stalwart-accounts/account.<lp>`
+# and reads them per accounts.json's `vaultKey` field.
+#
+# `account.admin` is special: Stalwart needs a single `user:password`
+# string in STALWART_RECOVERY_ADMIN to seed the fallback admin
+# principal at boot. The template below composes that from the literal
+# username `admin` plus the value of `account.admin`.
 #
 # VSO needs the `vault-secrets-operator` ServiceAccount in the same
 # namespace as this VaultStaticSecret; apps-mail doesn't create this SA
@@ -40,14 +48,15 @@ spec:
     name: stalwart-secrets
     create: true
     transformation:
-      # Keep the raw keys (admin-user, admin-password, api-user, …) so
-      # the apply sidecar can read them individually; add a composite
-      # STALWART_RECOVERY_ADMIN that the main Stalwart container reads
-      # as a single "user:password" env value.
+      # Keep the raw keys (account.api, account.bounce, account.admin)
+      # so the apply sidecar can read them as files under
+      # /etc/stalwart-accounts; add a composite STALWART_RECOVERY_ADMIN
+      # that the main Stalwart container reads as a single
+      # "user:password" env value.
       excludeRaw: false
       templates:
         STALWART_RECOVERY_ADMIN:
-          text: '{{- get .Secrets "admin-user" -}}:{{- get .Secrets "admin-password" -}}'
+          text: 'admin:{{- get .Secrets "account.admin" -}}'
   refreshAfter: 1h
   rolloutRestartTargets:
     - kind: Deployment


### PR DESCRIPTION
## Why mail still fails after #269

PR #269 fixes the TLS hostname-verify error, but mail still wouldn't deliver because **the credentials in use don't match any Stalwart principal that exists**:

- api's `SMTP_USERNAME` is pulled from Vault key `bounce-mailbox-user`, whose value is `bounce@v2.esa-blueshell.nl` — referencing the *retired* `v2` subdomain. Stalwart's configured domain is `esa-blueshell.nl`, so no principal matches.
- The Stalwart apply sidecar's `STALWART_USER` is pulled from `admin-user`, which no longer exists in Vault.

Per your direction: Vault now holds three keys under `secret/platform/mail`, all using the convention `account.<localpart>` = password, with the email derived as `<localpart>@esa-blueshell.nl`:

```
account.admin     → admin@esa-blueshell.nl    (Stalwart fallback admin)
account.api       → api@esa-blueshell.nl      (api SMTP submission)
account.bounce    → bounce@esa-blueshell.nl   (api IMAP bounce poller)
```

This PR rewires every consumer to match.

## Changes

| File | Change |
|---|---|
| `apps/vso-secrets/stalwart-secrets.yaml` | VSS composite `STALWART_RECOVERY_ADMIN` template now reads `account.admin` instead of `admin-user`/`admin-password`. Username is the literal `admin`. |
| `apps/mail/stalwart/deployment.yaml` | Apply sidecar's `STALWART_USER=admin` (literal), `STALWART_PASSWORD` reads `account.admin`. |
| `apps/stateless/api/deployment.yaml` | `SMTP_USERNAME=api@esa-blueshell.nl` (literal), `SMTP_PASSWORD` reads `account.api`. `EMAIL_BOUNCE_IMAP_USERNAME=bounce@esa-blueshell.nl` (literal), `EMAIL_BOUNCE_IMAP_PASSWORD` reads `account.bounce`. |

The literal usernames are now in the deployment YAML rather than Vault — they were never secret (Vault stored them because the v0.15 era had separate user/pass pairs). The full email forms ensure Stalwart's SMTP auth resolver matches against the correct principal in the configured domain.

## Sequencing with the other open PRs

Independent of #269 (TLS trust) — touches different files. Both need to land before mail works end-to-end.

After both merge + api + stalwart pods roll:
- api's TLS handshake against `stalwart.mail-system.svc.cluster.local:587` succeeds (#269).
- The api auths as `api@esa-blueshell.nl` with the `account.api` password (this PR).
- The apply sidecar's `reconcile_accounts` step (already in #263) reads `/etc/stalwart-accounts/account.api`, `account.bounce`, etc. and auto-creates the Stalwart principals.
- Mail delivers.

## Test plan

- [x] `kubectl kustomize` builds for all three affected apps.
- [ ] After merge + Keel rolls api + stalwart pods:
  - [ ] sidecar log shows `apply: creating account api@esa-blueshell.nl`, `apply: creating account bounce@esa-blueshell.nl`, etc.
  - [ ] Retry a failed Recovery email job from the Job Manager — succeeds.