### PR TITLE
platform(gatus): add Valkey status monitor

### DIFF
--- a/platform/cluster/flux/apps/utility-system/gatus/gatus-endpoints-configmap.yaml
+++ b/platform/cluster/flux/apps/utility-system/gatus/gatus-endpoints-configmap.yaml
@@ -110,6 +110,16 @@ data:
       interval: "60s"
       conditions:
       - "[CONNECTED] == true"
+    - name: "Valkey"
+      group: "data"
+      # Backs HTTP sessions + the api's user-lookup cache. A TCP connect
+      # from inside the cluster proves valkey is listening; if this goes
+      # red, authenticated api requests degrade (cache falls back to the
+      # DB) and new sessions can't be persisted.
+      url: "tcp://valkey.data-system.svc.cluster.local:6379"
+      interval: "60s"
+      conditions:
+      - "[CONNECTED] == true"
     # ---------- Mail ports ----------
     # TCP connect from inside the cluster proves stalwart is listening
     # on each port; a real end-to-end SMTP/IMAP handshake from outside


### PR DESCRIPTION
## Why
Valkey backs the api's HTTP sessions and the user-lookup cache, but the
status page had no visibility into it — when Valkey is unreachable,
authenticated requests degrade and sessions can't persist, and there was
no signal for that on status.esa-blueshell.nl.

## What this achieves
A "Valkey" entry in the status page's data group, polling Valkey every
60s, mirroring the existing MariaDB check.

## How
- `gatus-endpoints-configmap.yaml`: adds a `data`-group endpoint that
  TCP-probes `valkey.data-system.svc.cluster.local:6379` with
  `[CONNECTED] == true`.

Gatus reads its config at startup, so this applies on the next gatus pod
restart (Flux apply, or `kubectl rollout restart deployment/gatus -n utility-system`).

## Notes
- **Replicas:** audited the cluster manifests — api, frontend, valkey,
  stalwart, gatus, vault and the flux components are all already
  `replicas: 1`, and MariaDB runs `replicaCount: 0` (no secondaries). The
  multi-replica pods you saw were on the personal-stack cluster, not this
  one; nothing to reduce here.
- **Valkey health:** the deployment manifest, image and Service DNS are
  correct, and `SessionConfig`/`CacheConfig` are sound (the cache also now
  degrades gracefully — see #308). Confirm the live pod against the
  `blueshell` kubecontext (the earlier check was run against `personal`).