### PR TITLE
Export event sign-ups as CSV

### DIFF
--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/domain/event/persistence/EventSignUpFetchIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/domain/event/persistence/EventSignUpFetchIT.kt
@@ -1,0 +1,83 @@
+package net.blueshell.api.domain.event.persistence
+
+import net.blueshell.api.domain.event.persistence.repository.EventSignUpRepository
+import net.blueshell.api.domain.event.web.mapping.response.asResponse
+import net.blueshell.api.domain.survey.persistence.Answer
+import net.blueshell.api.domain.survey.persistence.Question
+import net.blueshell.api.domain.survey.persistence.Survey
+import net.blueshell.api.shared.enums.QuestionType
+import net.blueshell.api.shared.enums.Role
+import net.blueshell.api.testsupport.UserTestSupport
+import jakarta.persistence.EntityManagerFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.hibernate.SessionFactory
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+/**
+ * Guards the `EventSignUp.withGuestUserAndAnswers` entity graph against N+1 regressions.
+ *
+ * Mapping each sign-up to a response touches its user, guest and answers. The graph must
+ * fetch all three eagerly, so the statement count for `findByEvent_Id` stays constant no
+ * matter how many sign-ups an event has.
+ */
+@SpringBootTest
+class EventSignUpFetchIT : UserTestSupport() {
+
+    @Autowired
+    private lateinit var eventSignUps: EventSignUpRepository
+
+    @Autowired
+    private lateinit var entityManagerFactory: EntityManagerFactory
+
+    private val sessionFactory: SessionFactory
+        get() = entityManagerFactory.unwrap(SessionFactory::class.java)
+
+    @Test
+    fun `listing sign-ups for an event does not scale queries with the number of sign-ups`() {
+        val question = persistQuestion()
+        val singleSignUpEvent = createEventFixture().also { seedMemberSignUp(it, question) }
+        val manySignUpsEvent = createEventFixture().also { event ->
+            repeat(5) { seedMemberSignUp(event, question) }
+        }
+
+        // Prime the persistence unit so one-time, session-level statements don't skew the counts.
+        mapSignUps(singleSignUpEvent.id!!)
+        mapSignUps(manySignUpsEvent.id!!)
+
+        val queriesForOne = countStatements { mapSignUps(singleSignUpEvent.id!!) }
+        val queriesForMany = countStatements { mapSignUps(manySignUpsEvent.id!!) }
+
+        assertThat(mapSignUps(singleSignUpEvent.id!!)).hasSize(1)
+        assertThat(mapSignUps(manySignUpsEvent.id!!)).hasSize(5)
+        assertThat(queriesForMany)
+            .describedAs("query count must not grow with the number of sign-ups (N+1)")
+            .isEqualTo(queriesForOne)
+    }
+
+    private fun persistQuestion(): Question {
+        val survey = persist(Survey())
+        return persist(Question(idx = 0, survey = survey, type = QuestionType.OPEN, label = "Why?"))
+    }
+
+    private fun seedMemberSignUp(event: Event, question: Question) {
+        val user = createUserWithRole(Role.MEMBER)
+        val signUp = eventFactory.createSignUp(event, user)
+        val answer = persist(Answer(question = question, textResponse = "because"))
+        persist(EventSignUpAnswer(eventSignUp = signUp, answer = answer))
+    }
+
+    /** Loads the sign-ups for an event and fully maps them, forcing every association to initialise. */
+    private fun mapSignUps(eventId: Long) =
+        transactionTemplate.execute {
+            eventSignUps.findByEvent_Id(eventId).map { it.asResponse() }
+        }!!
+
+    private fun countStatements(block: () -> Unit): Long {
+        sessionFactory.statistics.isStatisticsEnabled = true
+        sessionFactory.statistics.clear()
+        block()
+        return sessionFactory.statistics.prepareStatementCount
+    }
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/domain/event/persistence/EventSignUp.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/domain/event/persistence/EventSignUp.kt
@@ -28,9 +28,10 @@ import org.hibernate.annotations.SQLRestriction
     ]
 )
 @NamedEntityGraph(
-    name = "EventSignUp.withGuestAndAnswers",
+    name = "EventSignUp.withGuestUserAndAnswers",
     attributeNodes = [
         NamedAttributeNode("guest"),
+        NamedAttributeNode("user"),
         NamedAttributeNode(value = "_answers", subgraph = "answersSub")
     ],
     subgraphs = [

--- a/services/api/src/main/kotlin/net/blueshell/api/domain/event/persistence/repository/EventSignUpRepository.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/domain/event/persistence/repository/EventSignUpRepository.kt
@@ -14,25 +14,39 @@ import java.util.*
 @Suppress("FunctionName")
 @Repository
 interface EventSignUpRepository : BaseRepository<EventSignUp, Long> {
-    @EntityGraph(value = "EventSignUp.withGuestAndAnswers", type = EntityGraph.EntityGraphType.LOAD)
+    @EntityGraph(value = "EventSignUp.withGuestUserAndAnswers", type = EntityGraph.EntityGraphType.LOAD)
     override fun findAll(spec: Specification<EventSignUp>): MutableList<EventSignUp>
 
-    @EntityGraph(value = "EventSignUp.withGuestAndAnswers", type = EntityGraph.EntityGraphType.LOAD)
+    @EntityGraph(value = "EventSignUp.withGuestUserAndAnswers", type = EntityGraph.EntityGraphType.LOAD)
     override fun findAll(spec: Specification<EventSignUp>, pageable: Pageable): Page<EventSignUp>
 
-    @EntityGraph(value = "EventSignUp.withGuestAndAnswers", type = EntityGraph.EntityGraphType.LOAD)
+    @EntityGraph(value = "EventSignUp.withGuestUserAndAnswers", type = EntityGraph.EntityGraphType.LOAD)
     fun findByUser_IdAndEvent_Id(userId: Long, eventId: Long): Optional<EventSignUp>
 
-    @EntityGraph(value = "EventSignUp.withGuestAndAnswers", type = EntityGraph.EntityGraphType.LOAD)
+    @EntityGraph(value = "EventSignUp.withGuestUserAndAnswers", type = EntityGraph.EntityGraphType.LOAD)
     @Query("SELECT es FROM EventSignUp es WHERE es.guest.accessTokenHash = :accessTokenHash")
     fun findByGuestAccessTokenHash(@Param("accessTokenHash") accessTokenHash: String): MutableList<EventSignUp>
 
-    @EntityGraph(value = "EventSignUp.withGuestAndAnswers", type = EntityGraph.EntityGraphType.LOAD)
-    fun findByEvent_Id(eventId: Long): MutableList<EventSignUp>
+    // Fetches every association the sign-up response touches in one query. user.memberProfile and
+    // answer.eventSignUpAnswer are eager mappedBy back-references, so they must be joined here or
+    // Hibernate fires one extra SELECT per row.
+    @Query(
+        """
+        SELECT DISTINCT es FROM EventSignUp es
+        LEFT JOIN FETCH es.guest
+        LEFT JOIN FETCH es.user u
+        LEFT JOIN FETCH u.memberProfile
+        LEFT JOIN FETCH es._answers a
+        LEFT JOIN FETCH a.question
+        LEFT JOIN FETCH a.eventSignUpAnswer
+        WHERE es.event.id = :eventId
+        """
+    )
+    fun findByEvent_Id(@Param("eventId") eventId: Long): MutableList<EventSignUp>
 
-    @EntityGraph(value = "EventSignUp.withGuestAndAnswers", type = EntityGraph.EntityGraphType.LOAD)
+    @EntityGraph(value = "EventSignUp.withGuestUserAndAnswers", type = EntityGraph.EntityGraphType.LOAD)
     fun findByGuestAccessTokenHashAndEvent_Id(accessTokenHash: String, eventId: Long): Optional<EventSignUp>
 
-    @EntityGraph(value = "EventSignUp.withGuestAndAnswers", type = EntityGraph.EntityGraphType.LOAD)
+    @EntityGraph(value = "EventSignUp.withGuestUserAndAnswers", type = EntityGraph.EntityGraphType.LOAD)
     fun findAllByEventSignUpForm_Id(surveyId: Long): MutableSet<EventSignUp>
 }

--- a/services/frontend/src/pages/events/EventSignUps.vue
+++ b/services/frontend/src/pages/events/EventSignUps.vue
@@ -12,8 +12,10 @@ import {
   QuestionType,
   type SurveyResponse,
 } from "@/services/api"
+import {buildEventSignUpsCsv, eventSignUpsCsvFilename} from "@/utils/eventSignUpsCsv"
 
 const event = ref<EventResponse>()
+const signUps = ref<EventSignUpResponse[]>([])
 
 type PersonInfo = {
   fullName: string;
@@ -38,7 +40,8 @@ onMounted(async () => {
       findEventSignUpsByEventId({path: {eventId}}),
     ])
 
-    responses.value = (signupsResp.data ?? []).map((es: EventSignUpResponse) => {
+    signUps.value = signupsResp.data ?? []
+    responses.value = signUps.value.map((es: EventSignUpResponse) => {
       const answers: Map<number, AnswerResponse> = new Map()
       es.answers?.forEach((answer: AnswerResponse) => {
         answers.set(answer.questionId, answer)
@@ -116,6 +119,20 @@ function isOpenAnswerEmpty(response: Response, question: QuestionResponse): bool
   return !answer || typeof text !== "string" || text.trim().length === 0
 }
 
+function exportCsv(): void {
+  if (!event.value) return
+  const csv = buildEventSignUpsCsv(event.value, signUps.value)
+  const blob = new Blob([csv], {type: "text/csv;charset=utf-8"})
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement("a")
+  anchor.href = url
+  anchor.download = eventSignUpsCsvFilename(event.value.title)
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(url)
+}
+
 </script>
 
 <template>
@@ -127,6 +144,19 @@ function isOpenAnswerEmpty(response: Response, question: QuestionResponse): bool
         class="mx-auto my-10"
         style="max-width: 1100px"
       >
+        <div class="d-flex justify-end mb-4">
+          <v-btn
+            color="primary"
+            data-testid="export-csv-btn"
+            :disabled="responses.length === 0"
+            prepend-icon="mdi-download"
+            variant="flat"
+            @click="exportCsv"
+          >
+            Export as CSV
+          </v-btn>
+        </div>
+
         <v-card class="mb-10">
           <v-card-title class="text-h5">
             Respondents

--- a/services/frontend/src/utils/eventSignUpsCsv.ts
+++ b/services/frontend/src/utils/eventSignUpsCsv.ts
@@ -1,0 +1,86 @@
+import {
+  type AnswerResponse,
+  type EventResponse,
+  type EventSignUpResponse,
+  type QuestionResponse,
+  QuestionType,
+} from "@/services/api"
+import {safeFormatISO} from "@/utils/datetime"
+
+const SUBMITTED_AT_FORMAT = "yyyy-MM-dd HH:mm"
+const FIXED_HEADERS = ["Submitted at", "Name", "Discord", "Email", "Phone"] as const
+
+type PersonColumns = {name: string; discord: string; email: string; phone: string}
+
+function personColumns(signUp: EventSignUpResponse): PersonColumns {
+  const source = signUp.user ?? signUp.guest
+  return {
+    name: signUp.user?.fullName ?? signUp.guest?.name ?? "",
+    discord: source?.discord ?? "",
+    email: source?.email ?? "",
+    phone: source?.phoneNumber ?? "",
+  }
+}
+
+/** Questions in display order, excluding DESCRIPTION blocks which carry no answer. */
+function exportableQuestions(event: EventResponse): QuestionResponse[] {
+  const questions = event.signUpForm?.questions ?? []
+  return questions
+    .filter((q) => q.type !== QuestionType.DESCRIPTION)
+    .sort((a, b) => a.idx - b.idx)
+}
+
+function answerCell(question: QuestionResponse, answer: AnswerResponse | undefined): string {
+  if (!answer) return ""
+  if (question.type === QuestionType.OPEN) return answer.textResponse ?? ""
+  const labels = question.choiceLabels ?? []
+  const selections = answer.optionSelections ?? []
+  return labels.filter((_, idx) => selections[idx]).join("; ")
+}
+
+/** Prefix cells that a spreadsheet would parse as a formula, defeating CSV injection. */
+function neutralizeFormula(value: string): string {
+  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value
+}
+
+function escapeField(value: string): string {
+  const guarded = neutralizeFormula(value)
+  return /[",\r\n]/.test(guarded) ? `"${guarded.replace(/"/g, '""')}"` : guarded
+}
+
+function toRow(fields: string[]): string {
+  return fields.map(escapeField).join(",")
+}
+
+/**
+ * Renders an event's sign-ups as RFC 4180 CSV, mirroring how Google Forms responses land in
+ * a Sheet: one header row, one row per respondent, and one column per form question.
+ */
+export function buildEventSignUpsCsv(event: EventResponse, signUps: EventSignUpResponse[]): string {
+  const questions = exportableQuestions(event)
+  const header = [...FIXED_HEADERS, ...questions.map((q) => q.label)]
+
+  const rows = signUps.map((signUp) => {
+    const person = personColumns(signUp)
+    const answersByQuestion = new Map(signUp.answers.map((a) => [a.questionId, a]))
+    const answerCells = questions.map((q) => answerCell(q, answersByQuestion.get(q.id)))
+    return [
+      safeFormatISO(signUp.createdAt, SUBMITTED_AT_FORMAT),
+      person.name,
+      person.discord,
+      person.email,
+      person.phone,
+      ...answerCells,
+    ]
+  })
+
+  return [header, ...rows].map(toRow).join("\r\n")
+}
+
+export function eventSignUpsCsvFilename(eventTitle: string | undefined): string {
+  const base = (eventTitle ?? "")
+    .trim()
+    .replace(/[^\w\- ]+/g, "")
+    .replace(/\s+/g, "-")
+  return `${base || "event"}-signups.csv`
+}

--- a/services/frontend/tests/e2e/events.spec.ts
+++ b/services/frontend/tests/e2e/events.spec.ts
@@ -1,3 +1,4 @@
+import {readFileSync} from "node:fs"
 import {expect, test} from "./test"
 import {installApiMocks, loginAsBoard} from "./mocks"
 
@@ -32,5 +33,61 @@ test.describe("events page", () => {
     await expect(eventCardAfterReturn).toBeVisible()
     await eventCardAfterReturn.getByTestId("event-edit-btn-500").click()
     await expect(page).toHaveURL(/\/events\/edit\/500/)
+  })
+
+  // Pin the zone so the formatted "Submitted at" column is deterministic across machines.
+  test.use({timezoneId: "UTC"})
+
+  test("exports the event sign-ups as a CSV download", async ({page}) => {
+    await installApiMocks(page, {
+      eventDetailsById: {
+        "500": {
+          id: 500,
+          title: "Game Night",
+          approved: true,
+          signUp: true,
+          membersOnly: false,
+          committeeId: 900,
+          signUpForm: {
+            id: 1,
+            responseCount: 1,
+            questions: [
+              {id: 10, idx: 0, type: "OPEN", label: "Why join", surveyId: 1},
+              {id: 11, idx: 1, type: "CHECKBOX", label: "Snacks", choiceLabels: ["Pizza", "Chips"], surveyId: 1},
+            ],
+          },
+        },
+      },
+      eventSignUpsByEventId: {
+        "500": [
+          {
+            id: 600,
+            eventId: 500,
+            createdAt: "2026-02-20T12:34:00.000Z",
+            user: {id: 1, fullName: "Ada Lovelace", discord: "ada#0001", email: "ada@example.com", phoneNumber: "0612345678"},
+            answers: [
+              {id: 1, questionId: 10, textResponse: "Love games"},
+              {id: 2, questionId: 11, optionSelections: [true, false]},
+            ],
+          },
+        ],
+      },
+    })
+    await loginAsBoard(page.context())
+
+    await page.goto("/events/signups/500")
+    const exportButton = page.getByTestId("export-csv-btn")
+    await expect(exportButton).toBeEnabled({timeout: 30_000})
+
+    const downloadPromise = page.waitForEvent("download")
+    await exportButton.click()
+    const download = await downloadPromise
+
+    expect(download.suggestedFilename()).toBe("Game-Night-signups.csv")
+
+    const contents = readFileSync(await download.path(), "utf-8")
+    const lines = contents.split("\r\n")
+    expect(lines[0]).toBe("Submitted at,Name,Discord,Email,Phone,Why join,Snacks")
+    expect(lines[1]).toBe("2026-02-20 12:34,Ada Lovelace,ada#0001,ada@example.com,0612345678,Love games,Pizza")
   })
 })

--- a/services/frontend/tests/e2e/mocks.ts
+++ b/services/frontend/tests/e2e/mocks.ts
@@ -13,6 +13,8 @@ type Fixtures = {
   addresses?: Array<Record<string, unknown>>
   events?: Array<Record<string, unknown>>
   eventSignUps?: Array<Record<string, unknown>>
+  eventDetailsById?: Record<string, Record<string, unknown>>
+  eventSignUpsByEventId?: Record<string, Array<Record<string, unknown>>>
   committees?: Array<Record<string, unknown>>
   blogs?: Array<Record<string, unknown>>
   blogsById?: Record<string, Record<string, unknown>>
@@ -312,6 +314,17 @@ export async function installApiMocks(page: Page, fixtures: Fixtures = {}) {
     }
     if (method === "GET" && (path === "/events/signups/byAccessToken" || path.startsWith("/events/signups/byAccessToken/"))) {
       return fulfillJson(route, baseEventSignUps)
+    }
+    if (method === "GET" && /^\/events\/\d+\/signups$/.test(path)) {
+      const eventId = path.split("/")[2]
+      return fulfillJson(route, fixtures.eventSignUpsByEventId?.[eventId] ?? [])
+    }
+    if (method === "GET" && /^\/events\/\d+$/.test(path)) {
+      const eventId = Number(path.split("/").at(-1))
+      const detail = fixtures.eventDetailsById?.[String(eventId)]
+        ?? baseEvents.find((candidate) => Number(candidate.id) === eventId)
+        ?? {id: eventId}
+      return fulfillJson(route, detail)
     }
     if (method === "GET" && path === "/committees") {
       return fulfillJson(route, baseCommittees)

--- a/services/frontend/tests/unit/utils/eventSignUpsCsv.test.ts
+++ b/services/frontend/tests/unit/utils/eventSignUpsCsv.test.ts
@@ -1,0 +1,151 @@
+import {beforeAll, describe, expect, it} from "vitest"
+import {Settings} from "luxon"
+import {
+  type EventResponse,
+  type EventSignUpResponse,
+  type QuestionResponse,
+  QuestionType,
+} from "@/services/api"
+import {buildEventSignUpsCsv, eventSignUpsCsvFilename} from "@/utils/eventSignUpsCsv"
+
+// Pin the zone so the formatted "Submitted at" column is deterministic across machines.
+beforeAll(() => {
+  Settings.defaultZone = "utc"
+})
+
+function question(partial: Partial<QuestionResponse> & {id: number; idx: number; type: QuestionType}): QuestionResponse {
+  return {
+    label: `Question ${partial.id}`,
+    surveyId: 1,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    version: 0,
+    ...partial,
+  } as QuestionResponse
+}
+
+function event(questions: QuestionResponse[], title = "Game Night"): EventResponse {
+  return {
+    id: 500,
+    title,
+    signUpForm: {id: 1, questions, responseCount: questions.length, createdAt: "", updatedAt: "", version: 0},
+  } as unknown as EventResponse
+}
+
+function signUp(partial: Partial<EventSignUpResponse>): EventSignUpResponse {
+  return {
+    id: 1,
+    eventId: 500,
+    answers: [],
+    createdAt: "2026-02-20T12:34:00.000Z",
+    updatedAt: "2026-02-20T12:34:00.000Z",
+    version: 0,
+    ...partial,
+  } as EventSignUpResponse
+}
+
+function rows(csv: string): string[] {
+  return csv.split("\r\n")
+}
+
+describe("buildEventSignUpsCsv", () => {
+  it("emits identity columns followed by one column per question in idx order", () => {
+    const questions = [
+      question({id: 11, idx: 1, type: QuestionType.OPEN, label: "Comments"}),
+      question({id: 10, idx: 0, type: QuestionType.OPEN, label: "Why join"}),
+    ]
+    const csv = buildEventSignUpsCsv(event(questions), [])
+    expect(rows(csv)[0]).toBe("Submitted at,Name,Discord,Email,Phone,Why join,Comments")
+  })
+
+  it("excludes DESCRIPTION blocks since they carry no answer", () => {
+    const questions = [
+      question({id: 10, idx: 0, type: QuestionType.DESCRIPTION, label: "Intro text"}),
+      question({id: 11, idx: 1, type: QuestionType.OPEN, label: "Name tag"}),
+    ]
+    const csv = buildEventSignUpsCsv(event(questions), [])
+    expect(rows(csv)[0]).toBe("Submitted at,Name,Discord,Email,Phone,Name tag")
+  })
+
+  it("renders a member sign-up from the user fields", () => {
+    const questions = [question({id: 10, idx: 0, type: QuestionType.OPEN})]
+    const su = signUp({
+      user: {
+        id: 1,
+        fullName: "Ada Lovelace",
+        discord: "ada#0001",
+        email: "ada@example.com",
+        phoneNumber: "0612345678",
+        createdAt: "",
+        updatedAt: "",
+        version: 0,
+      },
+      answers: [{id: 1, questionId: 10, textResponse: "Love games", createdAt: "", updatedAt: "", version: 0}],
+    })
+    const csv = buildEventSignUpsCsv(event(questions), [su])
+    expect(rows(csv)[1]).toBe("2026-02-20 12:34,Ada Lovelace,ada#0001,ada@example.com,0612345678,Love games")
+  })
+
+  it("falls back to guest fields when there is no user", () => {
+    const csv = buildEventSignUpsCsv(event([]), [
+      signUp({
+        guest: {
+          id: 9,
+          name: "Guesty",
+          discord: "guest#1234",
+          email: "guest@example.com",
+          phoneNumber: "0600000000",
+          createdAt: "",
+          updatedAt: "",
+          version: 0,
+        },
+      }),
+    ])
+    expect(rows(csv)[1]).toBe("2026-02-20 12:34,Guesty,guest#1234,guest@example.com,0600000000")
+  })
+
+  it("joins the selected labels for choice questions and leaves missing answers blank", () => {
+    const questions = [
+      question({id: 10, idx: 0, type: QuestionType.CHECKBOX, label: "Snacks", choiceLabels: ["Pizza", "Chips", "Fruit"]}),
+      question({id: 11, idx: 1, type: QuestionType.RADIO, label: "Drink", choiceLabels: ["Cola", "Water"]}),
+    ]
+    const su = signUp({
+      answers: [
+        {id: 1, questionId: 10, optionSelections: [true, false, true], createdAt: "", updatedAt: "", version: 0},
+        // no answer for question 11 -> blank cell
+      ],
+    })
+    const cells = rows(buildEventSignUpsCsv(event(questions), [su]))[1].split(",")
+    expect(cells.at(-2)).toBe("Pizza; Fruit")
+    expect(cells.at(-1)).toBe("")
+  })
+
+  it("escapes commas, quotes and newlines per RFC 4180", () => {
+    const questions = [question({id: 10, idx: 0, type: QuestionType.OPEN, label: "Note"})]
+    const su = signUp({
+      answers: [{id: 1, questionId: 10, textResponse: 'a, "b"\nc', createdAt: "", updatedAt: "", version: 0}],
+    })
+    const csv = buildEventSignUpsCsv(event(questions), [su])
+    expect(csv).toContain('"a, ""b""\nc"')
+  })
+
+  it("neutralizes spreadsheet formulas to prevent CSV injection", () => {
+    const questions = [question({id: 10, idx: 0, type: QuestionType.OPEN, label: "Note"})]
+    const su = signUp({
+      answers: [{id: 1, questionId: 10, textResponse: "=HYPERLINK(\"http://evil\")", createdAt: "", updatedAt: "", version: 0}],
+    })
+    const csv = buildEventSignUpsCsv(event(questions), [su])
+    expect(csv).toContain("'=HYPERLINK")
+  })
+})
+
+describe("eventSignUpsCsvFilename", () => {
+  it("slugifies the event title", () => {
+    expect(eventSignUpsCsvFilename("Game Night: 2026!")).toBe("Game-Night-2026-signups.csv")
+  })
+
+  it("falls back to a default base when the title is empty", () => {
+    expect(eventSignUpsCsvFilename(undefined)).toBe("event-signups.csv")
+    expect(eventSignUpsCsvFilename("   ")).toBe("event-signups.csv")
+  })
+})


### PR DESCRIPTION
## Why
The event sign-ups page shows respondents and their form answers on
screen, but there was no way to get that data out for a guest list,
catering count or attendance check. Anyone needing the data offline had
to copy it by hand.

## What this achieves
Committee members and board can download an event's sign-ups as a CSV
straight from the sign-ups page. The file holds one row per respondent
and one column per form question — the same shape Google Forms produces
when its responses sync to a sheet — so it opens cleanly in any
spreadsheet. Listing sign-ups for an event is also now a single query
regardless of how many people signed up.

## How
- `services/frontend/src/utils/eventSignUpsCsv.ts` composes the CSV from
  the structured response the API already returns: fixed identity
  columns (`Submitted at`, `Name`, `Discord`, `Email`, `Phone`) followed
  by one column per question in display order. OPEN answers emit their
  text, RADIO/CHECKBOX answers collapse to the selected choice labels,
  `DESCRIPTION` blocks are skipped, fields are escaped per RFC 4180, and
  any value beginning with `= + - @` is prefixed to defeat spreadsheet
  formula injection.
- `EventSignUps.vue` gains an `Export as CSV` button that builds the CSV
  and triggers a client-side download named `<event-title>-signups.csv`.
- `EventSignUpRepository.findByEvent_Id` switched from the shared entity
  graph to an explicit `JOIN FETCH` covering guest, user, answers and
  their questions, plus the eager `mappedBy` back-references
  `user.memberProfile` and `answer.eventSignUpAnswer` that otherwise
  fired one SELECT per row. The named graph itself also now includes
  `user`, removing the per-row user load from the other list paths.
- `EventSignUpFetchIT` measures Hibernate's prepared-statement count and
  asserts it does not grow as the number of sign-ups grows.
- Tests: a vitest suite for the CSV builder (headers, choice joins,
  guest vs member rows, escaping, formula neutralisation, filename
  slugging) and a Playwright test that clicks the button and verifies the
  downloaded file's contents. Mock routes for `GET /events/{id}` and
  `GET /events/{id}/signups` were added to the e2e harness.