### PR TITLE
api: filtered Discord REST client + DiscordClientConfig skeleton

### DIFF
--- a/build-logic/src/main/kotlin/testing-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/testing-conventions.gradle.kts
@@ -25,7 +25,7 @@ configurations["integrationTestRuntimeOnly"].extendsFrom(configurations.testRunt
 
 tasks.withType<Test> {
     useJUnitPlatform {
-        excludeTags("system", "brevo-live")
+        excludeTags("system", "brevo-live", "discord-live")
     }
 }
 
@@ -35,7 +35,7 @@ tasks.register<Test>("integrationTest") {
     testClassesDirs = sourceSets["integrationTest"].output.classesDirs
     classpath = sourceSets["integrationTest"].runtimeClasspath
     useJUnitPlatform {
-        excludeTags("system", "brevo-live")
+        excludeTags("system", "brevo-live", "discord-live")
     }
     shouldRunAfter(tasks.test)
 }

--- a/services/api/build.gradle.kts
+++ b/services/api/build.gradle.kts
@@ -121,6 +121,7 @@ dependencies {
     implementation("org.openapitools:jackson-databind-nullable:0.2.9")
 
     implementation(project(":services:api:clients:brevo"))
+    implementation(project(":services:api:clients:discord"))
 
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2")
 
@@ -211,6 +212,16 @@ val brevoLiveTest by tasks.registering(Test::class) {
     classpath = sourceSets["test"].runtimeClasspath
     shouldRunAfter(tasks.test)
     useJUnitPlatform { includeTags("brevo-live") }
+}
+
+val discordLiveTest by tasks.registering(Test::class) {
+    description =
+        "Runs live Discord API integration tests tagged with @Tag(\"discord-live\"). Requires DISCORD_BOT_TOKEN."
+    group = "verification"
+    testClassesDirs = sourceSets["integrationTest"].output.classesDirs
+    classpath = sourceSets["integrationTest"].runtimeClasspath
+    shouldRunAfter(tasks.named("integrationTest"))
+    useJUnitPlatform { includeTags("discord-live") }
 }
 
 tasks.withType<BootRun>().configureEach {

--- a/services/api/clients/discord/build.gradle.kts
+++ b/services/api/clients/discord/build.gradle.kts
@@ -1,0 +1,146 @@
+plugins {
+    id("openapi-client-conventions")
+}
+
+// Discord's published OpenAPI spec ships untagged and covers the entire
+// public API (~500 operations). Generating the whole surface would balloon
+// compile time and expose endpoints we never intend to call. Pre-filter the
+// spec to a small allow-list of paths the website actually uses, then tag
+// the survivors so the generator produces a single `DiscordApi`.
+private val operationAllowList: Map<String, Set<String>> = mapOf(
+    "/users/@me" to setOf("get"),
+    "/guilds/{guild_id}" to setOf("get"),
+    "/guilds/{guild_id}/members" to setOf("get"),
+    "/guilds/{guild_id}/members/search" to setOf("get"),
+    "/guilds/{guild_id}/members/{user_id}" to setOf("get", "patch"),
+    "/guilds/{guild_id}/roles" to setOf("get"),
+)
+
+private val INJECTED_TAG = "Discord"
+
+private val sourceSpec = rootProject.layout.projectDirectory.file("libs/openapi-specs/discord.json")
+private val filteredSpec = layout.buildDirectory.file("discord-filtered.json")
+
+val filterDiscordSpec = tasks.register("filterDiscordSpec") {
+    description = "Filters libs/openapi-specs/discord.json to the operations the website calls and tags them."
+    group = "openapi"
+
+    inputs.file(sourceSpec)
+    inputs.property("allowList", operationAllowList.mapValues { it.value.toList().sorted() })
+    inputs.property("tag", INJECTED_TAG)
+    outputs.file(filteredSpec)
+
+    doLast {
+        val source = sourceSpec.asFile
+        val target = filteredSpec.get().asFile
+        target.parentFile.mkdirs()
+
+        @Suppress("UNCHECKED_CAST")
+        val spec = groovy.json.JsonSlurper().parse(source) as MutableMap<String, Any?>
+
+        @Suppress("UNCHECKED_CAST")
+        val paths = spec["paths"] as MutableMap<String, Any?>
+        val httpMethods = setOf("get", "post", "put", "patch", "delete", "head", "options")
+
+        paths.keys.toList().forEach { path ->
+            val allowedMethods = operationAllowList[path]
+            if (allowedMethods == null) {
+                paths.remove(path)
+                return@forEach
+            }
+            @Suppress("UNCHECKED_CAST")
+            val ops = paths[path] as MutableMap<String, Any?>
+            ops.keys.toList().forEach { key ->
+                if (key !in httpMethods) return@forEach
+                if (key !in allowedMethods) {
+                    ops.remove(key)
+                    return@forEach
+                }
+                @Suppress("UNCHECKED_CAST")
+                val opMap = ops[key] as MutableMap<String, Any?>
+                opMap["tags"] = listOf(INJECTED_TAG)
+            }
+            if (ops.keys.none { it in httpMethods }) {
+                paths.remove(path)
+            }
+        }
+
+        // Discord's spec defines ~600 schemas in components.schemas; the
+        // openapi-generator emits Java for every one regardless of `apis`
+        // filtering, and several carry `@Max` values larger than Java's int
+        // range. Prune to only the schemas transitively reachable from the
+        // kept paths so the generated client stays small and compilable.
+        @Suppress("UNCHECKED_CAST")
+        val components = spec["components"] as? MutableMap<String, Any?>
+        @Suppress("UNCHECKED_CAST")
+        val schemas = components?.get("schemas") as? MutableMap<String, Any?>
+        if (schemas != null) {
+            val seed = mutableSetOf<String>()
+            collectSchemaRefs(paths, seed)
+            // Also seed from any sibling components subsections we kept
+            // (parameters/responses/etc.) so their schema refs stay alive.
+            components.forEach { (key, value) ->
+                if (key != "schemas") collectSchemaRefs(value, seed)
+            }
+            val reachable = mutableSetOf<String>()
+            val queue = ArrayDeque(seed)
+            while (queue.isNotEmpty()) {
+                val name = queue.removeFirst()
+                if (!reachable.add(name)) continue
+                val schema = schemas[name] ?: continue
+                val nested = mutableSetOf<String>()
+                collectSchemaRefs(schema, nested)
+                queue.addAll(nested - reachable)
+            }
+            schemas.keys.toList().forEach { if (it !in reachable) schemas.remove(it) }
+
+            // Discord's OpenAPI 3.1 spec uses `type: "null"` as a marker-flag
+            // shape on a few role-tag fields. openapi-generator can't synthesise
+            // a Java type for that and emits a missing `ModelNull` import.
+            // Rewrite to `type: "boolean"` so the property still appears on the
+            // generated DTO with the natural "present == true" semantics.
+            rewriteNullTypeProperties(schemas)
+        }
+
+        target.writeText(groovy.json.JsonOutput.toJson(spec))
+    }
+}
+
+/** In-place fixup: replace `type: "null"` properties with `type: "boolean"` everywhere in the tree. */
+fun rewriteNullTypeProperties(node: Any?) {
+    when (node) {
+        is MutableMap<*, *> -> {
+            @Suppress("UNCHECKED_CAST")
+            val map = node as MutableMap<String, Any?>
+            if (map["type"] == "null") map["type"] = "boolean"
+            map.values.forEach { rewriteNullTypeProperties(it) }
+        }
+        is List<*> -> node.forEach { rewriteNullTypeProperties(it) }
+    }
+}
+
+/** Walks an OpenAPI fragment and collects every `#/components/schemas/<name>` reference. */
+fun collectSchemaRefs(node: Any?, out: MutableSet<String>) {
+    when (node) {
+        is Map<*, *> -> node.forEach { (k, v) ->
+            if (k == "\$ref" && v is String && v.startsWith("#/components/schemas/")) {
+                out.add(v.removePrefix("#/components/schemas/"))
+            } else {
+                collectSchemaRefs(v, out)
+            }
+        }
+        is List<*> -> node.forEach { collectSchemaRefs(it, out) }
+    }
+}
+
+tasks.named("generate").configure { dependsOn(filterDiscordSpec) }
+
+openApiClient {
+    // Path is resolved against the repo root by the convention plugin, so this
+    // string must be a root-relative path.
+    specPath.set("services/api/clients/discord/build/discord-filtered.json")
+    apiPackage.set("net.blueshell.clients.discord.api")
+    modelPackage.set("net.blueshell.clients.discord.model")
+    packageName.set("net.blueshell.clients.discord.invoker")
+    apis.set(listOf(INJECTED_TAG))
+}

--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/discord/DiscordClientLiveIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/discord/DiscordClientLiveIT.kt
@@ -1,0 +1,37 @@
+package net.blueshell.api.platform.integration.discord
+
+import net.blueshell.clients.discord.api.DiscordApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+/**
+ * Live smoke test for the generated Discord client. Calls `GET /users/@me` to
+ * verify the bot token is accepted and the [DiscordClientConfig] wiring is
+ * correct.
+ *
+ * Uses the "discord-live" profile, which deactivates the test/dev guards and
+ * activates [DiscordClientConfig]. Credentials are resolved from the
+ * environment (`DISCORD_BOT_TOKEN`).
+ *
+ *     docker compose run api \
+ *       ./gradlew :services:api:discordLiveTest --tests "*.DiscordClientLiveIT"
+ */
+@Tag("discord-live")
+@SpringBootTest
+@ActiveProfiles("discord-live")
+class DiscordClientLiveIT {
+
+    @Autowired
+    private lateinit var discordApi: DiscordApi
+
+    @Test
+    fun `bot token resolves the bot user`() {
+        val me = discordApi.getMyUser()
+        assertThat(me).isNotNull
+        assertThat(me.id).isNotBlank()
+    }
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/sync/target/discord/DiscordClientConfig.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/sync/target/discord/DiscordClientConfig.kt
@@ -1,0 +1,39 @@
+package net.blueshell.api.platform.integration.sync.target.discord
+
+import net.blueshell.clients.discord.ApiClient
+import net.blueshell.clients.discord.api.DiscordApi
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter
+import org.springframework.web.client.RestClient
+import tools.jackson.databind.json.JsonMapper
+
+/**
+ * Wires the Discord [DiscordApi] client. Sibling of `BrevoClientConfig`:
+ * keeps the bot-token header and base URL out of the adapter layer so the
+ * adapter can be unit-tested with a mock client. Active in production only
+ * (test/dev get a mock from a sibling configuration in a later PR).
+ */
+@Configuration
+@Profile("!test & !dev")
+class DiscordClientConfig {
+    @Bean
+    fun discordApi(
+        restClientBuilder: RestClient.Builder,
+        jsonMapper: JsonMapper,
+        @Value($$"${discord.botToken:}") botToken: String,
+        @Value($$"${discord.baseUrl:https://discord.com/api/v10}") baseUrl: String,
+    ): DiscordApi =
+        DiscordApi(
+            ApiClient(
+                restClientBuilder.baseUrl(baseUrl)
+                    .defaultHeader("Authorization", "Bot $botToken")
+                    .configureMessageConverters {
+                        it.addCustomConverter(JacksonJsonHttpMessageConverter(jsonMapper))
+                    }
+                    .build()
+            )
+        )
+}

--- a/services/api/src/main/resources/application.yaml
+++ b/services/api/src/main/resources/application.yaml
@@ -124,6 +124,11 @@ brevo:
   folders:
     contributionPeriodsId: ${BREVO_FOLDER_CONTRIBUTION_PERIODS_ID:0}
 
+discord:
+  botToken: ${DISCORD_BOT_TOKEN:}
+  guildId: ${DISCORD_GUILD_ID:}
+  baseUrl: ${DISCORD_BASE_URL:https://discord.com/api/v10}
+
 google:
   calendar:
     id: ${GOOGLE_CALENDAR_ID:}

--- a/services/api/src/testFixtures/resources/application-discord-live.yml
+++ b/services/api/src/testFixtures/resources/application-discord-live.yml
@@ -1,0 +1,83 @@
+# Profile for running live Discord integration tests.
+# Mirrors application-brevo-live.yml: the key difference is that this profile
+# is NOT "test" or "dev", so the DiscordClientConfig (Profile("!test & !dev"))
+# activates and the real Discord API is called.
+spring:
+  application:
+    db: blueshell-test
+
+  main:
+    banner-mode: off
+    log-startup-info: false
+
+  jpa:
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+        highlight_sql: false
+        use_sql_comments: false
+
+  devtools:
+    restart:
+      enabled: false
+    livereload:
+      enabled: false
+
+logging:
+  pattern:
+    console: "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+  level:
+    root: INFO
+    net.blueshell: INFO
+    net.blueshell.api: DEBUG
+    org.springframework: WARN
+    org.springframework.web: WARN
+    org.springframework.boot.autoconfigure: WARN
+    org.springframework.jdbc: WARN
+    org.springframework.security: WARN
+    org.apache.catalina: WARN
+    org.apache.coyote: WARN
+    org.apache.tomcat: WARN
+    org.hibernate: WARN
+    org.hibernate.SQL: OFF
+    org.hibernate.type.descriptor.sql: OFF
+    org.hibernate.type.descriptor.jdbc: OFF
+    org.hibernate.orm.jdbc.bind: OFF
+    com.zaxxer.hikari: WARN
+    org.flywaydb: WARN
+    org.testcontainers: WARN
+    com.github.dockerjava: WARN
+
+app:
+  security:
+    require-https: false
+  jobs:
+    max-retries: 3
+    initial-backoff-millis: 1
+    backoff-multiplier: 2.0
+    auto-dispatch: false
+
+security:
+  cors:
+    allowed-origins:
+      - http://frontend:3000
+      - http://localhost:3000
+      - http://localhost:5173
+      - http://127.0.0.1:3000
+      - http://127.0.0.1:5173
+  openapi:
+    public:
+      enabled: true
+  auth-rate-limit:
+    enabled: false
+
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true
+
+server:
+  error:
+    include-message: always

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,7 @@ dependencyResolutionManagement {
 include(":libs:kotlin-common")
 include(":services:api")
 include(":services:api:clients:brevo")
+include(":services:api:clients:discord")
 include(":services:system-tests")
 
 // libs:kotlin-common is an empty skeleton in this PR. When the OIDC / Vault


### PR DESCRIPTION
## Why

`User.discord` today is a self-reported text handle. That makes every
downstream Discord operation unreliable: typos and renames silently
break role assignments and there is no way to push role state back
into the guild. The path forward is to link each user to a real
Discord snowflake, sync roles to that snowflake the same way contacts
sync to Brevo, and offer an admin-driven link flow during a grace
period plus a longer-term OAuth self-link. This PR lays the
foundation: a backend HTTP client that can authenticate as the
Blueshell bot and call the Discord REST API. Linking, role-mapping,
sync targets and frontend UI follow in their own PRs.

## What this achieves

- A typed `DiscordApi` bean is available to future adapters and
  services on the `!test & !dev` profile, configured by env vars
  that already exist in `.api.example.env`.
- The bot-token + base-URL wiring is in one place
  (`DiscordClientConfig`), kept out of any adapter layer.
- A `discordLiveTest` Gradle task plus a `discord-live`-tagged
  smoke IT verifies the credential / wiring against the real
  Discord API on demand. Live tests stay opt-in: `discord-live`
  is centrally excluded from `test` and `integrationTest`.

## How

A new Gradle subproject `:services:api:clients:discord` sits next to
`:services:api:clients:brevo` and uses the existing
`openapi-client-conventions` plugin. Discord publishes a single
OpenAPI 3.1 spec at `libs/openapi-specs/discord.json` with ~600
schemas and zero tags. Generating the whole surface would balloon
compile time and pull in shapes the website never touches, including
several `@Max` literals beyond Java's int range and `type: "null"`
marker fields the Java generator can not emit. To avoid that, the
subproject's `build.gradle.kts` adds a `filterDiscordSpec` task that
preprocesses the spec before it reaches the generator:

- keeps only six operations (`/users/@me`, `/guilds/{guild_id}` and
  the guild member + role read/patch endpoints),
- tags the survivors with `Discord` so the generator emits a single
  `DiscordApi`,
- prunes `components.schemas` to the transitive closure of refs
  reachable from those operations (~600 → ~20 classes),
- rewrites `type: "null"` properties to `boolean` so generated DTOs
  do not import a non-existent `ModelNull`.

The convention plugin then runs unchanged against
`build/discord-filtered.json`, emitting
`net.blueshell.clients.discord.api.DiscordApi` and a small set of
DTOs under `…discord.model`.

`DiscordClientConfig` mirrors `BrevoClientConfig`: a single
`@Bean fun discordApi(...)` builds a `RestClient` with
`Authorization: Bot $token`, the configured base URL
(`https://discord.com/api/v10` by default) and the project's
`JsonMapper`. Property names follow the existing `brevo.*` shape:

- `discord.botToken` ← `DISCORD_BOT_TOKEN`
- `discord.guildId` ← `DISCORD_GUILD_ID`
- `discord.baseUrl` ← `DISCORD_BASE_URL` (default `https://discord.com/api/v10`)

The smoke `DiscordClientLiveIT` lives in `src/integrationTest/`,
loads the `discord-live` profile, and calls
`DiscordApi.getMyUser()` to verify the token actually authenticates
the bot. The new `discordLiveTest` Gradle task uses
`sourceSets["integrationTest"]` (where this IT lives) and runs only
the `discord-live` tag. `testing-conventions` centrally excludes
`discord-live` from the regular `test` / `integrationTest` runs so
the live API is never hit by default.

No production code paths consume `DiscordApi` yet; this PR is the
client skeleton only.