### PR TITLE
ci: keep major updates out of grouped Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,13 @@
 # supply-chain attacks that rely on a compromised version being pulled in
 # immediately, leaving time for a malicious release to be yanked or flagged
 # before it reaches a PR here.
+#
+# The version-update groups carry only `minor` and `patch` updates. Major
+# bumps are excluded from the groups so Dependabot raises one PR per major
+# instead — a single grouped PR mixing a breaking major (a framework or
+# toolchain jump that needs code changes) with routine updates can never go
+# green and blocks the safe updates behind it. Security-update groups are
+# left unfiltered: a fix matters regardless of how the version moves.
 version: 2
 
 updates:
@@ -29,6 +36,9 @@ updates:
     groups:
       frontend:
         applies-to: version-updates
+        update-types:
+          - minor
+          - patch
         patterns:
           - "*"
       frontend-security:
@@ -52,6 +62,9 @@ updates:
     groups:
       gradle:
         applies-to: version-updates
+        update-types:
+          - minor
+          - patch
         patterns:
           - "*"
       gradle-security:
@@ -70,6 +83,9 @@ updates:
     groups:
       actions:
         applies-to: version-updates
+        update-types:
+          - minor
+          - patch
         patterns:
           - "*"
       actions-security:
@@ -91,6 +107,9 @@ updates:
     groups:
       docker:
         applies-to: version-updates
+        update-types:
+          - minor
+          - patch
         patterns:
           - "*"
       docker-security:


### PR DESCRIPTION
## Why
A grouped version-update PR bundles every pending bump for an ecosystem
into one branch. When that branch picks up a breaking major — a
framework or toolchain jump that needs source changes to compile — the
whole PR fails CI, and the routine minor/patch updates riding alongside
it are stuck until someone resolves the major. The frontend group did
exactly this: one PR carried Vuetify 4, TypeScript 6 and Vite 8 next to
three dozen harmless bumps, so none of them could merge.

## What this achieves
Grouped PRs stay green and mergeable. A breaking major arrives on its
own branch and can be taken as a deliberate, reviewable upgrade rather
than holding the safe updates hostage.

## How
- Each version-update group (`npm`, `gradle`, `github-actions`,
  `docker`) gains `update-types: [minor, patch]`. Majors no longer match
  the group, so Dependabot opens one PR per major instead.
- Security-update groups are deliberately left unfiltered: a security
  fix is worth taking whichever way the version number moves.