### PR TITLE
api: disable JSSE endpoint-identity check on SMTP STARTTLS

### DIFF
--- a/services/api/src/main/resources/application.yaml
+++ b/services/api/src/main/resources/application.yaml
@@ -176,19 +176,24 @@ spring.mail:
     # Stalwart's TLS cert is ACME-issued for the public mail hostname
     # (`stalwart.esa-blueshell.nl`) — public CAs can't sign certs for
     # `*.svc.cluster.local`, so STARTTLS to `stalwart.mail-system.svc`
-    # failed strict-hostname-verify with
-    #   "(certificate_unknown) No subject alternative DNS name matching
+    # fails the JSSE endpoint-identity check with
+    #   "No subject alternative DNS name matching
     #   stalwart.mail-system.svc.cluster.local found"
-    # and every Recovery / Activation / Reminder job died with
-    # MailSendException.
+    # at `HostnameChecker.matchDNS`, and every Recovery / Activation /
+    # Reminder job dies with MailSendException.
     #
-    # `mail.smtp.ssl.trust=<host>` tells JavaMail to trust whatever cert
-    # the configured SMTP host presents, skipping the SAN check for that
-    # one host. Encryption still happens (STARTTLS); the client just
-    # doesn't insist the cert's CN/SANs include the internal hostname.
-    # Acceptable because the traffic is intra-cluster — the pod overlay
-    # network is the trust boundary.
-    mail.smtp.ssl.trust: ${SMTP_SSL_TRUST:${SMTP_HOST:stalwart}}
+    # Two distinct checks happen on the TLS socket:
+    #   1. trust-manager (does a known CA sign this cert?) — passes,
+    #      the cert is Let's Encrypt-signed.
+    #   2. endpoint-identity (does the connect-host match a SAN?) —
+    #      fails, the SAN is the public mail hostname.
+    # `mail.smtp.ssl.trust` only affects (1). The SAN check is gated
+    # by `mail.smtp.ssl.checkserveridentity` (Angus default `true`,
+    # which sets `SSLParameters.endpointIdentificationAlgorithm=HTTPS`).
+    # Turning that off skips (2) for this connection. Acceptable
+    # because intra-cluster traffic is the trust boundary — the cert
+    # itself is still validated against the CA chain.
+    mail.smtp.ssl.checkserveridentity: ${SMTP_SSL_CHECK_SERVER_IDENTITY:false}
     mail.smtp.connectiontimeout: 10000
     mail.smtp.timeout: 30000
     mail.smtp.writetimeout: 30000


### PR DESCRIPTION
## Why

#269 set `mail.smtp.ssl.trust=<host>` on the JavaMail session to make api accept Stalwart's public-CN cert when STARTTLSing to the internal Service hostname `stalwart.mail-system.svc.cluster.local`. The Recovery email job still fails with the exact same trace it failed with before #269:

```
SSLHandshakeException: (certificate_unknown) No subject alternative DNS
name matching stalwart.mail-system.svc.cluster.local found.
  at sun.security.util.HostnameChecker.matchDNS
  at X509TrustManagerImpl.checkIdentity
  at AbstractTrustManagerWrapper.checkAdditionalTrust
  at CertificateMessage$T13CertificateConsumer.checkServerCerts
```

Two distinct checks happen on a TLS socket:

1. **Trust-manager** — is the cert signed by a known CA? Passes; the cert is Let's Encrypt signed and the JDK trusts that root.
2. **Endpoint-identity** — does the connect-host match one of the cert's SANs? Fails; the SANs cover `*.esa-blueshell.nl` and the connect host is the in-cluster Service DNS name.

`mail.smtp.ssl.trust` only governs (1). It does nothing for (2). Trace confirms: the failure is `HostnameChecker.matchDNS`, the JDK's identity verifier, not a CA-chain validation error.

(2) is gated by `mail.smtp.ssl.checkserveridentity` — defaults to `true` in modern Angus Mail, which makes Angus set `SSLParameters.endpointIdentificationAlgorithm=HTTPS` on the SSLSocket, which is what triggers the SAN comparison in the JSSE engine.

## What

`spring.mail.properties.mail.smtp.ssl.checkserveridentity` now defaults to `false` (overridable via `SMTP_SSL_CHECK_SERVER_IDENTITY`). The misdirected `mail.smtp.ssl.trust` line is dropped — keeping it around would be dead config.

The CA chain is still validated; only the hostname-vs-SAN check is skipped. Acceptable because the traffic is intra-cluster — the pod overlay network is the trust boundary, and the connect host (`stalwart.mail-system.svc.cluster.local`) is not externally resolvable.

## Verification path

1. Keel rolls api on the new image.
2. Recovery / Activation jobs that previously died with `MailSendException` succeed.
3. `kubectl logs deploy/api` shows no further `SSLHandshakeException` from `JavaMailSenderImpl.doSend`.