### PR TITLE
refactor(cohort): split sync state into synced_at/verified_at via a single ledger writer

### DIFF
--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/cohort/persistence/CohortRepositoryIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/cohort/persistence/CohortRepositoryIT.kt
@@ -162,7 +162,7 @@ class CohortRepositoryIT : UserTestSupport() {
                 userId = null,
                 subject = subject,
                 externalUserId = "ext-stranger",
-                observedAt = LocalDateTime.now(),
+                verifiedAt = LocalDateTime.now(),
             )
         )
 
@@ -194,10 +194,10 @@ class CohortRepositoryIT : UserTestSupport() {
         val now = LocalDateTime.now()
 
         cohortMembers.saveAndFlush(
-            CohortMember(cohort = cohort, userId = null, subject = subject, externalUserId = "ext-a", observedAt = now)
+            CohortMember(cohort = cohort, userId = null, subject = subject, externalUserId = "ext-a", verifiedAt = now)
         )
         cohortMembers.saveAndFlush(
-            CohortMember(cohort = cohort, userId = null, subject = subject, externalUserId = "ext-b", observedAt = now)
+            CohortMember(cohort = cohort, userId = null, subject = subject, externalUserId = "ext-b", verifiedAt = now)
         )
 
         assertThat(cohortMembers.findAllByCohortIdAndUserIdIsNull(cohort.id!!)).hasSize(2)
@@ -209,7 +209,7 @@ class CohortRepositoryIT : UserTestSupport() {
         val cohort = newCohort(subject)
         val now = LocalDateTime.now()
         cohortMembers.saveAndFlush(
-            CohortMember(cohort = cohort, userId = null, subject = subject, externalUserId = "ext-dup", observedAt = now)
+            CohortMember(cohort = cohort, userId = null, subject = subject, externalUserId = "ext-dup", verifiedAt = now)
         )
 
         assertThatThrownBy {
@@ -219,7 +219,7 @@ class CohortRepositoryIT : UserTestSupport() {
                     userId = null,
                     subject = subject,
                     externalUserId = "ext-dup",
-                    observedAt = now,
+                    verifiedAt = now,
                 )
             )
         }.isInstanceOf(DataIntegrityViolationException::class.java)

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortDriftService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortDriftService.kt
@@ -19,9 +19,9 @@ import java.time.ZoneOffset
  * (subject, system) pair. No outbound port calls — the live external
  * fetch happens in the reconcile job, not here.
  *
- * - Missing: desired rows (`userId != null`) with null `observedAt`.
- * - Extra:   stranger rows (`userId == null`) with non-null `observedAt`.
- * - `lastReconciledAt`: max `observedAt` across all ledger rows.
+ * - Missing: desired rows (`userId != null`) not yet pushed (`syncedAt == null`).
+ * - Extra:   stranger rows (`userId == null`) confirmed externally (`verifiedAt != null`).
+ * - `lastReconciledAt`: max `verifiedAt` across all ledger rows.
  */
 @Service
 @Transactional(readOnly = true)
@@ -41,8 +41,8 @@ class CohortDriftService(
 
         val allRows = memberRepo.findAllByCohortId(cohort.id!!)
 
-        // Missing: desired rows not yet confirmed present externally.
-        val missingRows = allRows.filter { it.userId != null && it.observedAt == null }
+        // Missing: desired rows not yet successfully pushed.
+        val missingRows = allRows.filter { it.userId != null && it.syncedAt == null }
         val missingUserIds = missingRows.mapNotNull { it.userId }.toSet()
         val missingMappedUserIds = externalIds.findBatch(USER_AGGREGATE, missingUserIds, system.name)
             .map { it.aggregateId }
@@ -55,7 +55,7 @@ class CohortDriftService(
         }
 
         // Extras: stranger rows present externally but not desired locally.
-        val strangerRows = allRows.filter { it.userId == null && it.observedAt != null }
+        val strangerRows = allRows.filter { it.userId == null && it.verifiedAt != null }
         val strangerExtIds = strangerRows.mapNotNull { it.externalUserId }.toSet()
         val ownerMappings = externalIds.findByExternalIds(USER_AGGREGATE, system.name, strangerExtIds)
             .associateBy { it.externalId }
@@ -99,7 +99,7 @@ class CohortDriftService(
         }
 
         val lastReconciledAt = allRows
-            .mapNotNull { it.observedAt }
+            .mapNotNull { it.verifiedAt }
             .maxOfOrNull { it }
             ?.toInstant(ZoneOffset.UTC)
 

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortMembershipSyncService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortMembershipSyncService.kt
@@ -1,6 +1,6 @@
 package net.blueshell.api.platform.integration.cohort.application
 
-import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortMemberRepository
+import net.blueshell.api.platform.integration.cohort.application.ledger.CohortLedger
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
 import net.blueshell.api.platform.integration.cohort.port.`in`.CohortMembershipSync
 import net.blueshell.api.platform.integration.cohort.port.`in`.SyncCohortMembershipIntent
@@ -36,7 +36,7 @@ import java.time.LocalDateTime
 @Service
 class CohortMembershipSyncService(
     private val cohorts: CohortRepository,
-    private val members: CohortMemberRepository,
+    private val ledger: CohortLedger,
     private val registry: CohortPortRegistry,
     private val externalIds: ExternalIdMappingService,
     private val jobs: TrackedJobDispatcher,
@@ -71,13 +71,8 @@ class CohortMembershipSyncService(
 
         // Stamp the ledger so the desired row reads as synced. This is the
         // primary path to healthy; reconcile only verifies afterwards.
-        val row = members.findByCohortIdAndUserId(cohortId, userId)
-        if (row == null) {
+        if (!ledger.markPushed(cohortId, userId, externalUserId, LocalDateTime.now())) {
             log.warn("Pushed user {} to {} cohort {} but its desired row is gone — not stamping", userId, system, cohortId)
-        } else {
-            row.externalUserId = externalUserId
-            row.observedAt = LocalDateTime.now()
-            members.save(row)
         }
         log.debug("Added user {} to {} cohort {} (ext={})", userId, system, cohortId, externalCohortId)
     }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRemediationService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRemediationService.kt
@@ -1,6 +1,6 @@
 package net.blueshell.api.platform.integration.cohort.application
 
-import net.blueshell.api.platform.integration.cohort.persistence.CohortMember
+import net.blueshell.api.platform.integration.cohort.application.ledger.CohortLedger
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortMemberRepository
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortSubjectRepository
@@ -23,11 +23,21 @@ import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionTemplate
 import java.time.LocalDateTime
 
+/**
+ * Operator/scheduled remediation against external membership. The list
+ * reconcile is now a *verifier*: the per-member sync path establishes
+ * health (`syncedAt`), and this confirms it (`verifiedAt`), demotes
+ * vanished members, and records strangers.
+ *
+ * All `cohort_member` writes go through [CohortLedger]; this service only
+ * decides which transition applies and enqueues follow-up jobs.
+ */
 @Service
 class CohortRemediationService(
     private val cohortRepo: CohortRepository,
     private val subjectRepo: CohortSubjectRepository,
     private val memberRepo: CohortMemberRepository,
+    private val ledger: CohortLedger,
     private val externalIds: ExternalIdMappingService,
     private val registry: CohortPortRegistry,
     private val jobs: TrackedJobDispatcher,
@@ -59,36 +69,18 @@ class CohortRemediationService(
             ?: throw NonRetryableJobException("Cohort $cohortId has no external id on $system")
 
         registry.require(system).removeMember(externalUserId, externalCohortId)
-
-        // Soft-delete the stranger row so the drift panel reflects the change.
-        memberRepo.findByCohortIdAndExternalUserIdAndUserIdIsNull(cohortId, externalUserId)
-            ?.let { memberRepo.delete(it) }
+        ledger.removeStranger(cohortId, externalUserId)
     }
 
     /**
-     * Fetches the full external member list for [cohortId], updates the
-     * unified [CohortMember] ledger, then enqueues narrow ADD jobs for
-     * each discrepancy. One network call per run.
-     *
-     * Ledger semantics after this call:
-     * - Desired rows whose external id is present remotely: stamped with
-     *   `externalUserId` + `observedAt`.
-     * - Desired rows absent remotely but with a known external id:
-     *   `observedAt` cleared; ADD job enqueued.
-     * - Desired rows with no external id yet: `SyncContact` enqueued.
-     * - Remote ids not matching any desired row: upserted as stranger
-     *   rows (`userId == null`).
-     * - Extras are recorded only; removal is admin-triggered via
-     *   remove-external, not automatic.
+     * Fetches the full external member list for [cohortId] and reconciles
+     * the ledger against it. One network call per run; runs the fetch
+     * outside any DB transaction.
      */
     override fun reconcileList(cohortId: Long) {
-        val plan = readOnlyTransaction.execute { loadPlan(cohortId) }
-
+        val plan = readOnlyTransaction.execute { loadPlan(cohortId) }!!
         val remote = registry.require(plan.system).listMembers(plan.externalCohortId)
-
-        writeTransaction.executeWithoutResult {
-            applySnapshot(plan, remote)
-        }
+        writeTransaction.executeWithoutResult { applySnapshot(plan, remote) }
     }
 
     private fun loadPlan(cohortId: Long): ReconcilePlan {
@@ -111,19 +103,10 @@ class CohortRemediationService(
             .findBatch(USER_AGGREGATE, desiredUserIds, system.name)
             .associate { it.aggregateId to it.externalId }
 
-        return ReconcilePlan(
-            cohortId = cohortId,
-            subjectId = subjectId,
-            system = system,
-            externalCohortId = externalCohortId,
-            externalIdByUserId = extIdByUserId,
-        )
+        return ReconcilePlan(cohortId, subjectId, system, externalCohortId, extIdByUserId)
     }
 
-    private fun applySnapshot(
-        plan: ReconcilePlan,
-        remote: List<MemberRef>,
-    ) {
+    private fun applySnapshot(plan: ReconcilePlan, remote: List<MemberRef>) {
         val cohort = cohortRepo.findById(plan.cohortId).orElseThrow {
             NonRetryableJobException("Cohort ${plan.cohortId} not found")
         }
@@ -131,77 +114,79 @@ class CohortRemediationService(
             NonRetryableJobException("Cohort ${plan.cohortId} references missing subject ${plan.subjectId}")
         }
         val remoteByExtId = remote.associateBy { it.externalUserId }
-        val remoteExtIds = remoteByExtId.keys
-
         val now = LocalDateTime.now()
         val desiredRows = memberRepo.findAllByCohortIdAndUserIdIsNotNull(plan.cohortId)
 
-        // Update desired rows and collect confirmed external ids.
-        val confirmedExtIds = mutableSetOf<String>()
+        val confirmed = confirmPresentDesiredRows(plan, desiredRows, remoteByExtId, now)
+        demoteVanishedDesiredRows(plan, desiredRows, remoteByExtId.keys)
+        enqueueFollowUpsForMissing(plan, desiredRows, remoteByExtId.keys)
+        reconcileStrangers(cohort, subject, remoteByExtId, confirmed, now)
+    }
+
+    /** Desired rows present in the snapshot: confirm and collapse any matching stranger. */
+    private fun confirmPresentDesiredRows(
+        plan: ReconcilePlan,
+        desiredRows: List<net.blueshell.api.platform.integration.cohort.persistence.CohortMember>,
+        remoteByExtId: Map<String, MemberRef>,
+        now: LocalDateTime,
+    ): Set<String> {
+        val confirmed = mutableSetOf<String>()
+        desiredRows.forEach { row ->
+            val extId = plan.externalIdByUserId[row.userId] ?: return@forEach
+            val remoteMember = remoteByExtId[extId] ?: return@forEach
+            ledger.markVerified(row, extId, remoteMember.label, now)
+            ledger.removeStranger(plan.cohortId, extId)
+            confirmed += extId
+        }
+        return confirmed
+    }
+
+    /** Desired rows that claimed sync/verify but are now absent: demote so they re-bucket as missing. */
+    private fun demoteVanishedDesiredRows(
+        plan: ReconcilePlan,
+        desiredRows: List<net.blueshell.api.platform.integration.cohort.persistence.CohortMember>,
+        remoteExtIds: Set<String>,
+    ) {
         desiredRows.forEach { row ->
             val extId = plan.externalIdByUserId[row.userId]
-            if (extId != null && extId in remoteExtIds) {
-                // Confirmed present: stamp the ledger.
-                row.externalUserId = extId
-                row.observedAt = now
-                row.label = remoteByExtId[extId]?.label
-                confirmedExtIds.add(extId)
-                memberRepo.save(row)
-                memberRepo.findByCohortIdAndExternalUserIdAndUserIdIsNull(plan.cohortId, extId)
-                    ?.let { memberRepo.delete(it) }
-            } else if (row.observedAt != null) {
-                // Was confirmed before but no longer present remotely.
-                row.observedAt = null
-                memberRepo.save(row)
-            }
+            val absent = extId == null || extId !in remoteExtIds
+            if (absent && (row.syncedAt != null || row.verifiedAt != null)) ledger.markDrifted(row)
         }
+    }
 
-        // Enqueue follow-ups for desired rows missing from the remote snapshot.
+    /** Desired rows absent remotely: materialise the contact, or re-push. */
+    private fun enqueueFollowUpsForMissing(
+        plan: ReconcilePlan,
+        desiredRows: List<net.blueshell.api.platform.integration.cohort.persistence.CohortMember>,
+        remoteExtIds: Set<String>,
+    ) {
         desiredRows.forEach { row ->
             val extId = plan.externalIdByUserId[row.userId]
             if (extId == null) {
-                jobs.enqueue(
-                    ContactJobs.SyncContact,
-                    ContactJobs.SyncContactPayload(row.userId!!),
-                )
+                jobs.enqueue(ContactJobs.SyncContact, ContactJobs.SyncContactPayload(row.userId!!))
             } else if (extId !in remoteExtIds) {
                 jobs.enqueue(
                     CohortJobs.SyncCohortMembership,
-                    CohortJobs.SyncCohortMembershipPayload(
-                        row.userId!!,
-                        plan.cohortId,
-                        SyncCohortMembershipIntent.ADD,
-                    ),
+                    CohortJobs.SyncCohortMembershipPayload(row.userId!!, plan.cohortId, SyncCohortMembershipIntent.ADD),
                 )
             }
         }
+    }
 
-        // Upsert stranger rows for remote ids not confirmed as desired.
-        val strangerExtIds = remoteExtIds - confirmedExtIds
-        strangerExtIds.forEach { extId ->
-            val existing = memberRepo.findByCohortIdAndExternalUserIdAndUserIdIsNull(plan.cohortId, extId)
-            if (existing != null) {
-                existing.observedAt = now
-                existing.label = remoteByExtId[extId]?.label
-                memberRepo.save(existing)
-            } else {
-                memberRepo.save(
-                    CohortMember(
-                        cohort = cohort,
-                        userId = null,
-                        subject = subject,
-                        externalUserId = extId,
-                        observedAt = now,
-                        label = remoteByExtId[extId]?.label,
-                    ),
-                )
-            }
+    /** Remote ids with no desired owner become strangers; strangers gone remotely are removed. */
+    private fun reconcileStrangers(
+        cohort: net.blueshell.api.platform.integration.cohort.persistence.Cohort,
+        subject: net.blueshell.api.platform.integration.cohort.persistence.CohortSubject,
+        remoteByExtId: Map<String, MemberRef>,
+        confirmedExtIds: Set<String>,
+        now: LocalDateTime,
+    ) {
+        (remoteByExtId.keys - confirmedExtIds).forEach { extId ->
+            ledger.upsertStranger(cohort, subject, extId, remoteByExtId[extId]?.label, now)
         }
-
-        // Soft-delete stranger rows for remote ids no longer present.
-        memberRepo.findAllByCohortIdAndUserIdIsNull(plan.cohortId)
-            .filter { it.externalUserId !in remoteExtIds }
-            .forEach { memberRepo.delete(it) }
+        memberRepo.findAllByCohortIdAndUserIdIsNull(cohort.id!!)
+            .filter { it.externalUserId !in remoteByExtId.keys }
+            .forEach { ledger.removeStranger(it) }
     }
 
     private fun foldLinkedUser(
@@ -212,15 +197,9 @@ class CohortRemediationService(
     ) {
         val cohort = cohortRepo.findBySubjectIdAndSystem(subjectId, system.name) ?: return
         val cohortId = cohort.id ?: return
-        val stranger = memberRepo.findByCohortIdAndExternalUserIdAndUserIdIsNull(cohortId, externalUserId)
-            ?: return
+        val stranger = memberRepo.findByCohortIdAndExternalUserIdAndUserIdIsNull(cohortId, externalUserId) ?: return
         val desired = memberRepo.findByCohortIdAndUserId(cohortId, userId) ?: return
-
-        desired.externalUserId = stranger.externalUserId
-        desired.observedAt = stranger.observedAt
-        desired.label = stranger.label
-        memberRepo.save(desired)
-        memberRepo.delete(stranger)
+        ledger.foldStrangerIntoDesired(desired, stranger)
     }
 
     private data class ReconcilePlan(
@@ -230,5 +209,4 @@ class CohortRemediationService(
         val externalCohortId: String,
         val externalIdByUserId: Map<Long, String?>,
     )
-
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRuleEvaluator.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRuleEvaluator.kt
@@ -33,7 +33,7 @@ import org.springframework.transaction.annotation.Transactional
  *    enqueues a per-member `SyncCohortMembership(REMOVE)`.
  *
  * The per-member sync is the primary path to a healthy ledger: a
- * successful ADD stamps `observed_at` on the desired row. List reconcile
+ * successful ADD stamps `synced_at` on the desired row. List reconcile
  * (`ReconcileList`) is a separate periodic/manual verifier, not enqueued
  * here.
  *

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortVerificationScheduler.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortVerificationScheduler.kt
@@ -1,0 +1,37 @@
+package net.blueshell.api.platform.integration.cohort.application
+
+import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
+import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService
+import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.COHORT_AGGREGATE
+import net.blueshell.api.shared.job.CohortJobs
+import net.blueshell.api.shared.job.TrackedJobDispatcher
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+/**
+ * Nightly verification sweep. Membership convergence is event-driven and
+ * health is established at push time, so this only *verifies*: it enqueues
+ * one `ReconcileList` per externally-mapped cohort to detect strangers and
+ * members that vanished out of band. The job's dedup key collapses overlap
+ * with on-demand reconciles.
+ */
+@Component
+class CohortVerificationScheduler(
+    private val cohorts: CohortRepository,
+    private val externalIds: ExternalIdMappingService,
+    private val jobs: TrackedJobDispatcher,
+) {
+    @Scheduled(cron = "\${cohort.verify-cron:0 0 3 * * *}")
+    fun verifyAllCohorts() {
+        val mapped = cohorts.findAll().filter { cohort ->
+            externalIds.find(COHORT_AGGREGATE, cohort.id!!, cohort.system) != null
+        }
+        log.info("Scheduling reconcile for {} externally-mapped cohorts", mapped.size)
+        mapped.forEach { jobs.enqueue(CohortJobs.ReconcileList, CohortJobs.ReconcileListPayload(it.id!!)) }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(CohortVerificationScheduler::class.java)
+    }
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/ledger/CohortLedger.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/ledger/CohortLedger.kt
@@ -1,0 +1,109 @@
+package net.blueshell.api.platform.integration.cohort.application.ledger
+
+import net.blueshell.api.platform.integration.cohort.persistence.Cohort
+import net.blueshell.api.platform.integration.cohort.persistence.CohortMember
+import net.blueshell.api.platform.integration.cohort.persistence.CohortSubject
+import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortMemberRepository
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+/**
+ * Single writer for `cohort_member` sync state. Every transition of
+ * `syncedAt` / `verifiedAt` / stranger rows goes through here, so the
+ * per-member sync path and the reconcile verifier share one definition
+ * of each state change instead of hand-rolling `row.apply { … }; save`.
+ *
+ * Callers own their transaction; these methods assume one is active.
+ */
+@Component
+class CohortLedger(private val members: CohortMemberRepository) {
+
+    /**
+     * A successful per-member push. Stamps `syncedAt` (and the external
+     * id) on the desired row. Returns false if the row is gone (the
+     * evaluator removed it mid-flight), so the caller can log the miss.
+     */
+    fun markPushed(cohortId: Long, userId: Long, externalUserId: String, at: LocalDateTime): Boolean {
+        val row = members.findByCohortIdAndUserId(cohortId, userId) ?: return false
+        row.externalUserId = externalUserId
+        row.syncedAt = at
+        members.save(row)
+        return true
+    }
+
+    /**
+     * Reconcile confirmed a desired row present in the live snapshot.
+     * Stamps `verifiedAt`, ensures `syncedAt` is set (present implies
+     * pushed), and records the external id + label.
+     */
+    fun markVerified(row: CohortMember, externalUserId: String, label: String?, at: LocalDateTime) {
+        row.externalUserId = externalUserId
+        if (row.syncedAt == null) row.syncedAt = at
+        row.verifiedAt = at
+        row.label = label
+        members.save(row)
+    }
+
+    /**
+     * Reconcile found a previously-pushed desired row absent remotely.
+     * Clears both stamps so it re-buckets as not-synced; the caller
+     * re-enqueues an ADD.
+     */
+    fun markDrifted(row: CohortMember) {
+        row.syncedAt = null
+        row.verifiedAt = null
+        members.save(row)
+    }
+
+    /** Upserts a stranger row (no local user) for a remote id with no desired owner. */
+    fun upsertStranger(
+        cohort: Cohort,
+        subject: CohortSubject,
+        externalUserId: String,
+        label: String?,
+        at: LocalDateTime,
+    ) {
+        val existing = members.findByCohortIdAndExternalUserIdAndUserIdIsNull(cohort.id!!, externalUserId)
+        if (existing != null) {
+            existing.verifiedAt = at
+            existing.label = label
+            members.save(existing)
+        } else {
+            members.save(
+                CohortMember(
+                    cohort = cohort,
+                    userId = null,
+                    subject = subject,
+                    externalUserId = externalUserId,
+                    verifiedAt = at,
+                    label = label,
+                ),
+            )
+        }
+    }
+
+    /** Soft-deletes the stranger row for an id (looked up; gone remotely or claimed by a user). */
+    fun removeStranger(cohortId: Long, externalUserId: String) {
+        members.findByCohortIdAndExternalUserIdAndUserIdIsNull(cohortId, externalUserId)
+            ?.let { members.delete(it) }
+    }
+
+    /** Soft-deletes an already-loaded stranger row. */
+    fun removeStranger(stranger: CohortMember) {
+        members.delete(stranger)
+    }
+
+    /**
+     * Claim fold: a linked user already had a stranger row. Move its
+     * external state onto the desired row (the member is confirmed
+     * present, so it counts as synced + verified) and drop the stranger.
+     */
+    fun foldStrangerIntoDesired(desired: CohortMember, stranger: CohortMember) {
+        desired.externalUserId = stranger.externalUserId
+        desired.syncedAt = stranger.verifiedAt
+        desired.verifiedAt = stranger.verifiedAt
+        desired.label = stranger.label
+        members.save(desired)
+        members.delete(stranger)
+    }
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/persistence/CohortMember.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/persistence/CohortMember.kt
@@ -14,14 +14,20 @@ import org.hibernate.annotations.SQLRestriction
 import java.time.LocalDateTime
 
 /**
- * Unified membership ledger. A row is one of three kinds:
+ * Unified membership ledger. Two nullable timestamps name two distinct
+ * facts, so a row's state is unambiguous:
  *
- * - **Desired** (`userId != null`, `observedAt == null`): the local
- *   rule engine has decided this user belongs here but the reconcile
- *   job has not yet confirmed their presence externally.
- * - **Healthy** (`userId != null`, `observedAt != null`): desired and
- *   confirmed present on the last reconcile run.
- * - **Stranger** (`userId == null`, `observedAt != null`): present
+ * - `syncedAt`   — we successfully pushed this member to the external
+ *   system (owned by the per-member sync path).
+ * - `verifiedAt` — a reconcile confirmed the member present in a live
+ *   remote snapshot (owned by the verifier).
+ *
+ * Row kinds:
+ * - **Desired, not synced** (`userId != null`, `syncedAt == null`): the
+ *   rule engine wants this user here but the push has not succeeded yet.
+ * - **Synced** (`userId != null`, `syncedAt != null`): pushed; healthy
+ *   once `verifiedAt` is also set.
+ * - **Stranger** (`userId == null`, `verifiedAt != null`): present
  *   externally but not desired locally (extra row).
  *
  * `userId` is a plain Long (not `@ManyToOne User`) so cohort code
@@ -45,7 +51,8 @@ import java.time.LocalDateTime
         Index(name = "idx_cohort_member_user", columnList = "user_id"),
         Index(name = "idx_cohort_member_deleted_at", columnList = "deleted_at"),
         Index(name = "idx_cohort_member_external", columnList = "cohort_id,external_user_id"),
-        Index(name = "idx_cohort_member_observed", columnList = "cohort_id,observed_at"),
+        Index(name = "idx_cohort_member_synced", columnList = "cohort_id,synced_at"),
+        Index(name = "idx_cohort_member_verified", columnList = "cohort_id,verified_at"),
     ],
 )
 @SQLDelete(sql = "UPDATE cohort_member SET deleted_at = NOW(), version = version + 1 WHERE id = ? AND version = ?")
@@ -65,8 +72,11 @@ class CohortMember(
     @Column(name = "external_user_id", nullable = true)
     var externalUserId: String? = null,
 
-    @Column(name = "observed_at", nullable = true)
-    var observedAt: LocalDateTime? = null,
+    @Column(name = "synced_at", nullable = true)
+    var syncedAt: LocalDateTime? = null,
+
+    @Column(name = "verified_at", nullable = true)
+    var verifiedAt: LocalDateTime? = null,
 
     @Column(name = "label", nullable = true)
     var label: String? = null,

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/persistence/repository/CohortMemberRepository.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/persistence/repository/CohortMemberRepository.kt
@@ -17,7 +17,7 @@ interface CohortMemberRepository : BaseRepository<CohortMember, Long> {
 
     fun findByCohortIdAndUserId(cohortId: Long, userId: Long): CohortMember?
 
-    // ── Stranger rows (userId == null, observedAt != null) ────────────────────
+    // ── Stranger rows (userId == null, verifiedAt != null) ────────────────────
 
     fun findAllByCohortIdAndUserIdIsNull(cohortId: Long): List<CohortMember>
 

--- a/services/api/src/main/resources/db/migration/V76__cohort_member_sync_state.sql
+++ b/services/api/src/main/resources/db/migration/V76__cohort_member_sync_state.sql
@@ -1,0 +1,22 @@
+-- Split the overloaded observed_at into two unambiguous timestamps:
+--   synced_at   - we successfully pushed this member to the external
+--                 system (owned by the per-member sync path).
+--   verified_at - a reconcile confirmed the member present in a live
+--                 remote snapshot (owned by the verifier).
+--
+-- Drift then reads cleanly: missing = desired row with synced_at NULL;
+-- a pushed-but-not-yet-verified member is no longer mistaken for missing.
+--
+-- observed_at (set on push by the V75 hotfix) becomes verified_at, and
+-- synced_at is backfilled from it: anything previously stamped was, by
+-- definition, pushed.
+
+ALTER TABLE cohort_member CHANGE COLUMN observed_at verified_at DATETIME(6) NULL;
+
+ALTER TABLE cohort_member ADD COLUMN synced_at DATETIME(6) NULL AFTER external_user_id;
+
+UPDATE cohort_member SET synced_at = verified_at WHERE verified_at IS NOT NULL;
+
+DROP INDEX idx_cohort_member_observed ON cohort_member;
+CREATE INDEX idx_cohort_member_verified ON cohort_member (cohort_id, verified_at);
+CREATE INDEX idx_cohort_member_synced ON cohort_member (cohort_id, synced_at);

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortDriftServiceTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortDriftServiceTest.kt
@@ -39,10 +39,10 @@ class CohortDriftServiceTest {
         every { members.findAllByCohortId(99L) } returns listOf(
             member(cohort, subject, userId = 1L),
             member(cohort, subject, userId = 2L),
-            member(cohort, subject, userId = 9L, observedAt = lastObserved),
-            member(cohort, subject, userId = null, externalUserId = "ext-active", observedAt = lastObserved),
-            member(cohort, subject, userId = null, externalUserId = "ext-soft", observedAt = lastObserved.minusDays(1)),
-            member(cohort, subject, userId = null, externalUserId = "ext-unknown", observedAt = lastObserved.minusDays(2)),
+            member(cohort, subject, userId = 9L, syncedAt = lastObserved, verifiedAt = lastObserved),
+            member(cohort, subject, userId = null, externalUserId = "ext-active", verifiedAt = lastObserved),
+            member(cohort, subject, userId = null, externalUserId = "ext-soft", verifiedAt = lastObserved.minusDays(1)),
+            member(cohort, subject, userId = null, externalUserId = "ext-unknown", verifiedAt = lastObserved.minusDays(2)),
         )
         every {
             externalIds.findBatch("USER", setOf(1L, 2L), TargetSystem.BREVO.name)
@@ -125,14 +125,16 @@ class CohortDriftServiceTest {
         subject: CohortSubject,
         userId: Long?,
         externalUserId: String? = null,
-        observedAt: LocalDateTime? = null,
+        syncedAt: LocalDateTime? = null,
+        verifiedAt: LocalDateTime? = null,
     ): CohortMember =
         CohortMember(
             cohort = cohort,
             userId = userId,
             subject = subject,
             externalUserId = externalUserId,
-            observedAt = observedAt,
+            syncedAt = syncedAt,
+            verifiedAt = verifiedAt,
         )
 
     private fun user(id: Long): User =

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortMembershipSyncServiceTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortMembershipSyncServiceTest.kt
@@ -3,10 +3,9 @@ package net.blueshell.api.platform.integration.cohort.application
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import net.blueshell.api.platform.integration.cohort.application.ledger.CohortLedger
 import net.blueshell.api.platform.integration.cohort.persistence.Cohort
 import net.blueshell.api.platform.integration.cohort.persistence.CohortKind
-import net.blueshell.api.platform.integration.cohort.persistence.CohortMember
-import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortMemberRepository
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
 import net.blueshell.api.platform.integration.cohort.port.`in`.SyncCohortMembershipIntent
 import net.blueshell.api.platform.integration.cohort.port.out.CohortPort
@@ -24,7 +23,7 @@ import java.util.Optional
 class CohortMembershipSyncServiceTest {
 
     private val cohorts: CohortRepository = mockk()
-    private val members: CohortMemberRepository = mockk(relaxed = true)
+    private val ledger: CohortLedger = mockk(relaxed = true)
     private val brevoPort: CohortPort = mockk(relaxed = true) {
         every { system } returns TargetSystem.BREVO
     }
@@ -32,17 +31,14 @@ class CohortMembershipSyncServiceTest {
     private val jobs: TrackedJobDispatcher = mockk(relaxed = true)
     private val service = CohortMembershipSyncService(
         cohorts = cohorts,
-        members = members,
+        ledger = ledger,
         registry = CohortPortRegistry(listOf(brevoPort)),
         externalIds = externalIds,
         jobs = jobs,
     )
 
     init {
-        // Default: no desired row to stamp (overridden by the stamping test).
-        // save echoes its argument so the relaxed return type does not mis-cast.
-        every { members.findByCohortIdAndUserId(any(), any()) } returns null
-        every { members.save(any<CohortMember>()) } answers { firstArg() }
+        every { ledger.markPushed(any(), any(), any(), any()) } returns true
     }
 
     @Test
@@ -71,19 +67,15 @@ class CohortMembershipSyncServiceTest {
     }
 
     @Test
-    fun `ADD stamps externalUserId and observedAt on the desired row after a successful push`() {
+    fun `ADD marks the desired row pushed after a successful external add`() {
         givenCohort(id = 10L, system = "BREVO", label = "Members")
         every { externalIds.find("USER", 1L, "BREVO") } returns mapping("USER", 1L, "BREVO", "777")
         every { externalIds.find("COHORT", 10L, "BREVO") } returns mapping("COHORT", 10L, "BREVO", "42")
-        val row = mockk<CohortMember>(relaxed = true)
-        every { members.findByCohortIdAndUserId(10L, 1L) } returns row
 
         service.sync(userId = 1L, cohortId = 10L, intent = SyncCohortMembershipIntent.ADD)
 
         verify { brevoPort.addMember("777", "42") }
-        verify { row.externalUserId = "777" }
-        verify { row.observedAt = any() }
-        verify { members.save(row) }
+        verify { ledger.markPushed(10L, 1L, "777", any()) }
     }
 
     @Test

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRemediationServiceTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRemediationServiceTest.kt
@@ -8,6 +8,7 @@ import net.blueshell.api.platform.integration.cohort.persistence.CohortKind
 import net.blueshell.api.platform.integration.cohort.persistence.CohortMember
 import net.blueshell.api.platform.integration.cohort.persistence.CohortSubject
 import net.blueshell.api.platform.integration.cohort.persistence.CohortSubjectType
+import net.blueshell.api.platform.integration.cohort.application.ledger.CohortLedger
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortMemberRepository
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortSubjectRepository
@@ -42,6 +43,7 @@ class CohortRemediationServiceTest {
         cohortRepo = cohorts,
         subjectRepo = subjects,
         memberRepo = members,
+        ledger = CohortLedger(members),
         externalIds = externalIds,
         registry = CohortPortRegistry(listOf(port)),
         jobs = jobs,
@@ -58,7 +60,8 @@ class CohortRemediationServiceTest {
             subject,
             userId = 2L,
             externalUserId = "ext-2",
-            observedAt = LocalDateTime.parse("2026-01-01T12:00:00"),
+            syncedAt = LocalDateTime.parse("2026-01-01T12:00:00"),
+            verifiedAt = LocalDateTime.parse("2026-01-01T12:00:00"),
         )
         val missingWithoutExternalId = member(cohort, subject, userId = 3L)
         val matchingStranger = member(
@@ -66,7 +69,7 @@ class CohortRemediationServiceTest {
             subject,
             userId = null,
             externalUserId = "ext-1",
-            observedAt = LocalDateTime.parse("2026-01-02T12:00:00"),
+            verifiedAt = LocalDateTime.parse("2026-01-02T12:00:00"),
             label = "old stranger",
         )
         val staleStranger = member(
@@ -74,7 +77,7 @@ class CohortRemediationServiceTest {
             subject,
             userId = null,
             externalUserId = "stale",
-            observedAt = LocalDateTime.parse("2026-01-03T12:00:00"),
+            verifiedAt = LocalDateTime.parse("2026-01-03T12:00:00"),
         )
         port.remote = listOf(
             MemberRef("ext-1", "Alice Remote"),
@@ -107,9 +110,11 @@ class CohortRemediationServiceTest {
         assertThat(port.lastExternalCohortId).isEqualTo("list-99")
         assertThat(port.sawTransactionDuringList).isFalse()
         assertThat(confirmed.externalUserId).isEqualTo("ext-1")
-        assertThat(confirmed.observedAt).isNotNull()
+        assertThat(confirmed.syncedAt).isNotNull()
+        assertThat(confirmed.verifiedAt).isNotNull()
         assertThat(confirmed.label).isEqualTo("Alice Remote")
-        assertThat(missingWithExternalId.observedAt).isNull()
+        assertThat(missingWithExternalId.syncedAt).isNull()
+        assertThat(missingWithExternalId.verifiedAt).isNull()
         verify { members.delete(matchingStranger) }
         verify { members.delete(staleStranger) }
         verify {
@@ -127,7 +132,7 @@ class CohortRemediationServiceTest {
                 match {
                     it.userId == null &&
                         it.externalUserId == "ext-extra" &&
-                        it.observedAt != null &&
+                        it.verifiedAt != null &&
                         it.label == "Extra Remote"
                 },
             )
@@ -143,7 +148,7 @@ class CohortRemediationServiceTest {
             subject,
             userId = null,
             externalUserId = "ext-9",
-            observedAt = LocalDateTime.parse("2026-03-01T08:00:00"),
+            verifiedAt = LocalDateTime.parse("2026-03-01T08:00:00"),
         )
         every { cohorts.findById(99L) } returns Optional.of(cohort)
         every { externalIds.find("COHORT", 99L, TargetSystem.BREVO.name) } returns
@@ -166,7 +171,7 @@ class CohortRemediationServiceTest {
             subject,
             userId = null,
             externalUserId = "ext-7",
-            observedAt = LocalDateTime.parse("2026-02-01T09:00:00"),
+            verifiedAt = LocalDateTime.parse("2026-02-01T09:00:00"),
             label = "Linked Remote",
         )
         val desired = member(cohort, subject, userId = 7L)
@@ -182,7 +187,8 @@ class CohortRemediationServiceTest {
 
         assertThat(result).isSameAs(mapping)
         assertThat(desired.externalUserId).isEqualTo("ext-7")
-        assertThat(desired.observedAt).isEqualTo(stranger.observedAt)
+        assertThat(desired.verifiedAt).isEqualTo(stranger.verifiedAt)
+        assertThat(desired.syncedAt).isEqualTo(stranger.verifiedAt)
         assertThat(desired.label).isEqualTo("Linked Remote")
         verify { members.save(desired) }
         verify { members.delete(stranger) }
@@ -204,7 +210,8 @@ class CohortRemediationServiceTest {
         subject: CohortSubject,
         userId: Long?,
         externalUserId: String? = null,
-        observedAt: LocalDateTime? = null,
+        syncedAt: LocalDateTime? = null,
+        verifiedAt: LocalDateTime? = null,
         label: String? = null,
     ): CohortMember =
         CohortMember(
@@ -212,7 +219,8 @@ class CohortRemediationServiceTest {
             userId = userId,
             subject = subject,
             externalUserId = externalUserId,
-            observedAt = observedAt,
+            syncedAt = syncedAt,
+            verifiedAt = verifiedAt,
             label = label,
         )
 

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/ledger/CohortLedgerTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/ledger/CohortLedgerTest.kt
@@ -1,0 +1,102 @@
+package net.blueshell.api.platform.integration.cohort.application.ledger
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.blueshell.api.platform.integration.cohort.persistence.Cohort
+import net.blueshell.api.platform.integration.cohort.persistence.CohortMember
+import net.blueshell.api.platform.integration.cohort.persistence.CohortSubject
+import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortMemberRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class CohortLedgerTest {
+
+    private val members: CohortMemberRepository = mockk(relaxed = true)
+    private val ledger = CohortLedger(members)
+
+    init {
+        every { members.save(any<CohortMember>()) } answers { firstArg() }
+    }
+    private val cohort: Cohort = mockk { every { id } returns 99L }
+    private val subject: CohortSubject = mockk()
+    private val now: LocalDateTime = LocalDateTime.parse("2026-06-01T10:00:00")
+
+    @Test
+    fun `markPushed stamps syncedAt and external id on the desired row`() {
+        val row = member(userId = 1L)
+        every { members.findByCohortIdAndUserId(99L, 1L) } returns row
+
+        val stamped = ledger.markPushed(99L, 1L, "ext-1", now)
+
+        assertThat(stamped).isTrue()
+        assertThat(row.syncedAt).isEqualTo(now)
+        assertThat(row.externalUserId).isEqualTo("ext-1")
+        verify { members.save(row) }
+    }
+
+    @Test
+    fun `markPushed reports false when the desired row is gone`() {
+        every { members.findByCohortIdAndUserId(99L, 1L) } returns null
+
+        assertThat(ledger.markPushed(99L, 1L, "ext-1", now)).isFalse()
+        verify(exactly = 0) { members.save(any<CohortMember>()) }
+    }
+
+    @Test
+    fun `markVerified sets verifiedAt and backfills syncedAt when absent`() {
+        val row = member(userId = 1L)
+
+        ledger.markVerified(row, "ext-1", "Ada", now)
+
+        assertThat(row.verifiedAt).isEqualTo(now)
+        assertThat(row.syncedAt).isEqualTo(now)
+        assertThat(row.label).isEqualTo("Ada")
+    }
+
+    @Test
+    fun `markVerified keeps an earlier syncedAt`() {
+        val pushedAt = now.minusHours(1)
+        val row = member(userId = 1L).apply { syncedAt = pushedAt }
+
+        ledger.markVerified(row, "ext-1", null, now)
+
+        assertThat(row.syncedAt).isEqualTo(pushedAt)
+        assertThat(row.verifiedAt).isEqualTo(now)
+    }
+
+    @Test
+    fun `markDrifted clears both stamps`() {
+        val row = member(userId = 1L).apply {
+            syncedAt = now
+            verifiedAt = now
+        }
+
+        ledger.markDrifted(row)
+
+        assertThat(row.syncedAt).isNull()
+        assertThat(row.verifiedAt).isNull()
+    }
+
+    @Test
+    fun `foldStrangerIntoDesired moves external state and drops the stranger`() {
+        val stranger = member(userId = null).apply {
+            externalUserId = "ext-7"
+            verifiedAt = now
+            label = "Linked"
+        }
+        val desired = member(userId = 7L)
+
+        ledger.foldStrangerIntoDesired(desired, stranger)
+
+        assertThat(desired.externalUserId).isEqualTo("ext-7")
+        assertThat(desired.syncedAt).isEqualTo(now)
+        assertThat(desired.verifiedAt).isEqualTo(now)
+        assertThat(desired.label).isEqualTo("Linked")
+        verify { members.delete(stranger) }
+    }
+
+    private fun member(userId: Long?): CohortMember =
+        CohortMember(cohort = cohort, userId = userId, subject = subject)
+}


### PR DESCRIPTION
## Why

The membership ledger overloaded one `observed_at` timestamp to mean two
different things — "we successfully pushed this member" and "a reconcile
confirmed the member present externally". A NULL was therefore ambiguous
(never pushed, or pushed then vanished?), and the stamp/clear logic was
duplicated inline across the per-member sync path and the reconcile pass,
with deep nesting in the reconcile snapshot.

## What this achieves

Two unambiguous timestamps name two facts:

- `synced_at` — the per-member push succeeded (owned by the sync path).
- `verified_at` — a reconcile confirmed the member present remotely.

Drift reads cleanly: a member is missing only when `synced_at` is NULL, so
a pushed-but-not-yet-verified member is no longer reported as not synced.
All ledger writes now funnel through one place, and the reconcile snapshot
is flat rather than five nested passes.

## How

- **`V76__cohort_member_sync_state.sql`** renames `observed_at` to
  `verified_at`, adds `synced_at` (backfilled from `verified_at`), and
  reindexes. `CohortMember` carries both columns with an updated state kdoc.
- **`CohortLedger`** (new) is the single writer for every `cohort_member`
  transition — `markPushed`, `markVerified`, `markDrifted`,
  `upsertStranger`, `removeStranger`, `foldStrangerIntoDesired`. The sync
  service and the reconcile verifier both delegate to it, so stamping is
  defined once.
- **`CohortRemediationService.applySnapshot`** is de-nested into named
  single-pass helpers — confirm present, demote vanished, enqueue missing,
  reconcile strangers — each delegating writes to the ledger.
  `CohortMembershipSyncService` stamps via `ledger.markPushed`.
- **`CohortDriftService`** buckets on `synced_at` (missing) and
  `verified_at` (extras); `lastReconciledAt` is the max `verified_at`.
- **`CohortVerificationScheduler`** (new) runs a nightly per-cohort
  reconcile so strangers and vanished members are still detected, now that
  membership health is established at push time rather than by an eager
  per-edit reconcile.

Adds `CohortLedgerTest`; updates the reconcile, drift and repository tests
for the new columns. The cohort integration tests pass against a real
MariaDB (Flyway applies V76, Hibernate validates the entity).