### PR TITLE
style(frontend): finish Vuetify 4 styling — form spacing + events calendar today marker

### DIFF
--- a/services/frontend/src/components/base/EventCalendar.vue
+++ b/services/frontend/src/components/base/EventCalendar.vue
@@ -212,10 +212,18 @@ defineExpose({
   border-bottom: 0.5px solid #e0e0e0;
 }
 
-.v-icon-btn {
-  height: 20px;
-  margin-top: 5px;
-  margin-bottom: 5px;
+// Vuetify 4 renders the day number as a circular icon button. The old
+// `height: 20px` rule squashed it into a lop-sided oval (40×20 with a 50%
+// radius). Mark today's date with a clean filled primary circle instead.
+.v-calendar-weekly__day.v-present .v-icon-btn {
+  width: 28px !important;
+  height: 28px !important;
+  min-width: 28px !important;
+  margin: 4px 0;
+  border: none !important;
+  border-radius: 50% !important;
+  background-color: rgb(var(--v-theme-primary)) !important;
+  color: #fff !important;
 }
 
 .v-calendar-weekly__day-label {

--- a/services/frontend/src/styles/forms.scss
+++ b/services/frontend/src/styles/forms.scss
@@ -1,12 +1,13 @@
+// Vuetify 4's grid switched from negative-margin gutters (which the old
+// col-padding resets here cancelled) to a flexbox `gap` that defaults to 24px.
+// That blew out the spacing between stacked form fields. Restore a tight,
+// form-appropriate gutter globally — the app's rows were always compact.
+.v-row {
+  row-gap: 8px;
+  column-gap: 16px;
+}
+
 .v-row > .v-col {
   padding-top: 0;
   padding-bottom: 0;
-}
-
-.v-row > .v-col:first-child {
-  padding-left: 0;
-}
-
-.v-row > .v-col:last-child {
-  padding-right: 0;
 }


### PR DESCRIPTION
## Why
Follow-up to the main Vuetify 4 styling repair (stacked on that branch),
fixing two remaining v4 regressions.

## What this achieves
- Form fields are spaced normally again instead of with the huge gap v4's
  grid introduced.
- The events calendar marks today with a clean filled circle instead of a
  squashed oval.

## How
- `forms.scss`: Vuetify 4's grid replaced negative-margin gutters with a
  flexbox `gap` defaulting to 24px, which blew out the spacing between
  stacked form inputs. Set a compact `row-gap: 8px` / `column-gap: 16px`
  on `.v-row`.
- `EventCalendar.vue`: v4 renders the day number as a circular icon
  button; the old `.v-icon-btn { height: 20px }` squashed today's marker
  into a 40×20 oval. Today (`.v-present`) now gets a clean 28×28 filled
  primary circle with white text.

Verified on the running app (headless Chromium): form spacing is tight,
the calendar's current-day marker is a clean circle. typecheck + lint pass.

Stacked on the Vuetify 4 styling-repair branch; retarget to `main` once
that merges.