### PR TITLE
test(jobs): stop scheduler racing JobExecutorIT manual execution

### DIFF
--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/queue/JobExecutorIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/queue/JobExecutorIT.kt
@@ -10,9 +10,21 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
+import org.springframework.test.context.TestPropertySource
 import java.util.concurrent.atomic.AtomicInteger
 
 @Import(JobExecutorITConfig::class)
+// These tests drive the executor manually. The test profile runs
+// StaleJobRecovery's retry/stale schedulers every 100ms, which would pick up
+// the same QUEUED job and call markRetryScheduled concurrently with the manual
+// execute() loop — an optimistic-lock race ("expected row count 1 but was 0").
+// Park both schedulers so manual execution is the only writer.
+@TestPropertySource(
+    properties = [
+        "app.jobs.retry-check-interval-ms=3600000",
+        "app.jobs.stale-check-interval-ms=3600000",
+    ],
+)
 class JobExecutorIT : ServiceTestSupport() {
 
     @Autowired


### PR DESCRIPTION
## Why
`JobExecutorIT` drives the executor synchronously — it enqueues a job and
calls `executor.execute()` in a loop, then asserts on the resulting state.
The test profile runs `StaleJobRecovery`'s retry and stale schedulers
every 100ms (`app.jobs.retry-check-interval-ms: 100`). Those schedulers
pick up the same QUEUED job and call `markRetryScheduled` at the same time
as the manual loop. When the timings overlap, both paths update the same
`job_executions` row and the optimistic-lock version check loses:
`ObjectOptimisticLockingFailureException: expected row count 1 but was 0`.
That intermittently fails `exhausting maxRetries marks the job as FAILED`
and blocks otherwise-green PRs (seen on the Valkey branch).

## What this achieves
The manual-execution job tests are the only writer to their rows again, so
the optimistic-lock flake no longer fires. The fix is test-only.

## How
- `JobExecutorIT` gains a class-level `@TestPropertySource` setting
  `app.jobs.retry-check-interval-ms` and `app.jobs.stale-check-interval-ms`
  to an hour, parking both background schedulers for this context. The
  schedulers keep their own coverage elsewhere; no production code changes.