### PR TITLE
fix(cohort): suspend the outer job transaction around every provider call

### DIFF
--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/cohort/adapter/job/CohortProviderTransactionBoundaryIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/cohort/adapter/job/CohortProviderTransactionBoundaryIT.kt
@@ -1,0 +1,95 @@
+package net.blueshell.api.platform.integration.cohort.adapter.job
+
+import net.blueshell.api.platform.integration.cohort.persistence.Cohort
+import net.blueshell.api.platform.integration.cohort.persistence.CohortKind
+import net.blueshell.api.platform.integration.cohort.persistence.CohortSubject
+import net.blueshell.api.platform.integration.cohort.persistence.CohortSubjectType
+import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
+import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortSubjectRepository
+import net.blueshell.api.platform.integration.cohort.port.`in`.SyncCohortMembershipIntent
+import net.blueshell.api.platform.integration.mock.MockCohortPort
+import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.COHORT_AGGREGATE
+import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.USER_AGGREGATE
+import net.blueshell.api.platform.integration.sync.persistence.ExternalIdMapping
+import net.blueshell.api.platform.integration.sync.persistence.repository.ExternalIdMappingRepository
+import net.blueshell.api.platform.integration.sync.port.TargetSystem
+import net.blueshell.api.shared.enums.Role
+import net.blueshell.api.shared.job.CohortJobs
+import net.blueshell.api.testsupport.UserTestSupport
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import tools.jackson.databind.ObjectMapper
+
+/**
+ * Proves the no-provider-call-inside-a-DB-transaction rule on the job
+ * path. [AbstractJsonJobHandler.handle][net.blueshell.api.platform.integration.queue.AbstractJsonJobHandler]
+ * is `@Transactional`, so a job is always dispatched with a transaction
+ * active. The application services suspend it (`PROPAGATION_NOT_SUPPORTED`)
+ * around every [CohortPort][net.blueshell.api.platform.integration.cohort.port.out.CohortPort]
+ * call; [MockCohortPort] records whether a transaction was actually active
+ * at each call so we can assert it never is.
+ */
+@SpringBootTest
+class CohortProviderTransactionBoundaryIT : UserTestSupport() {
+
+    @Autowired private lateinit var syncHandler: SyncCohortMembershipJobHandler
+
+    @Autowired private lateinit var verifyHandler: ReconcileListJobHandler
+
+    @Autowired private lateinit var cohorts: CohortRepository
+
+    @Autowired private lateinit var subjects: CohortSubjectRepository
+
+    @Autowired private lateinit var externalIds: ExternalIdMappingRepository
+
+    @Autowired private lateinit var port: MockCohortPort
+
+    @Autowired private lateinit var objectMapper: ObjectMapper
+
+    @Test
+    fun `membership-sync ADD calls the provider outside any transaction`() {
+        val user = createUserWithRole(Role.MEMBER)
+        val cohort = newCohort(newSubject())
+        externalIds.saveAndFlush(ExternalIdMapping(USER_AGGREGATE, user.id!!, TargetSystem.BREVO.name, "ext-user"))
+        externalIds.saveAndFlush(ExternalIdMapping(COHORT_AGGREGATE, cohort.id!!, TargetSystem.BREVO.name, "ext-cohort"))
+        port.transactionActiveDuringCalls.clear()
+
+        syncHandler.handle(
+            objectMapper.writeValueAsString(
+                CohortJobs.SyncCohortMembershipPayload(user.id!!, cohort.id!!, SyncCohortMembershipIntent.ADD),
+            ),
+            executionId = null,
+        )
+
+        assertThat(port.transactionActiveDuringCalls).isNotEmpty.containsOnly(false)
+    }
+
+    @Test
+    fun `reconcile-list verify fetches the member list outside any transaction`() {
+        val cohort = newCohort(newSubject())
+        externalIds.saveAndFlush(ExternalIdMapping(COHORT_AGGREGATE, cohort.id!!, TargetSystem.BREVO.name, "ext-cohort"))
+        port.transactionActiveDuringCalls.clear()
+
+        verifyHandler.handle(
+            objectMapper.writeValueAsString(CohortJobs.ReconcileListPayload(cohort.id!!)),
+            executionId = null,
+        )
+
+        assertThat(port.transactionActiveDuringCalls).isNotEmpty.containsOnly(false)
+    }
+
+    private fun newSubject(): CohortSubject =
+        subjects.save(CohortSubject(type = CohortSubjectType.CUSTOM, label = "Members"))
+
+    private fun newCohort(subject: CohortSubject): Cohort =
+        cohorts.save(
+            Cohort(
+                system = TargetSystem.BREVO.name,
+                kind = CohortKind.LIST,
+                label = "Members",
+                subjectId = subject.id,
+            ),
+        )
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortMembershipSyncService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortMembershipSyncService.kt
@@ -15,7 +15,10 @@ import net.blueshell.api.shared.job.NonRetryableJobException
 import net.blueshell.api.shared.job.TrackedJobDispatcher
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
 import java.time.LocalDateTime
 
 /**
@@ -40,7 +43,17 @@ class CohortMembershipSyncService(
     private val registry: CohortPortRegistry,
     private val externalIds: ExternalIdMappingService,
     private val jobs: TrackedJobDispatcher,
+    transactionManager: PlatformTransactionManager,
 ) : CohortMembershipSync {
+
+    // Suspends the surrounding transaction (this service's own and the
+    // @Transactional opened by AbstractJsonJobHandler) so the provider HTTP
+    // call holds no DB connection and runs with no transaction active —
+    // ADR-006/ADR-023. DB reads/writes stay in the suspended-and-resumed
+    // outer transaction around it.
+    private val outsideTransaction = TransactionTemplate(transactionManager).apply {
+        propagationBehavior = TransactionDefinition.PROPAGATION_NOT_SUPPORTED
+    }
 
     @Transactional
     override fun sync(userId: Long, cohortId: Long, intent: SyncCohortMembershipIntent) {
@@ -67,7 +80,7 @@ class CohortMembershipSyncService(
             )
         }
         val externalCohortId = findOrCreateExternalCohortId(cohortId, cohortLabel, system, port)
-        port.addMember(externalUserId, externalCohortId)
+        outsideTransaction.executeWithoutResult { port.addMember(externalUserId, externalCohortId) }
 
         // Stamp the ledger so the desired row reads as synced. This is the
         // primary path to healthy; reconcile only verifies afterwards.
@@ -87,7 +100,7 @@ class CohortMembershipSyncService(
             )
             return
         }
-        port.removeMember(externalUserId, externalCohortId)
+        outsideTransaction.executeWithoutResult { port.removeMember(externalUserId, externalCohortId) }
         log.debug("Removed user {} from {} cohort {} (ext={})", userId, system, cohortId, externalCohortId)
     }
 
@@ -105,7 +118,7 @@ class CohortMembershipSyncService(
     ): String {
         externalIds.find(COHORT_AGGREGATE, cohortId, system)?.externalId?.let { return it }
         log.info("Creating $system cohort {} ('{}') externally", cohortId, cohortLabel)
-        val created = port.createCohort(cohortLabel)
+        val created = outsideTransaction.execute { port.createCohort(cohortLabel) }!!
         externalIds.upsert(COHORT_AGGREGATE, cohortId, system, created)
         return created
     }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRemediationService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRemediationService.kt
@@ -19,6 +19,7 @@ import net.blueshell.api.shared.job.NonRetryableJobException
 import net.blueshell.api.shared.job.TrackedJobDispatcher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionTemplate
 import java.time.LocalDateTime
@@ -47,6 +48,12 @@ class CohortRemediationService(
     private val readOnlyTransaction = TransactionTemplate(transactionManager).apply { isReadOnly = true }
     private val writeTransaction = TransactionTemplate(transactionManager)
 
+    // Suspends any active transaction (notably the one AbstractJsonJobHandler
+    // opens) so provider HTTP calls hold no DB connection — ADR-006/ADR-023.
+    private val outsideTransaction = TransactionTemplate(transactionManager).apply {
+        propagationBehavior = TransactionDefinition.PROPAGATION_NOT_SUPPORTED
+    }
+
     @Transactional
     override fun linkUser(
         subjectId: Long,
@@ -68,7 +75,7 @@ class CohortRemediationService(
         val externalCohortId = externalIds.find(COHORT_AGGREGATE, cohortId, cohort.system)?.externalId
             ?: throw NonRetryableJobException("Cohort $cohortId has no external id on $system")
 
-        registry.require(system).removeMember(externalUserId, externalCohortId)
+        outsideTransaction.executeWithoutResult { registry.require(system).removeMember(externalUserId, externalCohortId) }
         ledger.removeStranger(cohortId, externalUserId)
     }
 
@@ -79,7 +86,7 @@ class CohortRemediationService(
      */
     override fun verifyCohort(cohortId: Long) {
         val plan = readOnlyTransaction.execute { loadPlan(cohortId) }!!
-        val remote = registry.require(plan.system).listMembers(plan.externalCohortId)
+        val remote = outsideTransaction.execute { registry.require(plan.system).listMembers(plan.externalCohortId) }!!
         writeTransaction.executeWithoutResult { applySnapshot(plan, remote) }
     }
 

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortTargetingService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortTargetingService.kt
@@ -14,6 +14,7 @@ import net.blueshell.api.shared.job.TrackedJobDispatcher
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.support.TransactionTemplate
 import org.springframework.web.server.ResponseStatusException
 
@@ -36,6 +37,13 @@ class CohortTargetingService(
 
     private val writeTransaction = TransactionTemplate(transactionManager)
 
+    // Suspends any active transaction (e.g. the one AbstractJsonJobHandler opens
+    // around deleteTarget) so provider HTTP calls hold no DB connection —
+    // ADR-006/ADR-023.
+    private val outsideTransaction = TransactionTemplate(transactionManager).apply {
+        propagationBehavior = TransactionDefinition.PROPAGATION_NOT_SUPPORTED
+    }
+
     override fun linkExisting(subjectId: Long, system: TargetSystem, externalId: String): CohortMappingRow =
         writeTransaction.execute {
             val subject = requireSubject(subjectId)
@@ -53,7 +61,7 @@ class CohortTargetingService(
             requireNoExistingMapping(subjectId, system)
         }
 
-        val externalId = registry.require(system).createCohort(label, folderHint)
+        val externalId = outsideTransaction.execute { registry.require(system).createCohort(label, folderHint) }!!
 
         return writeTransaction.execute {
             val cohort = cohortRepo.save(newCohort(system, label, folder = folderHint, subjectId = subjectId))
@@ -91,7 +99,7 @@ class CohortTargetingService(
     }
 
     override fun deleteTarget(system: TargetSystem, externalTargetId: String) {
-        registry.require(system).deleteCohort(externalTargetId)
+        outsideTransaction.executeWithoutResult { registry.require(system).deleteCohort(externalTargetId) }
     }
 
     private fun requireSubject(subjectId: Long) =

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/mock/MockCohortPort.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/mock/MockCohortPort.kt
@@ -7,7 +7,9 @@ import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicLong
 
 /**
@@ -28,12 +30,25 @@ class MockCohortPort : CohortPort {
     // cohortId → label
     private val cohorts = ConcurrentHashMap<String, String>()
 
-    // (externalUserId, externalCohortId) → email hint
-    private val memberships = ConcurrentHashMap<Pair<String, String>, String?>()
+    // (externalUserId, externalCohortId) → email hint ("" when unknown;
+    // ConcurrentHashMap forbids null values).
+    private val memberships = ConcurrentHashMap<Pair<String, String>, String>()
 
     private val idSequence = AtomicLong(9000)
 
+    /**
+     * Records `isActualTransactionActive()` at the entry of every provider
+     * call, so a boundary test can assert these run outside any DB
+     * transaction (the no-provider-call-inside-a-transaction rule).
+     */
+    val transactionActiveDuringCalls: MutableList<Boolean> = CopyOnWriteArrayList()
+
+    private fun recordTransactionState() {
+        transactionActiveDuringCalls += TransactionSynchronizationManager.isActualTransactionActive()
+    }
+
     override fun createCohort(label: String, hint: String?): String {
+        recordTransactionState()
         val id = idSequence.getAndIncrement().toString()
         cohorts[id] = label
         log.info("MockCohort: created cohort id={} label='{}'", id, label)
@@ -41,31 +56,36 @@ class MockCohortPort : CohortPort {
     }
 
     override fun addMember(externalUserId: String, externalCohortId: String) {
-        memberships[externalUserId to externalCohortId] = null
+        recordTransactionState()
+        memberships[externalUserId to externalCohortId] = ""
         log.info("MockCohort: added member {} to cohort {}", externalUserId, externalCohortId)
     }
 
     override fun removeMember(externalUserId: String, externalCohortId: String) {
+        recordTransactionState()
         memberships.remove(externalUserId to externalCohortId)
         log.info("MockCohort: removed member {} from cohort {}", externalUserId, externalCohortId)
     }
 
     override fun deleteCohort(externalCohortId: String) {
+        recordTransactionState()
         cohorts.remove(externalCohortId)
         memberships.keys.removeIf { (_, cohortId) -> cohortId == externalCohortId }
         log.info("MockCohort: deleted cohort {}", externalCohortId)
     }
 
-    override fun listMembers(externalCohortId: String): List<MemberRef> =
-        memberships.keys
+    override fun listMembers(externalCohortId: String): List<MemberRef> {
+        recordTransactionState()
+        return memberships.keys
             .filter { (_, cohortId) -> cohortId == externalCohortId }
-            .map { (userId, _) -> MemberRef(externalUserId = userId, label = memberships[userId to externalCohortId]) }
+            .map { (userId, _) -> MemberRef(externalUserId = userId, label = memberships[userId to externalCohortId]?.ifEmpty { null }) }
+    }
 
     // ── Test helpers ──────────────────────────────────────────────────────────
 
     /** Directly seeds a member with an optional email label for drift tests. */
     fun seedMember(externalUserId: String, externalCohortId: String, label: String? = null) {
-        memberships[externalUserId to externalCohortId] = label
+        memberships[externalUserId to externalCohortId] = label.orEmpty()
     }
 
     fun getMembers(externalCohortId: String): Set<String> =
@@ -74,6 +94,7 @@ class MockCohortPort : CohortPort {
     fun clear() {
         cohorts.clear()
         memberships.clear()
+        transactionActiveDuringCalls.clear()
     }
 
     companion object {

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortMembershipSyncServiceTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortMembershipSyncServiceTest.kt
@@ -35,6 +35,10 @@ class CohortMembershipSyncServiceTest {
         registry = CohortPortRegistry(listOf(brevoPort)),
         externalIds = externalIds,
         jobs = jobs,
+        // A relaxed manager still runs the TransactionTemplate callbacks; the
+        // real no-active-transaction guarantee is asserted in
+        // CohortProviderTransactionBoundaryIT against a real transaction manager.
+        transactionManager = mockk(relaxed = true),
     )
 
     init {


### PR DESCRIPTION
## Why
`AbstractJsonJobHandler.handle()` is `@Transactional`, so every cohort job dispatched its external provider calls inside an open DB transaction: `addMember`, `removeMember` and the lazy `createCohort` in `CohortMembershipSyncService`; `listMembers` and `removeMember` in `CohortRemediationService`; and `deleteCohort` in `CohortTargetingService`. Holding a transaction — and its pooled connection — open across a provider HTTP call breaks the no-external-calls-inside-a-DB-transaction rule (ADR-006/ADR-023). A slow or hung provider call ties up a connection for its full duration.

## What this achieves
Provider calls on the job path now run with no transaction active, so a network round-trip never pins a DB connection. The DB reads and writes around each call stay transactional.

## How
- Every `CohortPort` call now runs through a `PROPAGATION_NOT_SUPPORTED` `TransactionTemplate`, which suspends any active transaction for the network call and resumes it afterwards. This extends the pattern `CohortTargetingService` already used for `create` to the remaining job paths.
- `services/api/.../cohort/application/CohortMembershipSyncService.kt`, `CohortRemediationService.kt`, `CohortTargetingService.kt` each gained an `outsideTransaction` template and wrap their provider calls in it. `CohortMembershipSyncService` takes a new `PlatformTransactionManager` constructor parameter; its unit test passes a relaxed mock that still runs the template callbacks.
- `CohortProviderTransactionBoundaryIT` drives the real `@Transactional` `SyncCohortMembershipJobHandler` and `ReconcileListJobHandler` and asserts, through `MockCohortPort`, that no transaction is active at any provider call. `MockCohortPort` now records `isActualTransactionActive()` per call.
- Driving `addMember` through the handler surfaced a latent `MockCohortPort` bug: it stored a `null` value in a `ConcurrentHashMap`, which rejects nulls. The member hint is now stored as `""` and mapped back to `null` on read.

Verified locally against a throwaway MariaDB: the two boundary tests, all 18 cohort integration tests, and 130 unit/architecture tests pass.