### PR TITLE
docs(cohort): fix stale KDoc, document the port convention in ADR-022

### DIFF
--- a/docs/adr/api/ADR-022-platform-infrastructure-shared-organization.md
+++ b/docs/adr/api/ADR-022-platform-infrastructure-shared-organization.md
@@ -139,6 +139,52 @@ Simple integrations (e.g. `calendar/`) may omit sub-packages that don't apply
 (no web, no persistence), but must still use `adapter/` and `application/job/` for
 their adapter and job handler files.
 
+**Hexagonal ports (`port/in` and `port/out`) — optional refinement.**
+
+An integration with non-trivial inbound use cases and a vendor-facing
+Anti-Corruption Layer may name its ports explicitly under `port/`. The cohort
+module is the canonical example:
+
+```
+integration/cohort/
+├── port/in/                    # Inbound (driving) ports — one per use-case group
+│   ├── CohortMembershipSync.kt # ADD/REMOVE one (user, target) pair
+│   ├── CohortReconciliation.kt # "kick the engine" admin operations
+│   ├── CohortRemediation.kt    # link / verify / remove-external-member
+│   ├── CohortTargeting.kt      # link / create / switch / delete external target
+│   └── CohortDrift.kt          # compute a drift report
+├── port/out/                   # Outbound (driven) ACL ports
+│   ├── CohortPort.kt           # vendor-neutral target operations
+│   └── CohortPortRegistry.kt   # selects a CohortPort by TargetSystem
+├── adapter/                    # driving adapters (job handlers, web) + the ACL implementation (brevo/)
+├── application/                # port/in implementations: *Service, evaluator, ledger, schedulers
+└── persistence/                # entities + repositories
+```
+
+Conventions:
+
+- **Inbound use-case ports live under `port/in`.** One port per use-case group;
+  do **not** split one use case across several ports, and do **not** add a port
+  just to read or write a single column. A port with one implementation is fine —
+  its value is a published contract for driving adapters (job handlers, controllers),
+  a stable test seam, and consistency with hexagonal architecture, not caller count.
+- **Outbound ACL ports live under `port/out`.** These are the ADR-019
+  Anti-Corruption Layer interfaces (`CohortPort` is a vendor-neutral facade selected
+  at runtime by `TargetSystem`); their vendor implementations live under `adapter/`
+  (e.g. `adapter/brevo/BrevoCohortAdapter`).
+- **`application/` holds the `port/in` implementations** — the `*Service` beans,
+  the rule evaluator, the ledger writer, schedulers — exactly as the 4-sub-package
+  rule already requires for `@Service` beans.
+- **Driving adapters stay under `adapter/`** (job handlers under
+  `adapter/job/`, controllers under `adapter/web/` or `web/`).
+
+This is a refinement of the 4-sub-package structure, not a replacement: most
+integrations have a single trivial inbound path and do not need named ports. The
+architecture tests already permit it — `LayeredArchitectureTest` treats `platform/`
+as infrastructure and lets `shared/job` payloads reference
+`platform.integration..port.in..`, and `PlatformConsistencyArchitectureTest` has no
+rule against port packages.
+
 **Mock adapters** live in a shared sub-package, easily excludable by ArchUnit and profiles:
 ```
 integration/mock/
@@ -433,6 +479,8 @@ These tests enforce the canonical 4-sub-package structure within every integrati
 - ✅ Place ACL adapters and HTTP clients in `platform/integration/{system}/adapter/`
 - ✅ Place `@Service` beans in `platform/integration/{system}/application/`
 - ✅ Place schedulers in `platform/integration/{system}/application/`
+- ✅ Place inbound use-case ports in `platform/integration/{system}/port/in/` (one per use-case group) and their implementations in `application/`
+- ✅ Place outbound ACL ports in `platform/integration/{system}/port/out/` and their vendor implementations in `adapter/`
 - ✅ Place DTOs in `platform/integration/{system}/web/dto/`
 - ✅ Place permission evaluators in `infrastructure/security/permission/`
 - ✅ Place email builders in domain `application/email/`
@@ -450,6 +498,7 @@ These tests enforce the canonical 4-sub-package structure within every integrati
 - ❌ Place Spring `@Configuration` in infrastructure (use platform/config)
 - ❌ Place `*Adapter` or `*Client` classes at the module root (use `adapter/` sub-package)
 - ❌ Access repositories directly from `queue/` classes (use the service layer)
+- ❌ Split one inbound use case across multiple `port/in` interfaces, or add a port just to read/write a single column
 
 ---
 

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/listener/CohortRuleListener.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/listener/CohortRuleListener.kt
@@ -16,10 +16,12 @@ import org.springframework.transaction.annotation.Transactional
 
 /**
  * Funnels every change event that can alter a user's [UserFact]s into a
- * single re-evaluation of cohort membership. Shadow mode for now: the
- * evaluator only logs the diff. Hooking up every relevant source-of-truth
- * event in this PR means the follow-up cutover PR has nothing to wire —
- * it only flips the evaluator's "log" tail into "act".
+ * single re-evaluation of cohort membership. The evaluator writes the
+ * desired `cohort_member` rows and enqueues per-member
+ * `cohort.membership-sync` ADD/REMOVE jobs — it is not shadow mode.
+ *
+ * The engine still diffs cohort rows; the subject-level engine sketched
+ * by V72 is a deferred follow-up (see [CohortSubject]).
  *
  * `REQUIRES_NEW` mirrors the other listeners in the codebase: the
  * re-evaluation runs in its own transaction so an evaluator failure

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/persistence/CohortSubject.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/persistence/CohortSubject.kt
@@ -11,12 +11,16 @@ import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 
 /**
- * The logical thing the engine syncs — "Web Cmte", "Members 2025-2026",
+ * The logical audience the engine syncs — "Web Cmte", "Members 2025-2026",
  * "Newsletter Subscribers". One subject can map to zero or more
  * [Cohort]s, one per external system (Brevo list, Discord role, Google
- * group). Rules and member rows attach to the subject, not the mapping,
- * so adding a Discord mapping later does not require duplicating
- * membership state.
+ * group).
+ *
+ * The subject-level engine sketched by V72 — where rules and membership
+ * attach to the subject so a second system reuses the same desired state —
+ * is **not** finished. Today [CohortRule] and [CohortMember] still carry
+ * `cohort_id` and the evaluator diffs cohort rows; finishing the
+ * subject-level model is deferred until a second external system is real.
  */
 @Entity
 @Table(

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/port/in/CohortReconciliation.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/port/in/CohortReconciliation.kt
@@ -14,7 +14,8 @@ interface CohortReconciliation {
     /**
      * Re-evaluates one user's cohort membership against the current
      * rules. Desired-row writes happen synchronously; external state
-     * converges through `cohort.reconcile-list` jobs for touched cohorts.
+     * converges through per-member `cohort.membership-sync` ADD/REMOVE
+     * jobs enqueued for each cohort the user joins or leaves.
      */
     fun evaluateUserCohorts(userId: Long)
 

--- a/services/api/src/main/kotlin/net/blueshell/api/shared/job/CohortJobs.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/shared/job/CohortJobs.kt
@@ -48,8 +48,10 @@ object CohortJobs {
 
     /**
      * Re-evaluates one user's cohort membership against the current
-     * rules. Local desired-row writes happen here; touched cohorts
-     * converge through [ReconcileList] jobs.
+     * rules. Local desired-row writes happen here, and the evaluator
+     * enqueues one per-member [SyncCohortMembership] ADD/REMOVE job for
+     * each cohort the user joins or leaves. [ReconcileList] is the
+     * separate periodic verifier, not this job's convergence path.
      */
     object EvaluateUserCohorts : JobDefinition<EvaluateUserCohortsPayload> {
         override val type: String = "cohort.evaluate-user"


### PR DESCRIPTION
## Why
The cohort module has the right structure — inbound use-case ports, an outbound anti-corruption layer, a local membership ledger — but it reads as accidental. Several KDoc blocks describe behaviour the code no longer has, and the `port/in` / `port/out` split is documented in no ADR, so the layering looks like ceremony rather than an intentional convention.

## What this achieves
The comments now match what the code does, and a reader can find the package convention written down. No behaviour changes — this is a pure documentation pass that clears the ground for the cohort changes that follow.

## How
KDoc corrections:
- `CohortRuleListener` no longer claims "shadow mode … only logs the diff"; it states that the evaluator writes the desired `cohort_member` rows and enqueues per-member `cohort.membership-sync` ADD/REMOVE jobs.
- `CohortSubject` no longer says rules and members attach to the subject. It now states that the subject-level engine sketched by V72 is unfinished — `CohortRule` and `CohortMember` still carry `cohort_id` and the evaluator diffs cohort rows — and that finishing it is deferred until a second external system is real.
- `CohortJobs.EvaluateUserCohorts` and `CohortReconciliation.evaluateUserCohorts` no longer describe convergence "through ReconcileList jobs"; they describe per-member membership-sync jobs, and name `ReconcileList` as the separate periodic verifier.

ADR-022 (`docs/adr/api/ADR-022-platform-infrastructure-shared-organization.md`):
- New "Hexagonal ports" subsection documenting the convention — inbound use-case ports under `port/in` (one port per use-case group, never split across ports, never one-per-column), outbound ACL ports under `port/out` with vendor implementations under `adapter/`, and `port/in` implementations under `application/`. Notes that the architecture tests already permit it.
- Matching DO/DON'T entries.

Comments and one ADR only; no bytecode or structural change, so the handler/service and architecture suites are unaffected. `:services:api:compileKotlin` is green.