### PR TITLE
ci: group Dependabot updates so they accumulate in open PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,85 @@
+# Dependabot configuration.
+#
+# Every ecosystem below defines `groups`, and each group is declared twice —
+# once for `version-updates` and once for `security-updates`. Grouping is what
+# makes Dependabot fold newly discovered updates into the PR that is already
+# open instead of leaving a stale per-dependency PR behind: a grouped PR is
+# rebuilt on every run, so the next bump joins the existing branch rather than
+# being skipped once the open-PR limit is reached.
+#
+# Labels are left to Dependabot's defaults (`dependencies` plus the language
+# label), which already match the repo's existing dependency PRs.
+version: 2
+
+updates:
+  # ── Frontend (yarn / npm) ────────────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /services/frontend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      frontend:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      frontend-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # ── JVM modules (Gradle) ─────────────────────────────────────────────────
+  - package-ecosystem: gradle
+    directories:
+      - /
+      - /build-logic
+      - /libs/kotlin-common
+      - /services/api
+      - /services/system-tests
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      gradle:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      gradle-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # ── GitHub Actions ───────────────────────────────────────────────────────
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # ── Container base images (Dockerfiles) ──────────────────────────────────
+  - package-ecosystem: docker
+    directories:
+      - /services/api
+      - /services/frontend
+      - /infra/stalwart
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      docker:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      docker-security:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## Why
The repository had no `dependabot.yml`, so it only received GitHub's
default security updates — one PR per advisory, ungrouped. When an
update PR sat open, later updates opened separate fresh PRs or were
silently skipped once the open-PR limit was reached, instead of being
added to the PR already in flight. Stale dependency PRs piled up and
never picked up newer bumps.

## What this achieves
New dependency updates now fold into the PR that is already open rather
than spawning a parallel one or being dropped. A grouped PR is rebuilt
on every Dependabot run, so the next bump joins the existing branch.
Version updates are enabled alongside the security updates that were
already running, across the frontend, the JVM modules, GitHub Actions
and the container base images.

## How
- Adds `.github/dependabot.yml` (`version: 2`) covering four ecosystems:
  - `npm` — `services/frontend`
  - `gradle` — root, `build-logic`, `libs/kotlin-common`, `services/api`, `services/system-tests`
  - `github-actions` — `/`
  - `docker` — `services/api`, `services/frontend`, `infra/stalwart`
- Each ecosystem defines a catch-all group (`patterns: ["*"]`) declared
  twice, once with `applies-to: version-updates` and once with
  `applies-to: security-updates`. Grouping is the mechanism that makes
  Dependabot consolidate updates into a single, continuously refreshed
  PR per ecosystem instead of one stale PR per dependency.
- `open-pull-requests-limit: 5` and a weekly schedule per ecosystem.
- Labels are left to Dependabot's defaults (`dependencies` plus the
  language label), matching the repo's existing dependency PRs; no new
  repo labels are required.