### PR TITLE
style+platform: pill, clickable cards, tighter forms, approved marker, calendar today, 0-downtime frontend

### DIFF
--- a/platform/cluster/flux/apps/stateless/frontend/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/frontend/deployment.yaml
@@ -10,6 +10,13 @@ metadata:
     keel.sh/pollSchedule: '@every 2m'
 spec:
   replicas: 1
+  # Single replica, but replaced with zero downtime: surge a second pod and
+  # only retire the old one once the new pod is Ready (maxUnavailable=0).
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: frontend

--- a/services/frontend/src/components/base/EventCalendar.vue
+++ b/services/frontend/src/components/base/EventCalendar.vue
@@ -212,10 +212,18 @@ defineExpose({
   border-bottom: 0.5px solid #e0e0e0;
 }
 
-.v-icon-btn {
-  height: 20px;
-  margin-top: 5px;
-  margin-bottom: 5px;
+// Vuetify 4 renders the day number as a circular icon button; the old
+// `height: 20px` rule squashed today's marker into a lop-sided 40x20 oval.
+// Mark today with a clean filled primary circle instead.
+.v-calendar-weekly__day.v-present .v-icon-btn {
+  width: 28px !important;
+  height: 28px !important;
+  min-width: 28px !important;
+  margin: 4px 0;
+  border: none !important;
+  border-radius: 50% !important;
+  background-color: rgb(var(--v-theme-primary)) !important;
+  color: #fff !important;
 }
 
 .v-calendar-weekly__day-label {

--- a/services/frontend/src/components/common/cards/EventCard.vue
+++ b/services/frontend/src/components/common/cards/EventCard.vue
@@ -616,6 +616,9 @@ function handleSignUpClick() {
 .approve-btn {
   flex: 0 0 auto;
   white-space: nowrap;
+  // The card title is text-h4; without an explicit size the marker inherits
+  // that large font under Vuetify 4. Keep it a small badge.
+  font-size: 0.7rem !important;
 }
 
 .sign-up-form {

--- a/services/frontend/src/pages/Home.vue
+++ b/services/frontend/src/pages/Home.vue
@@ -35,7 +35,8 @@
           style="max-width:450px;min-height: 250px"
         >
           <a
-            style="width: 100%"
+            class="d-block"
+            style="width: 100%; color: inherit; text-decoration: none;"
             @click="$goto(col.url)"
           >
             <v-icon
@@ -47,13 +48,13 @@
             <p class="text-h3 ma-3 font-weight-thin">
               {{ col.title }}
             </p>
+            <p
+              class="text-body-1 font-weight-light mx-auto"
+              style="max-width: 400px"
+            >
+              {{ col.text }}
+            </p>
           </a>
-          <p
-            class="text-body-1 font-weight-light mx-auto"
-            style="max-width: 400px"
-          >
-            {{ col.text }}
-          </p>
         </v-col>
       </v-row>
     </v-container>

--- a/services/frontend/src/styles/forms.scss
+++ b/services/frontend/src/styles/forms.scss
@@ -1,12 +1,12 @@
+// Vuetify 4's grid replaced negative-margin gutters with a flexbox `gap`
+// defaulting to 24px, which blew out the spacing between stacked form fields.
+// Pull the gutters back tight — the app's rows were always compact.
+.v-row {
+  row-gap: 2px;
+  column-gap: 16px;
+}
+
 .v-row > .v-col {
   padding-top: 0;
   padding-bottom: 0;
-}
-
-.v-row > .v-col:first-child {
-  padding-left: 0;
-}
-
-.v-row > .v-col:last-child {
-  padding-right: 0;
 }

--- a/services/frontend/src/styles/housestyle.scss
+++ b/services/frontend/src/styles/housestyle.scss
@@ -4,10 +4,11 @@
 
 $accent: rgb(var(--v-theme-accent));
 
-// Don't force the house border-radius onto the pill (`rounded`) or icon
-// buttons — Vuetify 4 keeps their radius in a layer, and an unlayered rule
-// here would otherwise flatten them (e.g. the "Join now" pill).
-.v-btn:not(.v-btn--rounded):not(.v-btn--icon) {
+// Don't force the house border-radius onto rounded/pill/icon buttons —
+// Vuetify 4 applies `rounded="pill"` as the `.rounded-pill` utility (not
+// `.v-btn--rounded`), and an unlayered rule here would otherwise flatten it
+// back to 10px (e.g. the home "Join now" pill).
+.v-btn:not(.v-btn--rounded):not(.v-btn--icon):not(.rounded-pill):not(.rounded-circle):not(.rounded-0) {
   border-radius: settings.$border-radius-root;
 }
 


### PR DESCRIPTION
## Why
A batch of Vuetify 4 styling regressions/polish plus a deployment-strategy
request.

## What this achieves
- The home "Join now" button is a full pill again.
- The About/Esports/Events cards are clickable across the whole block, not
  just the icon.
- Form fields are tightly spaced again (v4's grid gap had blown them out).
- The events "Approved" marker is a small badge instead of heading-sized.
- The events calendar marks today with a clean circle, not a squashed oval.
- The frontend is replaced with zero downtime on a single replica.

## How
- `housestyle.scss`: the house `.v-btn` radius now also excludes
  `.rounded-pill`/`.rounded-circle` — v4 applies `rounded="pill"` as a utility
  class (not `.v-btn--rounded`), so the unlayered house rule was flattening it
  back to 10px.
- `forms.scss`: `.v-row` `row-gap: 2px` / `column-gap: 16px` (v4's flexbox grid
  defaults to a 24px gap).
- `Home.vue`: the column's `<a>` now wraps the icon, title and description, so
  the entire `.expand` block is the click target.
- `EventCard.vue`: `.approve-btn` gets an explicit small `font-size` (it sits
  inside a `text-h4` title and inherited the heading size under v4).
- `EventCalendar.vue`: today (`.v-present`) renders as a 28×28 filled primary
  circle instead of the oval the `height: 20px` rule produced under v4.
- `frontend` Deployment: explicit `RollingUpdate` with `maxSurge: 1`,
  `maxUnavailable: 0`. api already had this; stalwart/valkey keep `Recreate`
  (hostPorts / RWO PVC can't surge a second pod).

Verified on the running app: Join-now `border-radius: 9999px`, the card `<a>`
wraps the description, form `row-gap: 2px`, calendar today is a circle.
typecheck + lint pass; the stateless kustomize overlay builds.

Supersedes the unmerged #310 (its form-gap + calendar-today fixes are folded in
here, rebased onto current main).