### PR TITLE
style(frontend): tighten the inter-row spacing in forms (Vuetify 4)

### DIFF
--- a/services/frontend/src/styles/forms.scss
+++ b/services/frontend/src/styles/forms.scss
@@ -1,9 +1,16 @@
 // Vuetify 4's grid replaced negative-margin gutters with a flexbox `gap`
-// defaulting to 24px, which blew out the spacing between stacked form fields.
-// Pull the gutters back tight — the app's rows were always compact.
+// (defaulting to 24px) AND spaces consecutive rows with
+// `.v-row + .v-row { margin-top: var(--v-col-gap-y) }` (also 24px). Both blew
+// out form spacing; pull them back tight — the app's rows were always compact.
 .v-row {
   row-gap: 2px;
   column-gap: 16px;
+}
+
+// The real culprit behind "too much space between form rows": the inter-row
+// top margin. Override it (unlayered beats Vuetify's layered rule).
+.v-row + .v-row {
+  margin-top: 4px;
 }
 
 .v-row > .v-col {


### PR DESCRIPTION
## Why
Stacked form fields still had too much vertical space after the earlier
`row-gap` tweak — that only controls spacing *within* a `<v-row>`. The real
gap is Vuetify 4's stacked-row rule:

```css
.v-row + .v-row { margin-top: var(--v-col-gap-y); }   /* 24px */
```

Measured on the live signup form: row 0 `margin-top: 0`, every subsequent
row `margin-top: 24px`, rows stepping 102px apart.

## What this achieves
Stacked form fields sit tightly together (rows step 82px instead of 102px).

## How
- `forms.scss`: override `.v-row + .v-row { margin-top: 4px }` (unlayered, so
  it beats Vuetify's layered rule).

Note: this is global — any other page with stacked `<v-row>`s gets 4px between
them too. Verified on the membership signup form.