### PR TITLE
fix(api): production 500s — invalid leading-dot SESSION cookie domain

### DIFF
--- a/platform/cluster/flux/apps/stateless/api/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/api/deployment.yaml
@@ -148,13 +148,14 @@ spec:
               value: https://esa-blueshell.nl/api
             - name: FRONTEND_URL
               value: https://esa-blueshell.nl
-            # Leading dot scopes BSH_AUTH (and the future logout cookie)
-            # to every subdomain of esa-blueshell.nl. Traefik forwardAuth
-            # on vault/headlamp/stalwart/traefik subdomains can't
-            # authenticate the user without it (host-only cookie set on
-            # esa-blueshell.nl wouldn't be sent to the others).
+            # Scopes BSH_AUTH (and the SESSION cookie) to every subdomain of
+            # esa-blueshell.nl so Traefik forwardAuth on
+            # vault/headlamp/stalwart/traefik can authenticate the user.
+            # No leading dot: per RFC 6265 `Domain=esa-blueshell.nl` already
+            # covers all subdomains, and a leading dot makes Spring Session's
+            # cookie serializer throw (Invalid cookie domain) on every request.
             - name: AUTH_COOKIE_DOMAIN
-              value: .esa-blueshell.nl
+              value: esa-blueshell.nl
             - name: STORAGE_LOCATION
               value: /srv/storage
             # SMTP transport — relay through Stalwart via its public

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/config/SessionConfig.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/config/SessionConfig.kt
@@ -41,7 +41,12 @@ class SessionConfig(
             // SameSite=None requires Secure; localhost is a secure context in dev.
             setUseSecureCookie(requireHttps || sameSite.equals("None", ignoreCase = true))
             if (cookieDomain.isNotBlank()) {
-                setDomainName(cookieDomain)
+                // Spring Session's DefaultCookieSerializer rejects a leading-dot
+                // domain (legacy RFC 2109) and throws on every session commit,
+                // 500-ing the whole API. The auth cookie keeps its dotted value;
+                // strip the dot here — RFC 6265 `Domain=esa-blueshell.nl` already
+                // scopes the cookie to every subdomain.
+                setDomainName(cookieDomain.removePrefix("."))
             }
         }
 

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/config/SessionConfigTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/config/SessionConfigTest.kt
@@ -1,0 +1,44 @@
+package net.blueshell.api.platform.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.session.web.http.CookieSerializer.CookieValue
+import java.time.Duration
+
+class SessionConfigTest {
+
+    private fun serializerFor(domain: String) =
+        SessionConfig(
+            cookieName = "SESSION",
+            cookieDomain = domain,
+            sameSite = "None",
+            requireHttps = true,
+            sessionTimeout = Duration.ofDays(30),
+        ).cookieSerializer()
+
+    @Test
+    fun `strips a leading dot from the cookie domain so Spring Session accepts it`() {
+        val request = MockHttpServletRequest().apply { isSecure = true }
+        val response = MockHttpServletResponse()
+
+        // `.esa-blueshell.nl` made DefaultCookieSerializer throw on every
+        // session commit (Invalid cookie domain), 500-ing the whole API.
+        serializerFor(".esa-blueshell.nl").writeCookieValue(CookieValue(request, response, "abc123"))
+
+        val setCookie = response.getHeader("Set-Cookie")
+        assertThat(setCookie).contains("Domain=esa-blueshell.nl")
+        assertThat(setCookie).doesNotContain("Domain=.esa-blueshell.nl")
+    }
+
+    @Test
+    fun `leaves an already-dotless domain unchanged`() {
+        val request = MockHttpServletRequest().apply { isSecure = true }
+        val response = MockHttpServletResponse()
+
+        serializerFor("esa-blueshell.nl").writeCookieValue(CookieValue(request, response, "abc123"))
+
+        assertThat(response.getHeader("Set-Cookie")).contains("Domain=esa-blueshell.nl")
+    }
+}


### PR DESCRIPTION
## Why
Every `/api/*` call returns 500 in production. The api logs pin it down —
it is **not** Valkey (Valkey is healthy):

```
java.lang.IllegalArgumentException: Invalid cookie domain: .esa-blueshell.nl
  at org.springframework.session.web.http.DefaultCookieSerializer.validateDomain
  at SessionRepositoryFilter ... commitSession
```

`AUTH_COOKIE_DOMAIN` is `.esa-blueshell.nl` (leading dot — deliberate so the
`BSH_AUTH` auth cookie reaches subdomains). The Valkey-backed SESSION cookie
added in #288 inherits that value, but Spring Session 4's
`DefaultCookieSerializer` rejects a leading-dot domain and throws while
committing the session — which happens on every request.

## What this achieves
The API serves again, and the cascading frontend failures stop. Cross-
subdomain auth/sessions still work (RFC 6265 scopes a dotless domain to all
subdomains).

## How
- **`deployment.yaml`**: `AUTH_COOKIE_DOMAIN` → `esa-blueshell.nl` (no dot).
  Flux rolls the **current** image with the corrected env — no image rebuild
  needed, so this deploys fast on merge.
- **`SessionConfig`**: strips a leading dot defensively before setting the
  session cookie domain, so a dotted value can never 500 the API again.
- **`SessionConfigTest`**: regression test for dotted + dotless inputs.

Verified: `:services:api:test` (the new test) passes and the stateless
kustomize overlay builds.