### PR TITLE
ci: add 7-day Dependabot cooldown to slow supply-chain pull-in

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@
 #
 # Labels are left to Dependabot's defaults (`dependencies` plus the language
 # label), which already match the repo's existing dependency PRs.
+#
+# Each ecosystem also sets a 7-day `cooldown`: a freshly published release
+# is not proposed until it has been on the registry for a week. This blunts
+# supply-chain attacks that rely on a compromised version being pulled in
+# immediately, leaving time for a malicious release to be yanked or flagged
+# before it reaches a PR here.
 version: 2
 
 updates:
@@ -17,6 +23,8 @@ updates:
     directory: /services/frontend
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       frontend:
@@ -38,6 +46,8 @@ updates:
       - /services/system-tests
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       gradle:
@@ -54,6 +64,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       actions:
@@ -73,6 +85,8 @@ updates:
       - /infra/stalwart
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       docker:


### PR DESCRIPTION
## Why
Dependabot proposed a dependency update the moment a new version was
published to the registry. That immediacy is the window a supply-chain
attack relies on: a compromised release pulled in within minutes can
reach a PR — and a careless merge — before the ecosystem notices and
yanks it.

## What this achieves
A freshly published release is no longer proposed until it has been
public for a week. A malicious version published and later yanked within
that window never surfaces as a PR here, and genuine releases that turn
out to be broken have time to be flagged before adoption.

## How
- `.github/dependabot.yml`: each of the four ecosystems (npm, gradle,
  github-actions, docker) gains a `cooldown` block with `default-days: 7`.
- Grouping, schedule and open-PR limits are unchanged; the cooldown only
  delays when an individual version becomes eligible.