### PR TITLE
test(system): stabilise EventCreatePageSystemTest sign-up-limit flake

### DIFF
--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/helper/EventFormHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/helper/EventFormHelper.kt
@@ -92,6 +92,8 @@ object EventFormHelper {
     fun setSignUpLimit(page: Page, limit: Int) {
         val input = signUpLimitInput(page)
         input.fill(limit.toString())
+        // Force blur so Vuetify + vee-validate commit the value before submit.
+        input.press("Tab")
     }
 
     fun submit(page: Page) {


### PR DESCRIPTION
## Why
`EventCreatePageSystemTest > creating event with sign-up limit persists the limit` flaked intermittently across unrelated PRs. The POST returned 201, but the persisted event had `signUpLimit == null`, failing the assertion at the listing-lookup step. CI retry of the exact same commit passed, confirming a genuine timing race rather than a regression.

The sign-up-limit input is a Vuetify `v-text-field` wrapped in a vee-validate `Field`. The parent v-model on `event.signUpLimit` is only updated after `update:model-value` flows through vee-validate's `handleChange`. Playwright's `fill` does not emit `change`/`blur`, so clicking submit immediately after `fill` can win the race against the async validate + model-commit, producing a POST body without `signUpLimit`.

## What this achieves
The system test now deterministically reflects the typed value in the submitted POST body, eliminating the spurious null-limit failures.

## How
- `services/system-tests/.../helper/EventFormHelper.kt`: after `fill(limit)` in `setSignUpLimit`, press `Tab` to blur the field. The blur forces Vuetify + vee-validate to commit the value to the parent v-model before the submit click runs. No `Thread.sleep`, no other call-site changes.