### PR TITLE
Stabilise committee select in the event-form system tests

### DIFF
--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/helper/EventFormHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/helper/EventFormHelper.kt
@@ -49,7 +49,15 @@ object EventFormHelper {
     fun openCommitteeSelect(page: Page) {
         val committeeField = TestIdLocatorHelper.byTestId(page, COMMITTEE_FIELD_TEST_ID)
         val combo = committeeField.getByRole(AriaRole.COMBOBOX).first()
+        combo.waitFor()
+        // The select stays disabled until the committee list finishes loading;
+        // opening it before then is a no-op and the option lookup later times
+        // out. Wait for it to become enabled, then confirm the menu opened.
+        page.waitForCondition {
+            combo.getAttribute("disabled") == null && combo.getAttribute("aria-disabled") != "true"
+        }
         combo.click(Locator.ClickOptions().setForce(true))
+        page.getByRole(AriaRole.LISTBOX).first().waitFor()
     }
 
     fun selectCommittee(page: Page, committeeName: String) {


### PR DESCRIPTION
## Why
`EventCreatePageSystemTest` and `EventEditPageSystemTest` flake: a run intermittently fails with a 30s Playwright timeout in `EventFormHelper.selectCommittee`, waiting for a committee option that never appears.

## What this achieves
The committee selection in the event-form system tests no longer races the committee list load, removing a source of intermittent CI failures across the system-test shards.

## How
The committee `VSelect` is disabled until its list finishes loading (`disabled: !committees.length` in `EventForm.vue`). `openCommitteeSelect` force-clicked the combobox, and a force click skips Playwright's actionability/enabled check — so when the list had not loaded yet the click was a no-op, the menu never opened, and the subsequent `getByText(...)` option lookup ran out its full 30s timeout.

`EventFormHelper.openCommitteeSelect` now waits for the combobox to become enabled (list loaded), then opens it and waits for the options `listbox` to appear before the caller selects an option. No timeout value was changed.