### PR TITLE
test(event): fix flaky query-count guard in EventSignUpFetchIT

### DIFF
--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/domain/event/persistence/EventSignUpFetchIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/domain/event/persistence/EventSignUpFetchIT.kt
@@ -51,9 +51,11 @@ class EventSignUpFetchIT : UserTestSupport() {
 
         assertThat(mapSignUps(singleSignUpEvent.id!!)).hasSize(1)
         assertThat(mapSignUps(manySignUpsEvent.id!!)).hasSize(5)
+        // An N+1 adds one statement per extra sign-up; tolerate a single statement of
+        // session-level variance but reject growth proportional to the sign-up count.
         assertThat(queriesForMany)
             .describedAs("query count must not grow with the number of sign-ups (N+1)")
-            .isEqualTo(queriesForOne)
+            .isLessThanOrEqualTo(queriesForOne + 1)
     }
 
     private fun persistQuestion(): Question {


### PR DESCRIPTION
## Why
`EventSignUpFetchIT` guards `EventSignUp.withGuestUserAndAnswers` against
N+1 regressions by comparing the prepared-statement count for an event
with one sign-up against an event with five. It asserted the two counts
were *exactly* equal. The count carries a single statement of
session-level variance, so a perfectly healthy build could measure 1
statement for one path and 2 for the other and fail the strict equality.
A recent run failed with the larger event measuring *fewer* queries than
the smaller one — the opposite of an N+1, proving the failure was
measurement jitter rather than a real regression. The flake blocks
otherwise-green PRs from merging.

## What this achieves
The query-count guard no longer flakes on benign one-statement variance,
while still failing hard on an actual N+1. Unrelated PRs stop being
blocked by a spurious red check.

## How
- `services/api/src/integrationTest/.../EventSignUpFetchIT.kt`: the final
  assertion changes from `isEqualTo(queriesForOne)` to
  `isLessThanOrEqualTo(queriesForOne + 1)`. An N+1 adds one statement per
  extra sign-up (four for the five-sign-up event), so it still trips the
  guard decisively; the harmless single-statement jitter no longer does.