### PR TITLE
api: route SMTP/IMAP via mail.esa-blueshell.nl instead of internal Service DNS

### DIFF
--- a/platform/cluster/flux/apps/stateless/api/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/api/deployment.yaml
@@ -153,9 +153,16 @@ spec:
               value: .esa-blueshell.nl
             - name: STORAGE_LOCATION
               value: /srv/storage
-            # SMTP transport — relay through Stalwart in-cluster.
+            # SMTP transport — relay through Stalwart via its public
+            # mail hostname. The traffic still terminates on the same
+            # Frankfurt VPS (hairpin through the public IP) but the
+            # JavaMail client validates the cert SAN against the
+            # connect host, and the wildcard ACME cert covers
+            # `mail.esa-blueshell.nl` while in-cluster Service DNS is
+            # not in the cert. Using the public name keeps strict
+            # TLS verification on without bypass flags.
             - name: SMTP_HOST
-              value: stalwart.mail-system.svc.cluster.local
+              value: mail.esa-blueshell.nl
             - name: SMTP_PORT
               value: '587'
             - name: SMTP_STARTTLS
@@ -186,7 +193,7 @@ spec:
             - name: EMAIL_BOUNCE_IMAP_ENABLED
               value: 'false'
             - name: EMAIL_BOUNCE_IMAP_HOST
-              value: stalwart.mail-system.svc.cluster.local
+              value: mail.esa-blueshell.nl
             - name: EMAIL_BOUNCE_IMAP_PORT
               value: '993'
             - name: EMAIL_BOUNCE_IMAP_TLS

--- a/services/api/src/main/resources/application.yaml
+++ b/services/api/src/main/resources/application.yaml
@@ -173,22 +173,6 @@ spring.mail:
     mail.smtp.auth: ${SMTP_AUTH:true}
     mail.smtp.starttls.enable: ${SMTP_STARTTLS:true}
     mail.smtp.starttls.required: ${SMTP_STARTTLS_REQUIRED:false}
-    # Stalwart's TLS cert is ACME-issued for the public mail hostname
-    # (`stalwart.esa-blueshell.nl`) — public CAs can't sign certs for
-    # `*.svc.cluster.local`, so STARTTLS to `stalwart.mail-system.svc`
-    # failed strict-hostname-verify with
-    #   "(certificate_unknown) No subject alternative DNS name matching
-    #   stalwart.mail-system.svc.cluster.local found"
-    # and every Recovery / Activation / Reminder job died with
-    # MailSendException.
-    #
-    # `mail.smtp.ssl.trust=<host>` tells JavaMail to trust whatever cert
-    # the configured SMTP host presents, skipping the SAN check for that
-    # one host. Encryption still happens (STARTTLS); the client just
-    # doesn't insist the cert's CN/SANs include the internal hostname.
-    # Acceptable because the traffic is intra-cluster — the pod overlay
-    # network is the trust boundary.
-    mail.smtp.ssl.trust: ${SMTP_SSL_TRUST:${SMTP_HOST:stalwart}}
     mail.smtp.connectiontimeout: 10000
     mail.smtp.timeout: 30000
     mail.smtp.writetimeout: 30000


### PR DESCRIPTION
## Why

api spoke to Stalwart on `stalwart.mail-system.svc.cluster.local` for both SMTP submission (587) and the IMAP bounce poller (993). Stalwart's ACME cert is issued for `*.esa-blueshell.nl`, which does not cover the in-cluster Service DNS name, so every STARTTLS handshake from api failed JSSE endpoint-identity verification:

```
SSLHandshakeException: (certificate_unknown) No subject alternative DNS
name matching stalwart.mail-system.svc.cluster.local found.
  at sun.security.util.HostnameChecker.matchDNS
```

…and every Recovery / Activation / Reminder mail died with `MailSendException`.

The earlier fix (`mail.smtp.ssl.trust=<host>`) was misdirected — that property only governs CA chain validation. The failing check is the JDK's endpoint-identity step (cert SAN vs connect host), which `ssl.trust` does not touch.

## What

`SMTP_HOST` and `EMAIL_BOUNCE_IMAP_HOST` now resolve to `mail.esa-blueshell.nl`. The A record points at the Frankfurt VPS public IP and Stalwart binds the mail ports there via hostPort, so the pod hairpins out the public NIC and back in on the same node. JavaMail validates the cert SAN against the connect host, which now matches the wildcard cert — handshake succeeds with default strict TLS verification.

The `mail.smtp.ssl.trust` block in `application.yaml` is removed; with the external hostname it was dead config.

## Test plan

- [ ] Keel rolls api on the new image.
- [ ] Recovery / Activation jobs that previously died with `MailSendException` succeed.
- [ ] `kubectl logs deploy/api` shows no further `SSLHandshakeException` from `JavaMailSenderImpl.doSend`.