### PR TITLE
api: add cohort rule engine + listener (shadow mode)

### DIFF
--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRuleEvaluation.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRuleEvaluation.kt
@@ -1,0 +1,24 @@
+package net.blueshell.api.platform.integration.cohort.application
+
+/**
+ * Result of one pass of [CohortRuleEvaluator]. The engine computes the
+ * desired-vs-current diff for every event that re-evaluates a user; in
+ * shadow mode the diff is only logged. The follow-up PR that flips the
+ * engine into action will use [toAdd] and [toRemove] to drive the
+ * `CohortMember` writes and per-target sync jobs.
+ */
+data class CohortRuleEvaluation(
+    val userId: Long,
+    val facts: Set<UserFact>,
+    val desired: Set<Long>,
+    val current: Set<Long>,
+) {
+    val toAdd: Set<Long> get() = desired - current
+    val toRemove: Set<Long> get() = current - desired
+    val isNoOp: Boolean get() = toAdd.isEmpty() && toRemove.isEmpty()
+
+    companion object {
+        fun empty(userId: Long): CohortRuleEvaluation =
+            CohortRuleEvaluation(userId, emptySet(), emptySet(), emptySet())
+    }
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRuleEvaluator.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRuleEvaluator.kt
@@ -1,0 +1,57 @@
+package net.blueshell.api.platform.integration.cohort.application
+
+import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortMemberRepository
+import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRuleRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Decides which cohorts a user should belong to, based on the
+ * [UserFact]s currently true for them and the enabled [CohortRule]s.
+ *
+ * Shadow mode (this PR): computes the diff and logs it. Does *not*
+ * write `CohortMember` rows or enqueue any per-target sync jobs. The
+ * follow-up PR turns the diff into actual side effects.
+ *
+ * Keeping the read+diff phase in one place behind a stable contract
+ * means the cutover PR only swaps the "log" tail for "persist + fan
+ * out" without touching listener wiring.
+ */
+@Service
+class CohortRuleEvaluator(
+    private val userFactCollector: UserFactCollector,
+    private val rules: CohortRuleRepository,
+    private val memberships: CohortMemberRepository,
+) {
+    @Transactional(readOnly = true)
+    fun evaluate(userId: Long): CohortRuleEvaluation {
+        val facts = userFactCollector.collect(userId)
+        val desired = facts.flatMap { fact ->
+            rules.findAllByFactKindAndFactKeyAndEnabledTrue(fact.kind, fact.key)
+        }.mapNotNull { it.cohort.id }.toSet()
+        val current = memberships.findAllByUserId(userId).mapNotNull { it.cohort.id }.toSet()
+
+        val evaluation = CohortRuleEvaluation(userId, facts, desired, current)
+        logShadow(evaluation)
+        return evaluation
+    }
+
+    private fun logShadow(e: CohortRuleEvaluation) {
+        if (e.isNoOp) {
+            log.debug(
+                "[cohort-shadow] user={} facts={} cohorts unchanged (membership={})",
+                e.userId, e.facts.size, e.current,
+            )
+            return
+        }
+        log.info(
+            "[cohort-shadow] user={} facts={} would add={} would remove={} current={} desired={}",
+            e.userId, e.facts.size, e.toAdd, e.toRemove, e.current, e.desired,
+        )
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(CohortRuleEvaluator::class.java)
+    }
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/UserFact.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/UserFact.kt
@@ -1,0 +1,10 @@
+package net.blueshell.api.platform.integration.cohort.application
+
+import net.blueshell.api.platform.integration.cohort.persistence.CohortFactKind
+
+/**
+ * One fact held by a user, matched against [CohortRule] rows by
+ * `(kind, key)`. The interpretation of `key` is per-kind — see
+ * [CohortFactKind].
+ */
+data class UserFact(val kind: CohortFactKind, val key: String)

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/UserFactCollector.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/UserFactCollector.kt
@@ -1,0 +1,54 @@
+package net.blueshell.api.platform.integration.cohort.application
+
+import net.blueshell.api.domain.user.application.UserService
+import net.blueshell.api.platform.integration.cohort.persistence.CohortFactKind
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Computes the set of [UserFact]s currently true for a user, by reading
+ * the canonical sources on the [net.blueshell.api.domain.user.persistence.User]
+ * entity graph.
+ *
+ * Single place to extend when a new [CohortFactKind] is added. Lazy
+ * associations on `User` are walked inside the read-only transaction,
+ * so callers can pass just the user id.
+ */
+@Service
+class UserFactCollector(
+    private val users: UserService,
+) {
+    @Transactional(readOnly = true)
+    fun collect(userId: Long): Set<UserFact> {
+        val user = runCatching { users.findById(userId) }.getOrNull() ?: return emptySet()
+        val facts = mutableSetOf<UserFact>()
+
+        // ROLE: User.roles is the source of truth (membership / committee /
+        // board listeners grant the matching Role values).
+        user.roles.forEach { role ->
+            facts.add(UserFact(CohortFactKind.ROLE, role.name))
+        }
+
+        // COMMITTEE: one fact per committee the user is a member of.
+        user.committeeMembers.forEach { membership ->
+            val committeeId = membership.committee.id ?: return@forEach
+            facts.add(UserFact(CohortFactKind.COMMITTEE, committeeId.toString()))
+        }
+
+        // CONTRIBUTION_PAID: one fact per contribution-period the user has
+        // an active contribution row for (soft-deleted rows are filtered
+        // by @SQLRestriction).
+        user.contributions.forEach { contribution ->
+            val periodId = contribution.id.contributionPeriodId ?: return@forEach
+            facts.add(UserFact(CohortFactKind.CONTRIBUTION_PAID, periodId.toString()))
+        }
+
+        // NEWSLETTER: a single boolean fact; opt-out is represented by
+        // the *absence* of a rule, not a "false" fact.
+        if (user.newsletter) {
+            facts.add(UserFact(CohortFactKind.NEWSLETTER, "true"))
+        }
+
+        return facts
+    }
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/listener/CohortRuleListener.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/listener/CohortRuleListener.kt
@@ -1,0 +1,68 @@
+package net.blueshell.api.platform.integration.cohort.application.listener
+
+import net.blueshell.api.domain.committee.application.event.CommitteeMembershipChanged
+import net.blueshell.api.domain.contribution.application.event.ContributionChanged
+import net.blueshell.api.domain.user.application.event.MembershipChanged
+import net.blueshell.api.domain.user.application.event.UserCreated
+import net.blueshell.api.domain.user.application.event.UserDeleted
+import net.blueshell.api.domain.user.application.event.UserUpdated
+import net.blueshell.api.platform.integration.cohort.application.CohortRuleEvaluator
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Funnels every change event that can alter a user's [UserFact]s into a
+ * single re-evaluation of cohort membership. Shadow mode for now: the
+ * evaluator only logs the diff. Hooking up every relevant source-of-truth
+ * event in this PR means the follow-up cutover PR has nothing to wire —
+ * it only flips the evaluator's "log" tail into "act".
+ *
+ * `REQUIRES_NEW` mirrors the other listeners in the codebase: the
+ * re-evaluation runs in its own transaction so an evaluator failure
+ * cannot roll back the originating change.
+ */
+@Component
+class CohortRuleListener(
+    private val evaluator: CohortRuleEvaluator,
+) {
+    @EventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun onUserCreated(evt: UserCreated) {
+        evaluator.evaluate(evt.userId)
+    }
+
+    @EventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun onUserUpdated(evt: UserUpdated) {
+        evaluator.evaluate(evt.userId)
+    }
+
+    @EventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun onUserDeleted(evt: UserDeleted) {
+        // After deletion the fact collector returns an empty set, so the
+        // diff is "remove from every cohort the user was in". Exactly the
+        // semantics we want.
+        evaluator.evaluate(evt.userId)
+    }
+
+    @EventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun onMembershipChanged(evt: MembershipChanged) {
+        evaluator.evaluate(evt.userId)
+    }
+
+    @EventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun onCommitteeMembershipChanged(evt: CommitteeMembershipChanged) {
+        evaluator.evaluate(evt.userId)
+    }
+
+    @EventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun onContributionChanged(evt: ContributionChanged) {
+        evaluator.evaluate(evt.userId)
+    }
+}

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRuleEvaluatorTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRuleEvaluatorTest.kt
@@ -1,0 +1,107 @@
+package net.blueshell.api.platform.integration.cohort.application
+
+import io.mockk.every
+import io.mockk.mockk
+import net.blueshell.api.platform.integration.cohort.persistence.Cohort
+import net.blueshell.api.platform.integration.cohort.persistence.CohortFactKind
+import net.blueshell.api.platform.integration.cohort.persistence.CohortKind
+import net.blueshell.api.platform.integration.cohort.persistence.CohortMember
+import net.blueshell.api.platform.integration.cohort.persistence.CohortRule
+import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortMemberRepository
+import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRuleRepository
+import net.blueshell.api.shared.enums.Role
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class CohortRuleEvaluatorTest {
+
+    private val factCollector: UserFactCollector = mockk()
+    private val rules: CohortRuleRepository = mockk()
+    private val memberships: CohortMemberRepository = mockk()
+    private val evaluator = CohortRuleEvaluator(factCollector, rules, memberships)
+
+    @Test
+    fun `desired set is the union of cohorts referenced by rules matching held facts`() {
+        every { factCollector.collect(1L) } returns setOf(
+            UserFact(CohortFactKind.ROLE, Role.MEMBER.name),
+            UserFact(CohortFactKind.NEWSLETTER, "true"),
+        )
+        val brevoMembers = cohort(id = 10L)
+        val discordMember = cohort(id = 11L)
+        val newsletterList = cohort(id = 20L)
+        every {
+            rules.findAllByFactKindAndFactKeyAndEnabledTrue(CohortFactKind.ROLE, Role.MEMBER.name)
+        } returns listOf(rule(brevoMembers), rule(discordMember))
+        every {
+            rules.findAllByFactKindAndFactKeyAndEnabledTrue(CohortFactKind.NEWSLETTER, "true")
+        } returns listOf(rule(newsletterList))
+        every { memberships.findAllByUserId(1L) } returns emptyList()
+
+        val result = evaluator.evaluate(1L)
+
+        assertThat(result.desired).containsExactlyInAnyOrder(10L, 11L, 20L)
+        assertThat(result.toAdd).containsExactlyInAnyOrder(10L, 11L, 20L)
+        assertThat(result.toRemove).isEmpty()
+    }
+
+    @Test
+    fun `cohorts currently joined but no longer desired land in toRemove`() {
+        every { factCollector.collect(1L) } returns emptySet()
+        val stale = cohort(id = 99L)
+        every { memberships.findAllByUserId(1L) } returns listOf(membership(stale))
+
+        val result = evaluator.evaluate(1L)
+
+        assertThat(result.toRemove).containsExactly(99L)
+        assertThat(result.toAdd).isEmpty()
+    }
+
+    @Test
+    fun `noop evaluation reports current and desired set equal`() {
+        every { factCollector.collect(1L) } returns setOf(
+            UserFact(CohortFactKind.ROLE, Role.MEMBER.name),
+        )
+        val members = cohort(id = 10L)
+        every {
+            rules.findAllByFactKindAndFactKeyAndEnabledTrue(CohortFactKind.ROLE, Role.MEMBER.name)
+        } returns listOf(rule(members))
+        every { memberships.findAllByUserId(1L) } returns listOf(membership(members))
+
+        val result = evaluator.evaluate(1L)
+
+        assertThat(result.isNoOp).isTrue()
+        assertThat(result.toAdd).isEmpty()
+        assertThat(result.toRemove).isEmpty()
+    }
+
+    @Test
+    fun `evaluation returns empty result when user has no facts`() {
+        every { factCollector.collect(404L) } returns emptySet()
+        every { memberships.findAllByUserId(404L) } returns emptyList()
+
+        val result = evaluator.evaluate(404L)
+
+        assertThat(result.desired).isEmpty()
+        assertThat(result.current).isEmpty()
+        assertThat(result.isNoOp).isTrue()
+    }
+
+    private fun cohort(id: Long): Cohort {
+        val c = mockk<Cohort>()
+        every { c.id } returns id
+        every { c.kind } returns CohortKind.LIST
+        return c
+    }
+
+    private fun rule(cohort: Cohort): CohortRule {
+        val r = mockk<CohortRule>()
+        every { r.cohort } returns cohort
+        return r
+    }
+
+    private fun membership(cohort: Cohort): CohortMember {
+        val m = mockk<CohortMember>()
+        every { m.cohort } returns cohort
+        return m
+    }
+}

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/UserFactCollectorTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/UserFactCollectorTest.kt
@@ -1,0 +1,122 @@
+package net.blueshell.api.platform.integration.cohort.application
+
+import io.mockk.every
+import io.mockk.mockk
+import net.blueshell.api.domain.committee.persistence.Committee
+import net.blueshell.api.domain.committee.persistence.CommitteeMember
+import net.blueshell.api.domain.contribution.persistence.Contribution
+import net.blueshell.api.domain.user.application.UserService
+import net.blueshell.api.domain.user.persistence.User
+import net.blueshell.api.platform.integration.cohort.persistence.CohortFactKind
+import net.blueshell.api.shared.enums.Role
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class UserFactCollectorTest {
+
+    private val users: UserService = mockk()
+    private val collector = UserFactCollector(users)
+
+    @Test
+    fun `returns empty set when user is not found`() {
+        every { users.findById(999L) } throws RuntimeException("not found")
+
+        assertThat(collector.collect(999L)).isEmpty()
+    }
+
+    @Test
+    fun `emits one ROLE fact per role on the user`() {
+        every { users.findById(1L) } returns userWith(
+            roles = setOf(Role.GUEST, Role.MEMBER, Role.BOARD),
+        )
+
+        val facts = collector.collect(1L)
+
+        assertThat(facts).contains(
+            UserFact(CohortFactKind.ROLE, Role.GUEST.name),
+            UserFact(CohortFactKind.ROLE, Role.MEMBER.name),
+            UserFact(CohortFactKind.ROLE, Role.BOARD.name),
+        )
+    }
+
+    @Test
+    fun `emits one COMMITTEE fact per committee membership`() {
+        every { users.findById(1L) } returns userWith(
+            committeeMembers = setOf(
+                committeeMembership(committeeId = 7L),
+                committeeMembership(committeeId = 42L),
+            ),
+        )
+
+        val facts = collector.collect(1L)
+
+        assertThat(facts).contains(
+            UserFact(CohortFactKind.COMMITTEE, "7"),
+            UserFact(CohortFactKind.COMMITTEE, "42"),
+        )
+    }
+
+    @Test
+    fun `emits one CONTRIBUTION_PAID fact per contribution period`() {
+        every { users.findById(1L) } returns userWith(
+            contributions = setOf(
+                contribution(periodId = 100L),
+                contribution(periodId = 101L),
+            ),
+        )
+
+        val facts = collector.collect(1L)
+
+        assertThat(facts).contains(
+            UserFact(CohortFactKind.CONTRIBUTION_PAID, "100"),
+            UserFact(CohortFactKind.CONTRIBUTION_PAID, "101"),
+        )
+    }
+
+    @Test
+    fun `emits NEWSLETTER fact only when user has opted in`() {
+        every { users.findById(1L) } returns userWith(newsletter = true)
+        every { users.findById(2L) } returns userWith(newsletter = false)
+
+        assertThat(collector.collect(1L))
+            .contains(UserFact(CohortFactKind.NEWSLETTER, "true"))
+        assertThat(collector.collect(2L))
+            .noneMatch { it.kind == CohortFactKind.NEWSLETTER }
+    }
+
+    @Test
+    fun `committee membership with null committee id is silently skipped`() {
+        every { users.findById(1L) } returns userWith(
+            committeeMembers = setOf(committeeMembership(committeeId = null)),
+        )
+
+        assertThat(collector.collect(1L))
+            .noneMatch { it.kind == CohortFactKind.COMMITTEE }
+    }
+
+    private fun userWith(
+        roles: Set<Role> = emptySet(),
+        committeeMembers: Set<CommitteeMember> = emptySet(),
+        contributions: Set<Contribution> = emptySet(),
+        newsletter: Boolean = false,
+    ): User = mockk<User>().also {
+        every { it.roles } returns roles.toMutableSet()
+        every { it.committeeMembers } returns committeeMembers
+        every { it.contributions } returns contributions
+        every { it.newsletter } returns newsletter
+    }
+
+    private fun committeeMembership(committeeId: Long?): CommitteeMember {
+        val committee = mockk<Committee>()
+        every { committee.id } returns committeeId
+        val cm = mockk<CommitteeMember>()
+        every { cm.committee } returns committee
+        return cm
+    }
+
+    private fun contribution(periodId: Long): Contribution {
+        val c = mockk<Contribution>()
+        every { c.id } returns Contribution.Id(userId = 1L, contributionPeriodId = periodId)
+        return c
+    }
+}


### PR DESCRIPTION
## Why

The cohort tables that landed in the previous PR are infrastructure
only — nothing yet decides which users belong in which cohort. That
decision needs to flow from the user's facts (their roles, committee
memberships, contribution-period payments, newsletter opt-in) and
re-evaluate every time one of those facts changes. Building the
engine but leaving it in shadow mode for one PR keeps the cutover
risk low: this PR wires every event source and proves the diff
calculation is correct via logs; the follow-up PR flips the
"log it" tail into "persist it + fan it out to adapters" without
touching listener wiring or evaluator logic.

## What this achieves

- Every event in the codebase today that can change a user's facts
  (UserCreated/UserUpdated/UserDeleted, MembershipChanged,
  CommitteeMembershipChanged, ContributionChanged) now triggers a
  cohort re-evaluation.
- The evaluator emits a `[cohort-shadow]` log line on every call
  showing the user's facts, the desired cohort set, the current
  cohort set, and the toAdd / toRemove diff. Operators can verify
  the rule engine produces the right answers against real traffic
  before any side effects land.
- Adding a new fact kind in future is a single change: extend
  `CohortFactKind`, teach `UserFactCollector` how to derive it,
  and admin-editable rules pick it up automatically.

## How

`UserFact` is a `(kind, key)` value type. The interpretation of
`key` is per-kind and documented on `CohortFactKind`.

`UserFactCollector` reads the canonical sources off the User entity
graph inside one read-only transaction:
- `ROLE` from `User.roles`,
- `COMMITTEE` from `User.committeeMembers` (one fact per committee
  id),
- `CONTRIBUTION_PAID` from `User.contributions` (one fact per
  contribution-period id),
- `NEWSLETTER` from `User.newsletter` — only when opted in;
  opt-out is represented by the absence of a rule, not a `"false"`
  fact.

`CohortRuleEvaluator` collects the user's facts, fetches every
enabled `CohortRule` whose left-hand side matches a held fact,
builds the desired cohort set, diffs against the user's current
`CohortMember` rows, and returns a `CohortRuleEvaluation`
(`facts`, `desired`, `current`, `toAdd`, `toRemove`, `isNoOp`).
Each call emits a `[cohort-shadow]` log line. No-op evaluations
log at DEBUG to keep noise down; non-trivial diffs log at INFO.

`CohortRuleListener` subscribes to all six change events via
`@EventListener` + `@Transactional(REQUIRES_NEW)`, mirroring
`MembershipEventListener` and the other listeners in this codebase
(no Modulith `@ApplicationModuleListener`, no `@Async`). Each
handler calls `evaluator.evaluate(userId)`. After deletion the
fact collector returns the empty set, so the diff naturally
collapses to "remove from every cohort the user was in" — exactly
the semantics the cutover PR will need.

`CohortRuleEvaluatorTest` and `UserFactCollectorTest` are pure
unit tests using `mockk` (no Spring context). Coverage: every
fact kind, every diff path (toAdd-only, toRemove-only, no-op,
empty user). `mockk` is used over `mockito-kotlin` here because
`@Entity` property getters are not always open enough for
mockito's CGLIB proxy to intercept reliably; the codebase already
ships mockk for exactly these cases.

No production code paths consume the evaluator's results yet —
the shadow log is the only side effect.