### PR TITLE
Stabilise flaky job-executor and event-form committee tests

### DIFF
--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/queue/JobExecutorIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/queue/JobExecutorIT.kt
@@ -10,9 +10,14 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
+import org.springframework.test.context.TestPropertySource
 import java.util.concurrent.atomic.AtomicInteger
 
+// These tests drive the executor by hand; disable the background recovery
+// scheduler so it cannot dispatch the same job concurrently and trip an
+// optimistic-lock failure.
 @Import(JobExecutorITConfig::class)
+@TestPropertySource(properties = ["app.jobs.recovery.enabled=false"])
 class JobExecutorIT : ServiceTestSupport() {
 
     @Autowired

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/queue/StaleJobRecovery.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/queue/StaleJobRecovery.kt
@@ -4,6 +4,7 @@ import io.micrometer.core.instrument.MeterRegistry
 import net.blueshell.api.platform.config.JobQueueProperties
 import net.blueshell.api.platform.integration.job.application.service.JobExecutionService
 import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.data.domain.PageRequest
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
@@ -24,7 +25,10 @@ import java.time.temporal.ChronoUnit
  * have it set, so the two queries are disjoint and the same row is never
  * fired twice in the same tick.
  */
+// Default on. Tests that drive the executor manually disable it
+// (app.jobs.recovery.enabled=false) so the scheduler does not race them.
 @Component
+@ConditionalOnProperty(name = ["app.jobs.recovery.enabled"], havingValue = "true", matchIfMissing = true)
 class StaleJobRecovery(
     private val jobExecutionService: JobExecutionService,
     private val jobExecutor: JobExecutor,

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/helper/EventFormHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/helper/EventFormHelper.kt
@@ -18,13 +18,19 @@ object EventFormHelper {
     private const val SUBMIT_BUTTON_TEST_ID = "event-form-submit-btn"
 
     fun openCreatePage(page: Page, frontendUrl: String) {
-        page.navigate("$frontendUrl/events/create")
+        // Wait for the committee list the form loads on mount, so the committee
+        // select is populated (and enabled) before any interaction.
+        page.waitForResponse("**/committees") {
+            page.navigate("$frontendUrl/events/create")
+        }
         page.waitForURL("**/events/create**")
         TestIdLocatorHelper.textInput(page, TITLE_FIELD_TEST_ID).waitFor()
     }
 
     fun openEditPage(page: Page, frontendUrl: String, eventId: Long) {
-        page.navigate("$frontendUrl/events/edit/$eventId")
+        page.waitForResponse("**/committees") {
+            page.navigate("$frontendUrl/events/edit/$eventId")
+        }
         page.waitForURL("**/events/edit/$eventId**")
         TestIdLocatorHelper.textInput(page, TITLE_FIELD_TEST_ID).waitFor()
     }
@@ -49,15 +55,16 @@ object EventFormHelper {
     fun openCommitteeSelect(page: Page) {
         val committeeField = TestIdLocatorHelper.byTestId(page, COMMITTEE_FIELD_TEST_ID)
         val combo = committeeField.getByRole(AriaRole.COMBOBOX).first()
+        val listbox = page.getByRole(AriaRole.LISTBOX).first()
         combo.waitFor()
-        // The select stays disabled until the committee list finishes loading;
-        // opening it before then is a no-op and the option lookup later times
-        // out. Wait for it to become enabled, then confirm the menu opened.
+        // Clicking the select before its list has loaded is a no-op, so retry
+        // opening until the options menu actually appears.
         page.waitForCondition {
-            combo.getAttribute("disabled") == null && combo.getAttribute("aria-disabled") != "true"
+            if (!listbox.isVisible()) {
+                combo.click(Locator.ClickOptions().setForce(true))
+            }
+            listbox.isVisible()
         }
-        combo.click(Locator.ClickOptions().setForce(true))
-        page.getByRole(AriaRole.LISTBOX).first().waitFor()
     }
 
     fun selectCommittee(page: Page, committeeName: String) {


### PR DESCRIPTION
## Why
Two intermittent CI failures, both timing races that surface under load (and more often on the Java 25 toolchain):

- `JobExecutorIT > exhausting maxRetries marks the job as FAILED` fails with `ObjectOptimisticLockingFailureException` on `job_executions`.
- `EventCreatePageSystemTest > events page fetches banner for newly created event` times out after 30s waiting for the committee options menu.

## What this achieves
Both tests become deterministic, unblocking the system-test and api-integration CI jobs.

## How
- `JobExecutorIT` drives the executor by hand, but `StaleJobRecovery`'s `@Scheduled` retry-check (every 100ms under the test profile) dispatched the same job concurrently — two writers, one optimistic-lock loser. `StaleJobRecovery` is now gated behind `app.jobs.recovery.enabled` (default `true`, so production and `StaleJobRecoveryIT` are unchanged), and the manual-execution test sets it `false`.
- The committee `VSelect` in `EventForm.vue` is disabled until its list loads. `EventFormHelper.openCreatePage`/`openEditPage` now wait for the committee fetch (`**/committees`) before interacting, and `openCommitteeSelect` retries the open until the options `listbox` is visible.

No timeout or interval value was changed.
