### PR TITLE
stalwart: pin auto-published hostname + hand DKIM publishing to Stalwart

### DIFF
--- a/infra/dns/esa-blueshell.nl.zone
+++ b/infra/dns/esa-blueshell.nl.zone
@@ -84,19 +84,12 @@ esa-blueshell.nl.	1	IN	TXT	"v=spf1 mx ~all" ; cf_tags=cf-proxied:false
 ;; alignment on outbound mail.
 _dmarc.esa-blueshell.nl.	1	IN	TXT	"v=DMARC1; p=none; rua=mailto:postmaster@esa-blueshell.nl; adkim=r; aspf=r" ; cf_tags=cf-proxied:false
 
-;; DKIM — selector matches Stalwart's DkimSignature.selector
-;; (`default`). The `p=` value is the base64-encoded public key
-;; Stalwart derives from the dkim-private-key stored in Vault. Read
-;; the actual value from the running pod after the apply sidecar
-;; creates the DkimSignature for the first time:
-;;
-;;   kubectl -n mail-system exec deploy/stalwart -c stalwart-apply -- \
-;;     stalwart-cli query DkimSignature --fields selector publicKey
-;;
-;; then paste the public key (without BEGIN/END PEM markers, all on
-;; one line) into the TXT record below.
-default._domainkey.esa-blueshell.nl.	1	IN	TXT	"v=DKIM1; k=rsa; p=REPLACE_AFTER_FIRST_BOOT" ; cf_tags=cf-proxied:false
-
+;; DKIM is owned by Stalwart. The Domain object has
+;; dkimManagement=Automatic, so Stalwart generates Dkim1RsaSha256 +
+;; Dkim1Ed25519Sha256 keys at first boot, rotates them on a
+;; schedule, and publishes the matching <selector>._domainkey TXT
+;; records through the same Cloudflare DnsServer that handles ACME.
+;; No DKIM records belong in this zone file.
 
 aaaa-auth.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/auth"
 aaaa-headlamp.esa-blueshell.nl.	1	IN	TXT	"heritage=external-dns,external-dns/owner=blueshell-website-production,external-dns/resource=ingressroute/edge-system/headlamp"

--- a/infra/stalwart/apply.sh
+++ b/infra/stalwart/apply.sh
@@ -130,12 +130,16 @@ reconcile() {
   #      operator-imported records in infra/dns are advance scaffolding
   #      (placeholders / fallbacks) and get authoritatively replaced by
   #      Stalwart's writes once the Domain object is wired up.
-  #    - dkimManagement: Manual — reconcile_dkim below owns the
-  #      DkimSignature lifecycle, and the matching DNS TXT record is
-  #      operator-published; Stalwart's automatic rotation logic would
-  #      just clash with both.
+  #    - dkimManagement: Automatic — Stalwart generates Dkim1RsaSha256
+  #      + Dkim1Ed25519Sha256 keys at first boot, rotates them on a
+  #      schedule, and publishes the matching <selector>._domainkey
+  #      TXT records via the same DnsServer used for ACME. With Manual
+  #      management Stalwart still generates the keys but does not
+  #      push the TXT records, leaving outbound mail unsigned — which
+  #      was the case before this change (DKIM ✗ in the security check
+  #      summary while SPF + DMARC were ✓).
   #    Convergent: webadmin changes get straightened on the next boot.
-  printf '{"@type":"update","object":"Domain","id":"%s","value":{"certificateManagement":{"@type":"Automatic","acmeProviderId":"%s"},"dnsManagement":{"@type":"Automatic","dnsServerId":"%s"},"dkimManagement":{"@type":"Manual"}}}\n' \
+  printf '{"@type":"update","object":"Domain","id":"%s","value":{"certificateManagement":{"@type":"Automatic","acmeProviderId":"%s"},"dnsManagement":{"@type":"Automatic","dnsServerId":"%s"},"dkimManagement":{"@type":"Automatic"}}}\n' \
     "$dom" "$acme" "$dns" | sc apply --file /dev/stdin
 
   # 4. Renew the Cloudflare DNS-01 token every boot. Rotating the Vault
@@ -144,12 +148,7 @@ reconcile() {
   printf '{"@type":"update","object":"DnsServer","id":"%s","value":{"secret":{"@type":"Value","secret":"%s"}}}\n' \
     "$dns" "$CF_DNS_API_TOKEN" | sc apply --file /dev/stdin
 
-  # 5. DKIM signing — create one Dkim1RsaSha256 signature for the
-  #    domain using the private key from secret/platform/mail. No-op
-  #    once a DkimSignature exists; rotation is operator-driven.
-  reconcile_dkim "$dom"
-
-  # 6. Reconcile Vault-managed accounts (passwords, aliases, group
+  # 5. Reconcile Vault-managed accounts (passwords, aliases, group
   #    memberships) from accounts.json. Existing accounts get update-
   #    only — never delete and never recreate — so the mailbox an
   #    account links to is never disturbed. Only list accounts whose
@@ -158,44 +157,6 @@ reconcile() {
   reconcile_accounts "$dom"
 
   echo "apply: reconcile complete"
-}
-
-reconcile_dkim() {
-  # $1 is the Domain object id. Creates a Dkim1RsaSha256 signature
-  # with selector "default", using the PEM-encoded private key from
-  # secret/platform/mail (key `dkim-private-key`). The Vault value
-  # must be the raw PEM with literal -----BEGIN PRIVATE KEY-----
-  # markers — write it with `vault kv put -mount=secret platform/mail
-  # dkim-private-key=@/path/to/key.pem`.
-  #
-  # No-op when a DkimSignature already exists for this domain. To
-  # rotate: delete the existing DkimSignature via webadmin or CLI
-  # (`stalwart-cli delete DkimSignature <id>`), bump the Vault key to
-  # the new private key, restart the pod. The matching DNS TXT record
-  # (`default._domainkey`) must be published manually in Cloudflare
-  # from the resulting publicKey field — `infra/dns` ships a
-  # placeholder ready to receive it.
-  dom="$1"
-  pkey_file="${ACCOUNT_PASSWORDS_DIR}/dkim-private-key"
-  if [ ! -s "$pkey_file" ]; then
-    echo "apply: skipping DKIM: dkim-private-key missing from secret/platform/mail (mail will deliver unsigned)" >&2
-    return 0
-  fi
-
-  existing="$(sc query DkimSignature --json 2>/dev/null \
-    | jq -rs --arg d "$dom" 'map(select(.domainId==$d))[0].id // empty')"
-  if [ -n "$existing" ]; then
-    echo "apply: DkimSignature already exists for ${STALWART_DOMAIN} (id=${existing}) — skipping"
-    return 0
-  fi
-
-  echo "apply: creating DkimSignature (selector=default, algorithm=Dkim1RsaSha256)"
-  pkey="$(cat "$pkey_file")"
-  jq -nc --arg dom "$dom" --arg pk "$pkey" \
-    '{"@type":"create","object":"DkimSignature","value":{"dkim-rsa":{"@type":"Dkim1RsaSha256",domainId:$dom,selector:"default",privateKey:$pk}}}' \
-    | sc apply --file /dev/stdin
-  echo "apply: DkimSignature created. Read the public key for DNS publishing with:"
-  echo "  stalwart-cli query DkimSignature --fields selector publicKey"
 }
 
 # objectList/set values are encoded by the apply API as index-keyed maps,

--- a/infra/stalwart/apply.sh
+++ b/infra/stalwart/apply.sh
@@ -88,9 +88,34 @@ reconcile() {
     return 1
   fi
 
-  # 2. Hostname + default domain (idempotent).
-  printf '{"@type":"update","object":"SystemSettings","value":{"defaultHostname":"%s","defaultDomainId":"%s"}}\n' \
-    "$STALWART_HOSTNAME" "$dom" | sc apply --file /dev/stdin
+  # 2. Hostname + default domain + advertised-service hostnames
+  #    (idempotent).
+  #
+  #    `defaultHostname` is just the SMTP greeting / fallback name.
+  #    Auto-publish for SRV / autoconfig / autodiscover / MX records
+  #    reads each *advertised service's own* `hostname` field, and
+  #    falls back to the OS hostname (= pod name in k8s, e.g.
+  #    `stalwart-54b9578f55-cttqm`) when that field is null. That
+  #    fallback leaks pod names into the public zone and breaks every
+  #    mail client doing autodiscovery. Pin every advertised hostname
+  #    + the MX target to STALWART_HOSTNAME so the records Stalwart
+  #    writes to Cloudflare reference a name that actually resolves
+  #    publicly.
+  jq -nc --arg host "$STALWART_HOSTNAME" --arg dom "$dom" '
+    {
+      "@type": "update",
+      "object": "SystemSettings",
+      "value": {
+        defaultHostname: $host,
+        defaultDomainId: $dom,
+        mailExchangers: {"0": {hostname: $host, priority: 10}},
+        services: (
+          ["caldav","carddav","imap","jmap","managesieve","pop3","smtp","webdav"]
+          | map({(.): {hostname: $host, cleartext: false}})
+          | add
+        )
+      }
+    }' | sc apply --file /dev/stdin
 
   # 3. Wire the domain:
   #    - certificateManagement: Automatic via the ACME provider (DNS-01).

--- a/platform/cluster/flux/apps/mail/stalwart/deployment.yaml
+++ b/platform/cluster/flux/apps/mail/stalwart/deployment.yaml
@@ -161,8 +161,17 @@ spec:
           env:
             - name: STALWART_URL
               value: http://127.0.0.1:8080
+            # The hostname Stalwart advertises in auto-published DNS
+            # records (SRV / MX / autodiscover / autoconfig / MTA-STS).
+            # `mail.esa-blueshell.nl` is non-Cloudflare-proxied per the
+            # infra/dns zone — mail protocols are raw TCP and can't
+            # traverse Cloudflare's HTTP proxy, so any client (Outlook,
+            # Thunderbird, our own api) needs an unproxied target.
+            # `stalwart.esa-blueshell.nl` exists for the admin UI and
+            # is proxied; pointing autodiscovery at it would break
+            # IMAPS/SMTP submission at TLS.
             - name: STALWART_HOSTNAME
-              value: stalwart.esa-blueshell.nl
+              value: mail.esa-blueshell.nl
             - name: STALWART_DOMAIN
               value: esa-blueshell.nl
             # Vault keys follow the `account.<localpart>` convention.

--- a/platform/docs/vault-bootstrap.md
+++ b/platform/docs/vault-bootstrap.md
@@ -164,7 +164,6 @@ login for operator reference, store it separately as
 vault kv put secret/platform/mail \
   admin-user=admin \
   admin-password=<stalwart-admin-password> \
-  dkim-private-key=<base64-encoded-rsa-2048-pem> \
   bounce-mailbox-user=bounce@esa-blueshell.nl \
   bounce-mailbox-password=<bounce-mailbox-password>
 ```

--- a/scripts/seed-vault-from-env.sh
+++ b/scripts/seed-vault-from-env.sh
@@ -382,7 +382,6 @@ append_field secret/platform/mariadb legacy-password "$(first_value DATABASE_PAS
 
 append_field secret/platform/mail admin-user "$(first_value STALWART_ADMIN_USER 2>/dev/null || true)"
 append_field secret/platform/mail admin-password "$(first_value STALWART_ADMIN_PASSWORD 2>/dev/null || true)"
-append_field secret/platform/mail dkim-private-key "$(first_value DKIM_PRIVATE_KEY 2>/dev/null || true)"
 append_field secret/platform/mail bounce-mailbox-user "$(first_value BOUNCE_MAILBOX_USER EMAIL_BOUNCE_IMAP_USERNAME 2>/dev/null || true)"
 append_field secret/platform/mail bounce-mailbox-password "$(first_value BOUNCE_MAILBOX_PASSWORD EMAIL_BOUNCE_IMAP_PASSWORD 2>/dev/null || true)"
 


### PR DESCRIPTION
Two coordinated fixes to Stalwart's auto-publish so it actually writes useful records to Cloudflare. Both involve setting fields that default to null / Manual and silently undermine the auto-publisher.

## Auto-publish hostname pinned to `mail.esa-blueshell.nl`

Stalwart's per-domain `dnsManagement: Automatic` publishes SRV / autodiscover / autoconfig / MTA-STS / MX records to Cloudflare. For each advertised service the publisher reads `SystemSettings.services[<proto>].hostname`; when that field is `null` it falls back to the OS hostname — which in Kubernetes is the pod name. Observed live:

```
_submissions._tcp.esa-blueshell.nl. SRV  0 1 465 stalwart-54b9578f55-cttqm.
_imaps._tcp.esa-blueshell.nl.       SRV  0 1 993 stalwart-54b9578f55-cttqm.
autodiscover.esa-blueshell.nl.      CNAME    stalwart-54b9578f55-cttqm.
mta-sts.esa-blueshell.nl.           CNAME    stalwart-54b9578f55-cttqm.
```

Pod names don't resolve publicly, so Outlook autodiscovery dead-ends and every IMAPS / submission attempt fails before TLS.

`SystemSettings.defaultHostname` was already set to a real name, but that's the SMTP-greeting / fallback hostname — auto-publish does **not** use it as the per-service default. Step 2 of `apply.sh` now writes every per-service hostname explicitly:

```jq
mailExchangers: {"0": {hostname: $host, priority: 10}},
services: (
  ["caldav","carddav","imap","jmap","managesieve","pop3","smtp","webdav"]
  | map({(.): {hostname: $host, cleartext: false}})
  | add
)
```

`STALWART_HOSTNAME` flips from `stalwart.esa-blueshell.nl` to `mail.esa-blueshell.nl` — `stalwart.*` is Cloudflare-proxied in `infra/dns` (admin UI lives behind the proxy + forward-auth), incompatible with raw mail TCP. `mail.*` is unproxied, covered by the same `*.esa-blueshell.nl` wildcard cert, and is already the MX target in the zone.

Stale `stalwart-<pod>.esa-blueshell.nl` records from previous boots have already been cleaned out of Cloudflare manually.

## DKIM handed to Stalwart (`dkimManagement: Automatic`)

The Domain was wired with `dkimManagement: Manual`. Stalwart still generated `Dkim1RsaSha256` + `Dkim1Ed25519Sha256` keys at first boot (visible in the datastore at selectors `v1-rsa-20260528` / `v1-ed25519-20260528`, both `stage=active`), but did not push the matching `<selector>._domainkey` TXT records via its DnsServer. Outbound mail signs locally, the receiver can't verify, and the DKIM security check reports `✗ "No DKIM record found"` while SPF + DMARC are both ✓.

Flipping `dkimManagement` to `Automatic` makes Stalwart publish those records through the same Cloudflare DnsServer that already handles ACME and rotate the keys on its own schedule. No operator key material is required; the keys live in the same RocksDB datastore as the rest of Stalwart's config.

`reconcile_dkim` is removed, along with the Vault `dkim-private-key` seed (`seed-vault-from-env.sh` + `vault-bootstrap.md`). The `default._domainkey` zone-file placeholder is dropped — that selector was never used (Stalwart picks its own selector with a date suffix), and any operator-published TXT at that name would just go stale next rotation.

## Test plan

- [ ] Stalwart-tools `:latest` rebuilds; Keel rolls the stalwart pod.
- [ ] `apply.sh` step 2 logs `SystemSettings` update with the new hostname; step 3 logs `Domain` update with `dkimManagement:Automatic`.
- [ ] `dig _submissions._tcp.esa-blueshell.nl SRV +short` returns `0 1 465 mail.esa-blueshell.nl.`
- [ ] `dig autodiscover.esa-blueshell.nl CNAME +short` returns `mail.esa-blueshell.nl.`
- [ ] `dig v1-rsa-20260528._domainkey.esa-blueshell.nl TXT +short` returns the DKIM public key.
- [ ] DKIM security check flips to ✓.
- [ ] Outlook autodiscovery against `<user>@esa-blueshell.nl` resolves to `mail.esa-blueshell.nl:993/465` and the TLS handshake succeeds.