### PR TITLE
fix(cohort): mark members synced at push time, backfill the ledger

### DIFF
--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortMembershipSyncService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortMembershipSyncService.kt
@@ -1,5 +1,6 @@
 package net.blueshell.api.platform.integration.cohort.application
 
+import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortMemberRepository
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
 import net.blueshell.api.platform.integration.cohort.port.`in`.CohortMembershipSync
 import net.blueshell.api.platform.integration.cohort.port.`in`.SyncCohortMembershipIntent
@@ -14,6 +15,8 @@ import net.blueshell.api.shared.job.NonRetryableJobException
 import net.blueshell.api.shared.job.TrackedJobDispatcher
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 /**
  * Application implementation of the [CohortMembershipSync] inbound
@@ -33,11 +36,13 @@ import org.springframework.stereotype.Service
 @Service
 class CohortMembershipSyncService(
     private val cohorts: CohortRepository,
+    private val members: CohortMemberRepository,
     private val registry: CohortPortRegistry,
     private val externalIds: ExternalIdMappingService,
     private val jobs: TrackedJobDispatcher,
 ) : CohortMembershipSync {
 
+    @Transactional
     override fun sync(userId: Long, cohortId: Long, intent: SyncCohortMembershipIntent) {
         val cohort = cohorts.findById(cohortId).orElseThrow {
             NonRetryableJobException("Cohort $cohortId not found")
@@ -63,6 +68,17 @@ class CohortMembershipSyncService(
         }
         val externalCohortId = findOrCreateExternalCohortId(cohortId, cohortLabel, system, port)
         port.addMember(externalUserId, externalCohortId)
+
+        // Stamp the ledger so the desired row reads as synced. This is the
+        // primary path to healthy; reconcile only verifies afterwards.
+        val row = members.findByCohortIdAndUserId(cohortId, userId)
+        if (row == null) {
+            log.warn("Pushed user {} to {} cohort {} but its desired row is gone — not stamping", userId, system, cohortId)
+        } else {
+            row.externalUserId = externalUserId
+            row.observedAt = LocalDateTime.now()
+            members.save(row)
+        }
         log.debug("Added user {} to {} cohort {} (ext={})", userId, system, cohortId, externalCohortId)
     }
 

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRuleEvaluator.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRuleEvaluator.kt
@@ -7,6 +7,7 @@ import net.blueshell.api.platform.integration.cohort.persistence.repository.Coho
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRuleRepository
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortSubjectRepository
+import net.blueshell.api.platform.integration.cohort.port.`in`.SyncCohortMembershipIntent
 import net.blueshell.api.shared.job.CohortJobs
 import net.blueshell.api.shared.job.TrackedJobDispatcher
 import org.slf4j.LoggerFactory
@@ -26,10 +27,15 @@ import org.springframework.transaction.annotation.Transactional
  * 2. Fetches every enabled rule whose left-hand side matches a held
  *    fact and builds the desired cohort set.
  * 3. Diffs against the user's current `cohort_member` rows.
- * 4. For each cohort to add: inserts a desired `CohortMember` row.
- * 5. For each cohort to remove: soft-deletes the desired row.
- * 6. Enqueues one `ReconcileList` job per touched cohort so observed
- *    external state converges through the ledger.
+ * 4. For each cohort to add: inserts a desired `CohortMember` row and
+ *    enqueues a per-member `SyncCohortMembership(ADD)`.
+ * 5. For each cohort to remove: soft-deletes the desired row and
+ *    enqueues a per-member `SyncCohortMembership(REMOVE)`.
+ *
+ * The per-member sync is the primary path to a healthy ledger: a
+ * successful ADD stamps `observed_at` on the desired row. List reconcile
+ * (`ReconcileList`) is a separate periodic/manual verifier, not enqueued
+ * here.
  *
  * All of the above runs in a single transaction. The job dispatch
  * uses the `afterCommit` hook in `JobDispatcher.enqueue`, so a
@@ -73,14 +79,18 @@ class CohortRuleEvaluator(
             return evaluation
         }
 
-        evaluation.toAdd.forEach { cohortId -> add(userId, cohortId) }
+        evaluation.toAdd.forEach { cohortId ->
+            add(userId, cohortId)
+            jobs.enqueue(
+                CohortJobs.SyncCohortMembership,
+                CohortJobs.SyncCohortMembershipPayload(userId, cohortId, SyncCohortMembershipIntent.ADD),
+            )
+        }
         evaluation.toRemove.forEach { cohortId ->
             removeExistingMembership(currentMemberships, cohortId)
-        }
-        (evaluation.toAdd + evaluation.toRemove).forEach { cohortId ->
             jobs.enqueue(
-                CohortJobs.ReconcileList,
-                CohortJobs.ReconcileListPayload(cohortId),
+                CohortJobs.SyncCohortMembership,
+                CohortJobs.SyncCohortMembershipPayload(userId, cohortId, SyncCohortMembershipIntent.REMOVE),
             )
         }
 

--- a/services/api/src/main/resources/db/migration/V75__backfill_cohort_member_observed_at.sql
+++ b/services/api/src/main/resources/db/migration/V75__backfill_cohort_member_observed_at.sql
@@ -1,0 +1,18 @@
+-- V74 added cohort_member.observed_at as a nullable column with no
+-- backfill. The drift read classifies a desired row (user_id set) with
+-- observed_at NULL as "missing / not synced", so every member carried
+-- over already-synced by the V67 cutover instantly read as missing.
+--
+-- Stamp observed_at for active desired rows so the panel reflects
+-- reality. updated_at is a conservative observed timestamp. A member who
+-- is genuinely absent externally is self-healed on the next reconcile:
+-- it clears observed_at and re-enqueues an ADD (which now stamps on
+-- success). Stranger rows (user_id IS NULL) are left untouched.
+--
+-- The sentinel '9999-12-31 23:59:59' matches CohortMember's @SQLRestriction
+-- (active row marker).
+UPDATE cohort_member
+   SET observed_at = updated_at
+ WHERE user_id IS NOT NULL
+   AND observed_at IS NULL
+   AND deleted_at = '9999-12-31 23:59:59';

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortMembershipSyncServiceTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortMembershipSyncServiceTest.kt
@@ -5,6 +5,8 @@ import io.mockk.mockk
 import io.mockk.verify
 import net.blueshell.api.platform.integration.cohort.persistence.Cohort
 import net.blueshell.api.platform.integration.cohort.persistence.CohortKind
+import net.blueshell.api.platform.integration.cohort.persistence.CohortMember
+import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortMemberRepository
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
 import net.blueshell.api.platform.integration.cohort.port.`in`.SyncCohortMembershipIntent
 import net.blueshell.api.platform.integration.cohort.port.out.CohortPort
@@ -22,6 +24,7 @@ import java.util.Optional
 class CohortMembershipSyncServiceTest {
 
     private val cohorts: CohortRepository = mockk()
+    private val members: CohortMemberRepository = mockk(relaxed = true)
     private val brevoPort: CohortPort = mockk(relaxed = true) {
         every { system } returns TargetSystem.BREVO
     }
@@ -29,10 +32,18 @@ class CohortMembershipSyncServiceTest {
     private val jobs: TrackedJobDispatcher = mockk(relaxed = true)
     private val service = CohortMembershipSyncService(
         cohorts = cohorts,
+        members = members,
         registry = CohortPortRegistry(listOf(brevoPort)),
         externalIds = externalIds,
         jobs = jobs,
     )
+
+    init {
+        // Default: no desired row to stamp (overridden by the stamping test).
+        // save echoes its argument so the relaxed return type does not mis-cast.
+        every { members.findByCohortIdAndUserId(any(), any()) } returns null
+        every { members.save(any<CohortMember>()) } answers { firstArg() }
+    }
 
     @Test
     fun `ADD calls port when both external ids exist`() {
@@ -57,6 +68,22 @@ class CohortMembershipSyncServiceTest {
         verify { brevoPort.createCohort("Members", null) }
         verify { externalIds.upsert("COHORT", 10L, "BREVO", "99") }
         verify { brevoPort.addMember("777", "99") }
+    }
+
+    @Test
+    fun `ADD stamps externalUserId and observedAt on the desired row after a successful push`() {
+        givenCohort(id = 10L, system = "BREVO", label = "Members")
+        every { externalIds.find("USER", 1L, "BREVO") } returns mapping("USER", 1L, "BREVO", "777")
+        every { externalIds.find("COHORT", 10L, "BREVO") } returns mapping("COHORT", 10L, "BREVO", "42")
+        val row = mockk<CohortMember>(relaxed = true)
+        every { members.findByCohortIdAndUserId(10L, 1L) } returns row
+
+        service.sync(userId = 1L, cohortId = 10L, intent = SyncCohortMembershipIntent.ADD)
+
+        verify { brevoPort.addMember("777", "42") }
+        verify { row.externalUserId = "777" }
+        verify { row.observedAt = any() }
+        verify { members.save(row) }
     }
 
     @Test

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRuleEvaluatorTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRuleEvaluatorTest.kt
@@ -12,6 +12,7 @@ import net.blueshell.api.platform.integration.cohort.persistence.CohortRule
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortMemberRepository
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRuleRepository
+import net.blueshell.api.platform.integration.cohort.port.`in`.SyncCohortMembershipIntent
 import net.blueshell.api.shared.enums.Role
 import net.blueshell.api.shared.job.CohortJobs
 import net.blueshell.api.shared.job.TrackedJobDispatcher
@@ -35,7 +36,7 @@ class CohortRuleEvaluatorTest {
     private val evaluator = CohortRuleEvaluator(factCollector, rules, memberships, cohorts, subjectRepo, jobs, users)
 
     @Test
-    fun `cohorts in the desired set but not currently joined are added and a ReconcileList job is enqueued`() {
+    fun `cohorts in the desired set but not currently joined are added and a per-member ADD is enqueued`() {
         every { factCollector.collect(1L) } returns setOf(
             UserFact(CohortFactKind.ROLE, Role.MEMBER.name),
         )
@@ -57,17 +58,17 @@ class CohortRuleEvaluatorTest {
         assertThat(saved.captured.userId).isEqualTo(1L)
         verify {
             jobs.enqueue(
-                CohortJobs.ReconcileList,
-                CohortJobs.ReconcileListPayload(10L),
+                CohortJobs.SyncCohortMembership,
+                CohortJobs.SyncCohortMembershipPayload(1L, 10L, SyncCohortMembershipIntent.ADD),
             )
         }
         verify(exactly = 0) {
-            jobs.enqueue(CohortJobs.SyncCohortMembership, any<CohortJobs.SyncCohortMembershipPayload>())
+            jobs.enqueue(CohortJobs.ReconcileList, any<CohortJobs.ReconcileListPayload>())
         }
     }
 
     @Test
-    fun `cohorts currently joined but no longer desired are soft-deleted and a ReconcileList job is enqueued`() {
+    fun `cohorts currently joined but no longer desired are soft-deleted and a per-member REMOVE is enqueued`() {
         every { factCollector.collect(1L) } returns emptySet()
         val stale = cohort(id = 99L)
         val staleMembership = membership(stale)
@@ -80,12 +81,12 @@ class CohortRuleEvaluatorTest {
         verify { memberships.delete(staleMembership) }
         verify {
             jobs.enqueue(
-                CohortJobs.ReconcileList,
-                CohortJobs.ReconcileListPayload(99L),
+                CohortJobs.SyncCohortMembership,
+                CohortJobs.SyncCohortMembershipPayload(1L, 99L, SyncCohortMembershipIntent.REMOVE),
             )
         }
         verify(exactly = 0) {
-            jobs.enqueue(CohortJobs.SyncCohortMembership, any<CohortJobs.SyncCohortMembershipPayload>())
+            jobs.enqueue(CohortJobs.ReconcileList, any<CohortJobs.ReconcileListPayload>())
         }
     }
 
@@ -132,8 +133,14 @@ class CohortRuleEvaluatorTest {
         assertThat(result.desired).containsExactlyInAnyOrder(10L, 20L)
         assertThat(result.toAdd).containsExactlyInAnyOrder(10L, 20L)
         verify {
-            jobs.enqueue(CohortJobs.ReconcileList, CohortJobs.ReconcileListPayload(10L))
-            jobs.enqueue(CohortJobs.ReconcileList, CohortJobs.ReconcileListPayload(20L))
+            jobs.enqueue(
+                CohortJobs.SyncCohortMembership,
+                CohortJobs.SyncCohortMembershipPayload(1L, 10L, SyncCohortMembershipIntent.ADD),
+            )
+            jobs.enqueue(
+                CohortJobs.SyncCohortMembership,
+                CohortJobs.SyncCohortMembershipPayload(1L, 20L, SyncCohortMembershipIntent.ADD),
+            )
         }
     }
 


### PR DESCRIPTION
## Why

The cohort drift panel reported **every** member as "not synced" even
though their sync jobs all succeeded and they really were in the external
system. Two compounding defects:

- `V74__cohort_member_ledger.sql` added `cohort_member.observed_at` as a
  nullable column with **no backfill**. Drift classifies a desired row
  (`user_id` set) with `observed_at` null as "not synced", so every
  member carried over already-synced by the `V67` cutover read as missing
  the instant V74 ran.
- `observed_at` was only ever stamped by list reconcile, and only when a
  member was *already present* in the remote snapshot. The per-member
  add pushed to the provider but never touched the ledger, and the
  evaluator enqueued only `ReconcileList` — which ran before the add took
  effect and was never re-run. A member could be added externally while
  `observed_at` stayed null forever.

## What this achieves

"Synced" becomes true the moment a member is successfully pushed, set at
the push site rather than only by a later reconcile. Existing members are
backfilled so the panel reflects reality immediately. List reconcile
stays as a separate periodic/manual verifier.

## How

- **`V75__backfill_cohort_member_observed_at.sql`** stamps
  `observed_at = updated_at` for active desired rows
  (`user_id IS NOT NULL`, `observed_at IS NULL`), so already-synced
  members stop reading as missing. Stranger rows are untouched.
- **`CohortMembershipSyncService`** now stamps `external_user_id` +
  `observed_at` on the desired row after `port.addMember` succeeds,
  inside the (now `@Transactional`) sync. The per-member push is the
  primary path to a healthy ledger; the no-external-id branch keeps its
  `SyncContact`-then-retry behaviour.
- **`CohortRuleEvaluator`** enqueues per-member
  `SyncCohortMembership(ADD/REMOVE)` for touched cohorts instead of one
  `ReconcileList` per cohort.

A genuinely-absent backfilled member self-heals on the next reconcile: it
clears `observed_at` and re-enqueues an ADD, which now stamps on success.

After deploy, run `cohort.reconcile-list` once per active cohort to
verify the backfilled stamps against the live external lists.