### PR TITLE
Valkey-backed sessions and user-lookup cache

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -24,9 +24,13 @@ services:
     depends_on: !override
       db:
         condition: service_healthy
+      valkey:
+        condition: service_healthy
     environment:
       - TZ=Europe/Amsterdam
       - SPRING_PROFILES_ACTIVE=test
+      - VALKEY_HOST=valkey
+      - VALKEY_PORT=6379
       - APP_URL=http://localhost:8080
       - FRONTEND_URL=http://localhost:3000
       - MYSQL_HOST=db

--- a/platform/cluster/flux/apps/data/kustomization.yaml
+++ b/platform/cluster/flux/apps/data/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - bitnami-oci-source.yaml
   - vault
   - mariadb
+  - valkey

--- a/platform/cluster/flux/apps/data/valkey/deployment.yaml
+++ b/platform/cluster/flux/apps/data/valkey/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: valkey-data
+  namespace: data-system
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: valkey
+  namespace: data-system
+spec:
+  replicas: 1
+  # Recreate, not RollingUpdate: the PVC is ReadWriteOnce so two pods can't
+  # mount it at once during a surge.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: valkey
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: valkey
+    spec:
+      containers:
+        - name: valkey
+          image: valkey/valkey:8-alpine
+          ports:
+            - name: valkey
+              containerPort: 6379
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          livenessProbe:
+            tcpSocket:
+              port: valkey
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            exec:
+              command: ["valkey-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: valkey-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: valkey
+  namespace: data-system
+spec:
+  selector:
+    app.kubernetes.io/name: valkey
+  ports:
+    - name: valkey
+      port: 6379
+      targetPort: valkey

--- a/platform/cluster/flux/apps/data/valkey/kustomization.yaml
+++ b/platform/cluster/flux/apps/data/valkey/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml

--- a/platform/cluster/flux/apps/stateless/api/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/api/deployment.yaml
@@ -140,6 +140,10 @@ spec:
               value: mariadb.data-system.svc.cluster.local
             - name: MYSQL_PORT
               value: '3306'
+            - name: VALKEY_HOST
+              value: valkey.data-system.svc.cluster.local
+            - name: VALKEY_PORT
+              value: '6379'
             - name: APP_URL
               value: https://esa-blueshell.nl/api
             - name: FRONTEND_URL

--- a/services/api/build.gradle.kts
+++ b/services/api/build.gradle.kts
@@ -63,6 +63,10 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-authorization-server")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    // Valkey-backed server-side HTTP sessions + a Valkey cache layer. Lettuce
+    // is the default client pulled in by spring-boot-starter-data-redis.
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation("org.springframework.session:spring-session-data-redis")
     implementation(platform("org.springframework.modulith:spring-modulith-bom:2.0.6"))
     implementation("org.springframework.modulith:spring-modulith-starter-jdbc")
     implementation("org.springframework.cloud:spring-cloud-starter-vault-config:5.0.1")
@@ -141,6 +145,10 @@ dependencies {
     testFixturesApi("org.springframework.boot:spring-boot-starter-flyway")
     testFixturesApi("org.flywaydb:flyway-mysql:12.0.2")
     testFixturesApi("com.github.javafaker:javafaker:1.0.2")
+    // Shared test base boots a throwaway Valkey via @ServiceConnection so the
+    // Redis-backed HTTP session path is exercised under the real prod config.
+    testFixturesApi("org.springframework.boot:spring-boot-testcontainers")
+    testFixturesApi("org.testcontainers:testcontainers:1.21.4")
     testFixturesCompileOnly("jakarta.servlet:jakarta.servlet-api:6.1.0")
 
     mockitoAgent("org.mockito:mockito-core:5.21.0")

--- a/services/api/docker-compose.yml
+++ b/services/api/docker-compose.yml
@@ -22,6 +22,22 @@ services:
       retries: 5
       start_period: 30s
 
+  valkey:
+    image: valkey/valkey:8-alpine
+    container_name: valkey
+    ports:
+      - "6379:6379"
+    volumes:
+      - valkey-data:/data
+    networks:
+      - global_network
+    restart: unless-stopped
+    healthcheck:
+      test: [ "CMD", "valkey-cli", "ping" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   api:
     image: api:dev
     pull_policy: never
@@ -50,8 +66,12 @@ services:
       - PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
       - EMAIL_FROM_ADDRESS=no-reply@localhost
       - EMAIL_REPLY_TO_ADDRESS=dev@localhost
+      - VALKEY_HOST=valkey
+      - VALKEY_PORT=6379
     depends_on:
       db:
+        condition: service_healthy
+      valkey:
         condition: service_healthy
     healthcheck:
       test: [ "CMD", "curl", "http://localhost:8080/health" ]
@@ -66,5 +86,6 @@ networks:
 
 volumes:
   data:
+  valkey-data:
   gradle-cache:
   playwright-browsers:

--- a/services/api/src/main/kotlin/net/blueshell/api/domain/auth/web/AuthenticationController.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/domain/auth/web/AuthenticationController.kt
@@ -47,6 +47,9 @@ class AuthenticationController(
             val validation = jwtTokenUtil.parseAndValidate(token)
             validation.jti?.let(jwtRevocationService::revoke)
         }
+        // Drop the server-side session from Valkey so the SESSION cookie can't
+        // outlive the logout (the JWT cookie alone expiring is not enough).
+        request.getSession(false)?.invalidate()
         authTokenCookieService.clearAuthCookie(response)
     }
 

--- a/services/api/src/main/kotlin/net/blueshell/api/domain/user/application/UserService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/domain/user/application/UserService.kt
@@ -15,6 +15,8 @@ import net.blueshell.api.shared.security.CurrentUserProvider
 import net.blueshell.api.shared.security.CurrentUser
 import net.blueshell.api.shared.service.BaseModelService
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.security.access.AccessDeniedException
@@ -40,6 +42,9 @@ class UserService @Autowired constructor(
         }
     }
 
+    // Hot path: JwtAuthFilter calls this on every authenticated request.
+    // Cached in Valkey (short TTL), evicted whenever the user is mutated.
+    @Cacheable("users.principalByUsername")
     fun loadUserPrincipalByUsername(username: String): UserPrincipal {
         return UserPrincipalMapper.fromUser(findByUsername(username))
     }
@@ -58,6 +63,7 @@ class UserService @Autowired constructor(
     }
 
     @Transactional
+    @CacheEvict("users.principalByUsername", key = "#entity.username")
     override fun update(entity: User): User {
         val saved = super.update(entity)
         trackedEvents.publish { actor ->

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/config/CacheConfig.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/config/CacheConfig.kt
@@ -1,0 +1,35 @@
+package net.blueshell.api.platform.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import java.time.Duration
+
+/**
+ * Valkey-backed cache. Caches the per-request user-principal lookup that
+ * JwtAuthFilter runs on every authenticated request. Short TTL bounds
+ * staleness on role/enabled changes. Disabled under the `test` profile
+ * (`spring.cache.type=none`) so DB resets between tests are never masked.
+ */
+@Configuration
+@EnableCaching
+@Profile("!test")
+class CacheConfig(
+    @param:Value($$"${cache.ttl:5m}")
+    private val ttl: Duration,
+) {
+    @Bean
+    fun cacheManager(connectionFactory: RedisConnectionFactory): RedisCacheManager =
+        RedisCacheManager.builder(connectionFactory)
+            .cacheDefaults(
+                RedisCacheConfiguration.defaultCacheConfig()
+                    .entryTtl(ttl)
+                    .disableCachingNullValues(),
+            )
+            .build()
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/config/SecurityConfig.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/config/SecurityConfig.kt
@@ -122,7 +122,10 @@ class SecurityConfig(
 
         http.securityMatcher("/**")
             .csrf { it.csrfTokenRepository(csrfTokenRepository).ignoringRequestMatchers("/auth/logout") }
-            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            // IF_REQUIRED (not STATELESS) so the SecurityContext JwtAuthFilter
+            // saves is persisted to the Valkey-backed session, keeping the user
+            // signed in after the JWT expires.
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED) }
         http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter::class.java)
         publicAuthRateLimitFilterProvider.ifAvailable { rateLimitFilter ->
             http.addFilterBefore(rateLimitFilter, JwtAuthFilter::class.java)

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/config/SessionConfig.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/config/SessionConfig.kt
@@ -1,0 +1,51 @@
+package net.blueshell.api.platform.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.session.config.SessionRepositoryCustomizer
+import org.springframework.session.data.redis.RedisSessionRepository
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession
+import org.springframework.session.web.http.CookieSerializer
+import org.springframework.session.web.http.DefaultCookieSerializer
+import java.time.Duration
+
+/**
+ * Server-side HTTP sessions stored in Valkey. The SESSION cookie outlives the
+ * 24h JWT, so once authenticated the browser stays signed in for the session
+ * timeout (default 30d) without re-login. Cookie domain mirrors the auth
+ * cookie so the session travels to every subdomain behind Traefik forwardAuth.
+ */
+@Configuration
+@EnableRedisHttpSession(redisNamespace = "blueshell-api")
+class SessionConfig(
+    @param:Value($$"${session.cookie.name:SESSION}")
+    private val cookieName: String,
+    @param:Value($$"${session.cookie.domain:}")
+    private val cookieDomain: String,
+    @param:Value($$"${session.cookie.same-site:None}")
+    private val sameSite: String,
+    @param:Value($$"${app.security.require-https:true}")
+    private val requireHttps: Boolean,
+    @param:Value($$"${session.timeout:30d}")
+    private val sessionTimeout: Duration,
+) {
+    @Bean
+    fun cookieSerializer(): CookieSerializer =
+        DefaultCookieSerializer().apply {
+            setCookieName(cookieName)
+            setCookiePath("/")
+            setSameSite(sameSite)
+            setUseHttpOnlyCookie(true)
+            setCookieMaxAge(sessionTimeout.seconds.toInt())
+            // SameSite=None requires Secure; localhost is a secure context in dev.
+            setUseSecureCookie(requireHttps || sameSite.equals("None", ignoreCase = true))
+            if (cookieDomain.isNotBlank()) {
+                setDomainName(cookieDomain)
+            }
+        }
+
+    @Bean
+    fun redisSessionRepositoryCustomizer(): SessionRepositoryCustomizer<RedisSessionRepository> =
+        SessionRepositoryCustomizer { it.setDefaultMaxInactiveInterval(sessionTimeout) }
+}

--- a/services/api/src/main/resources/application-test.yml
+++ b/services/api/src/main/resources/application-test.yml
@@ -2,6 +2,11 @@ spring:
   application:
     db: blueshell-test
 
+  # Caching off in tests so DB resets between cases are never masked by a
+  # stale Valkey entry. Sessions still use the throwaway Valkey container.
+  cache:
+    type: none
+
   flyway:
     clean-on-validation-error: true
     clean-disabled: false

--- a/services/api/src/main/resources/application.yaml
+++ b/services/api/src/main/resources/application.yaml
@@ -40,6 +40,12 @@ spring:
       connection-test-query: "SELECT 1"
       keepalive-time: 30000
 
+  data:
+    redis:
+      host: ${VALKEY_HOST:localhost}
+      port: ${VALKEY_PORT:6379}
+      timeout: 500ms
+
   jpa:
     hibernate:
       ddl-auto: none
@@ -114,6 +120,18 @@ app:
 
 frontend:
   url: ${FRONTEND_URL:http://localhost:3000}
+
+# Valkey-backed HTTP sessions. The SESSION cookie domain defaults to the same
+# value as the auth cookie so the session travels to every subdomain in prod.
+session:
+  timeout: ${SESSION_TIMEOUT:30d}
+  cookie:
+    name: ${SESSION_COOKIE_NAME:SESSION}
+    same-site: ${SESSION_COOKIE_SAME_SITE:None}
+    domain: ${SESSION_COOKIE_DOMAIN:${AUTH_COOKIE_DOMAIN:}}
+
+cache:
+  ttl: ${CACHE_TTL:5m}
 
 storage:
   location: ${STORAGE_LOCATION:./storage}

--- a/services/api/src/testFixtures/kotlin/net/blueshell/api/testsupport/ServiceTestSupport.kt
+++ b/services/api/src/testFixtures/kotlin/net/blueshell/api/testsupport/ServiceTestSupport.kt
@@ -5,6 +5,7 @@ import net.blueshell.api.config.TestCleanUpListener
 import net.blueshell.api.platform.integration.job.persistence.repository.JobExecutionRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestExecutionListeners
 import org.springframework.test.context.event.ApplicationEvents
@@ -24,6 +25,7 @@ import org.springframework.transaction.support.TransactionTemplate
  */
 @SpringBootTest
 @ActiveProfiles("test")
+@Import(ValkeyTestContainerConfig::class)
 @RecordApplicationEvents
 @TestExecutionListeners(
     listeners = [TestCleanUpListener::class],

--- a/services/api/src/testFixtures/kotlin/net/blueshell/api/testsupport/ValkeyTestContainerConfig.kt
+++ b/services/api/src/testFixtures/kotlin/net/blueshell/api/testsupport/ValkeyTestContainerConfig.kt
@@ -1,0 +1,23 @@
+package net.blueshell.api.testsupport
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.springframework.context.annotation.Bean
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * Throwaway Valkey for the @SpringBootTest context so the Redis-backed HTTP
+ * session path runs under the real prod config. @ServiceConnection wires
+ * spring.data.redis.host/port; `name = "redis"` makes Boot pick the Redis
+ * connection-details factory for the non-`redis` image name.
+ */
+@TestConfiguration(proxyBeanMethods = false)
+class ValkeyTestContainerConfig {
+
+    @Bean
+    @ServiceConnection(name = "redis")
+    fun valkeyContainer(): GenericContainer<*> =
+        GenericContainer(DockerImageName.parse("valkey/valkey:8-alpine").asCompatibleSubstituteFor("redis"))
+            .withExposedPorts(6379)
+}


### PR DESCRIPTION
## Why
Authentication relied solely on a stateless 24h JWT, so the browser was signed out a day after login. A server-side session store keeps users signed in for weeks instead of a day, and gives the per-request user lookup a cache.

## What this achieves
- The browser stays signed in for 30 days: once a request authenticates, the `SecurityContext` is persisted to a Valkey-backed HTTP session, so login survives JWT expiry and api restarts.
- The `SESSION` cookie spans every subdomain in production (domain defaults to the auth cookie's), so Traefik forwardAuth on vault/headlamp/stalwart resolves the principal from the session too — not just the 24h JWT cookie.
- The per-request `loadUserPrincipalByUsername` lookup that `JwtAuthFilter` runs on every authenticated call is now served from Valkey.

## How
- Added `spring-session-data-redis` + `spring-boot-starter-data-redis` to `services/api/build.gradle.kts`; `gradle.lockfile` regenerated.
- `services/api/.../platform/config/SessionConfig.kt` — `@EnableRedisHttpSession`, `SESSION` cookie, 30d timeout, domain defaulting to `${AUTH_COOKIE_DOMAIN}`.
- `SecurityConfig.kt` — session policy `STATELESS` → `IF_REQUIRED` so the context reaches the session. `AuthenticationController.logout` invalidates the server-side session in addition to clearing the JWT cookie and revoking the jti.
- `services/api/.../platform/config/CacheConfig.kt` — `@EnableCaching` + Valkey `RedisCacheManager`; `UserService.loadUserPrincipalByUsername` is `@Cacheable`, evicted on user update. Disabled under the `test` profile (`spring.cache.type=none`) so DB resets between tests are never masked.
- Local config in `application.yaml`: `spring.data.redis.*`, `session.*`, `cache.ttl`.
- Valkey added to `services/api/docker-compose.yml` and `docker-compose.ci.yml`; a `Deployment`/`Service`/`PersistentVolumeClaim` under `platform/cluster/flux/apps/data/valkey`, registered in the data kustomization. `VALKEY_HOST`/`VALKEY_PORT` wired into `apps/stateless/api/deployment.yaml`.
- `ServiceTestSupport` boots a throwaway Valkey via `@ServiceConnection` (`ValkeyTestContainerConfig`) so the Redis-backed session path runs under the real config in tests.

OIDC token issuance still uses the JWT path and is unchanged.