### PR TITLE
refactor(cohort): classify ledger rows through one computed CohortMemberState

### DIFF
--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/adapter/brevo/BrevoCohortAdapter.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/adapter/brevo/BrevoCohortAdapter.kt
@@ -42,4 +42,7 @@ class BrevoCohortAdapter(
     override fun listMembers(externalCohortId: String): List<MemberRef> =
         delegate.listMembers(externalCohortId.toLong())
             .map { MemberRef(it.externalUserId.toString(), it.email) }
+            // Never surface a blank external id: it would classify as an
+            // INVALID ledger row downstream (see CohortMemberState).
+            .filter { it.externalUserId.isNotBlank() }
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortDriftService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortDriftService.kt
@@ -1,6 +1,9 @@
 package net.blueshell.api.platform.integration.cohort.application
 
 import net.blueshell.api.domain.user.application.UserService
+import net.blueshell.api.platform.integration.cohort.persistence.CohortMemberState
+import net.blueshell.api.platform.integration.cohort.persistence.needsPush
+import net.blueshell.api.platform.integration.cohort.persistence.state
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortMemberRepository
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
 import net.blueshell.api.platform.integration.cohort.port.`in`.CohortDrift
@@ -42,7 +45,7 @@ class CohortDriftService(
         val allRows = memberRepo.findAllByCohortId(cohort.id!!)
 
         // Missing: desired rows not yet successfully pushed.
-        val missingRows = allRows.filter { it.userId != null && it.syncedAt == null }
+        val missingRows = allRows.filter { it.needsPush }
         val missingUserIds = missingRows.mapNotNull { it.userId }.toSet()
         val missingMappedUserIds = externalIds.findBatch(USER_AGGREGATE, missingUserIds, system.name)
             .map { it.aggregateId }
@@ -55,7 +58,7 @@ class CohortDriftService(
         }
 
         // Extras: stranger rows present externally but not desired locally.
-        val strangerRows = allRows.filter { it.userId == null && it.verifiedAt != null }
+        val strangerRows = allRows.filter { it.state == CohortMemberState.STRANGER }
         val strangerExtIds = strangerRows.mapNotNull { it.externalUserId }.toSet()
         val ownerMappings = externalIds.findByExternalIds(USER_AGGREGATE, system.name, strangerExtIds)
             .associateBy { it.externalId }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRemediationService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRemediationService.kt
@@ -1,6 +1,8 @@
 package net.blueshell.api.platform.integration.cohort.application
 
 import net.blueshell.api.platform.integration.cohort.application.ledger.CohortLedger
+import net.blueshell.api.platform.integration.cohort.persistence.CohortMemberState
+import net.blueshell.api.platform.integration.cohort.persistence.state
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortMemberRepository
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortSubjectRepository
@@ -157,7 +159,9 @@ class CohortRemediationService(
         desiredRows.forEach { row ->
             val extId = plan.externalIdByUserId[row.userId]
             val absent = extId == null || extId !in remoteExtIds
-            if (absent && (row.syncedAt != null || row.verifiedAt != null)) ledger.markDrifted(row)
+            if (absent && (row.state == CohortMemberState.SYNCED || row.state == CohortMemberState.VERIFIED)) {
+                ledger.markDrifted(row)
+            }
         }
     }
 

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/ledger/CohortLedger.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/ledger/CohortLedger.kt
@@ -63,6 +63,9 @@ class CohortLedger(private val members: CohortMemberRepository) {
         label: String?,
         at: LocalDateTime,
     ) {
+        // A blank external id would produce an INVALID stranger row (see
+        // CohortMemberState); reject it at the edge so the ledger never holds one.
+        require(externalUserId.isNotBlank()) { "Stranger external id must not be blank for cohort ${cohort.id}" }
         val existing = members.findByCohortIdAndExternalUserIdAndUserIdIsNull(cohort.id!!, externalUserId)
         if (existing != null) {
             existing.verifiedAt = at

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/persistence/CohortMember.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/persistence/CohortMember.kt
@@ -22,13 +22,10 @@ import java.time.LocalDateTime
  * - `verifiedAt` — a reconcile confirmed the member present in a live
  *   remote snapshot (owned by the verifier).
  *
- * Row kinds:
- * - **Desired, not synced** (`userId != null`, `syncedAt == null`): the
- *   rule engine wants this user here but the push has not succeeded yet.
- * - **Synced** (`userId != null`, `syncedAt != null`): pushed; healthy
- *   once `verifiedAt` is also set.
- * - **Stranger** (`userId == null`, `verifiedAt != null`): present
- *   externally but not desired locally (extra row).
+ * Callers classify a row through the computed [CohortMemberState]
+ * ([state]) rather than reading these nullable fields by hand:
+ * `DESIRED`, `SYNCED`, `VERIFIED` for the desired-row lifecycle and
+ * `STRANGER` for an externally-present row with no local user.
  *
  * `userId` is a plain Long (not `@ManyToOne User`) so cohort code
  * stays decoupled from the `domain.user` entity graph.

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/persistence/CohortMemberState.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/persistence/CohortMemberState.kt
@@ -1,0 +1,34 @@
+package net.blueshell.api.platform.integration.cohort.persistence
+
+/**
+ * The state of a [CohortMember] ledger row, computed from its nullable
+ * fields so call sites stop re-deriving it by hand. Lives in the
+ * persistence package next to the entity, so the entity stays free of
+ * application imports.
+ *
+ * - `DESIRED`  — the rule engine wants this user here; not pushed yet.
+ * - `SYNCED`   — pushed to the external system (`syncedAt`), not yet
+ *   confirmed against a live snapshot.
+ * - `VERIFIED` — confirmed present in a live remote snapshot (`verifiedAt`,
+ *   which implies `syncedAt`).
+ * - `STRANGER` — present externally but not desired locally (no `userId`).
+ * - `INVALID`  — a field combination no normal transition produces (e.g.
+ *   a stranger with no external id, or `verifiedAt` set without `syncedAt`).
+ *   The ledger upholds the invariants that keep this empty; it exists so
+ *   an impossible row surfaces instead of silently classifying.
+ */
+enum class CohortMemberState { DESIRED, SYNCED, VERIFIED, STRANGER, INVALID }
+
+val CohortMember.state: CohortMemberState
+    get() = when {
+        userId == null && externalUserId.isNullOrBlank() -> CohortMemberState.INVALID
+        userId == null && verifiedAt == null -> CohortMemberState.INVALID
+        userId == null -> CohortMemberState.STRANGER
+        verifiedAt != null && syncedAt == null -> CohortMemberState.INVALID
+        verifiedAt != null -> CohortMemberState.VERIFIED
+        syncedAt != null -> CohortMemberState.SYNCED
+        else -> CohortMemberState.DESIRED
+    }
+
+/** A desired row still awaiting its first successful push. */
+val CohortMember.needsPush: Boolean get() = state == CohortMemberState.DESIRED

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/ledger/CohortLedgerTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/ledger/CohortLedgerTest.kt
@@ -3,11 +3,15 @@ package net.blueshell.api.platform.integration.cohort.application.ledger
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import io.mockk.slot
 import net.blueshell.api.platform.integration.cohort.persistence.Cohort
 import net.blueshell.api.platform.integration.cohort.persistence.CohortMember
+import net.blueshell.api.platform.integration.cohort.persistence.CohortMemberState
 import net.blueshell.api.platform.integration.cohort.persistence.CohortSubject
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortMemberRepository
+import net.blueshell.api.platform.integration.cohort.persistence.state
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
@@ -33,6 +37,7 @@ class CohortLedgerTest {
         assertThat(stamped).isTrue()
         assertThat(row.syncedAt).isEqualTo(now)
         assertThat(row.externalUserId).isEqualTo("ext-1")
+        assertThat(row.state).isEqualTo(CohortMemberState.SYNCED)
         verify { members.save(row) }
     }
 
@@ -53,6 +58,7 @@ class CohortLedgerTest {
         assertThat(row.verifiedAt).isEqualTo(now)
         assertThat(row.syncedAt).isEqualTo(now)
         assertThat(row.label).isEqualTo("Ada")
+        assertThat(row.state).isEqualTo(CohortMemberState.VERIFIED)
     }
 
     @Test
@@ -77,6 +83,7 @@ class CohortLedgerTest {
 
         assertThat(row.syncedAt).isNull()
         assertThat(row.verifiedAt).isNull()
+        assertThat(row.state).isEqualTo(CohortMemberState.DESIRED)
     }
 
     @Test
@@ -94,7 +101,27 @@ class CohortLedgerTest {
         assertThat(desired.syncedAt).isEqualTo(now)
         assertThat(desired.verifiedAt).isEqualTo(now)
         assertThat(desired.label).isEqualTo("Linked")
+        assertThat(desired.state).isEqualTo(CohortMemberState.VERIFIED)
         verify { members.delete(stranger) }
+    }
+
+    @Test
+    fun `upsertStranger inserts a STRANGER row`() {
+        every { members.findByCohortIdAndExternalUserIdAndUserIdIsNull(99L, "ext-9") } returns null
+        val saved = slot<CohortMember>()
+        every { members.save(capture(saved)) } answers { firstArg() }
+
+        ledger.upsertStranger(cohort, subject, "ext-9", "Stranger", now)
+
+        assertThat(saved.captured.state).isEqualTo(CohortMemberState.STRANGER)
+        assertThat(saved.captured.externalUserId).isEqualTo("ext-9")
+    }
+
+    @Test
+    fun `upsertStranger rejects a blank external id`() {
+        assertThatThrownBy { ledger.upsertStranger(cohort, subject, "  ", null, now) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+        verify(exactly = 0) { members.save(any<CohortMember>()) }
     }
 
     private fun member(userId: Long?): CohortMember =

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/persistence/CohortMemberStateTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/persistence/CohortMemberStateTest.kt
@@ -1,0 +1,70 @@
+package net.blueshell.api.platform.integration.cohort.persistence
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class CohortMemberStateTest {
+
+    private val cohort: Cohort = mockk { every { id } returns 1L }
+    private val subject: CohortSubject = mockk()
+    private val at: LocalDateTime = LocalDateTime.parse("2026-06-01T10:00:00")
+
+    @Test
+    fun `desired row — user, no stamps`() {
+        assertThat(member(userId = 7L).state).isEqualTo(CohortMemberState.DESIRED)
+    }
+
+    @Test
+    fun `synced row — user with syncedAt only`() {
+        val row = member(userId = 7L).apply { externalUserId = "ext"; syncedAt = at }
+        assertThat(row.state).isEqualTo(CohortMemberState.SYNCED)
+    }
+
+    @Test
+    fun `verified row — user with both stamps`() {
+        val row = member(userId = 7L).apply { externalUserId = "ext"; syncedAt = at; verifiedAt = at }
+        assertThat(row.state).isEqualTo(CohortMemberState.VERIFIED)
+    }
+
+    @Test
+    fun `stranger row — no user, external id, verified`() {
+        val row = member(userId = null).apply { externalUserId = "ext"; verifiedAt = at }
+        assertThat(row.state).isEqualTo(CohortMemberState.STRANGER)
+    }
+
+    @Test
+    fun `invalid — no user and no external id`() {
+        val row = member(userId = null).apply { verifiedAt = at }
+        assertThat(row.state).isEqualTo(CohortMemberState.INVALID)
+    }
+
+    @Test
+    fun `invalid — no user, external id, but not verified`() {
+        val row = member(userId = null).apply { externalUserId = "ext" }
+        assertThat(row.state).isEqualTo(CohortMemberState.INVALID)
+    }
+
+    @Test
+    fun `invalid — blank external id stranger`() {
+        val row = member(userId = null).apply { externalUserId = "  "; verifiedAt = at }
+        assertThat(row.state).isEqualTo(CohortMemberState.INVALID)
+    }
+
+    @Test
+    fun `invalid — verifiedAt without syncedAt on a desired row`() {
+        val row = member(userId = 7L).apply { externalUserId = "ext"; verifiedAt = at }
+        assertThat(row.state).isEqualTo(CohortMemberState.INVALID)
+    }
+
+    @Test
+    fun `needsPush is true only for a desired row`() {
+        assertThat(member(userId = 7L).needsPush).isTrue()
+        assertThat(member(userId = 7L).apply { externalUserId = "ext"; syncedAt = at }.needsPush).isFalse()
+    }
+
+    private fun member(userId: Long?): CohortMember =
+        CohortMember(cohort = cohort, userId = userId, subject = subject)
+}


### PR DESCRIPTION
## Why
A `CohortMember`'s state is spread across `userId`, `externalUserId`, `syncedAt` and `verifiedAt`, and call sites re-derived it by hand with subtly different null checks. `CohortDriftService` bucketed "missing" as `userId != null && syncedAt == null` and "extras" as `userId == null && verifiedAt != null`, while `CohortRemediationService` demoted on `syncedAt != null || verifiedAt != null`. Three hand-rolled readings of the same field combinations is one drift away from disagreeing.

## What this achieves
There is now one definition of what a ledger row means, and the call sites read it rather than re-implementing it. An impossible field combination classifies as `INVALID` and surfaces instead of being silently treated as missing or extra.

## How
- New `CohortMemberState` (`DESIRED`, `SYNCED`, `VERIFIED`, `STRANGER`, `INVALID`) plus a `val CohortMember.state` extension in `cohort/persistence/CohortMemberState.kt` — co-located with the entity so the entity imports no application code. The stranger case is decided first, then the desired-row lifecycle; `INVALID` names the combinations no normal transition produces.
- Call sites switched over: `CohortDriftService` uses `needsPush` for the "missing" bucket and `state == STRANGER` for extras; `CohortRemediationService` demotes on `state in (SYNCED, VERIFIED)`. `CohortMember`'s KDoc now points at the enum.
- To keep `INVALID` empty, blank external ids are rejected at the edges: `CohortLedger.upsertStranger` requires a non-blank id, and `BrevoCohortAdapter.listMembers` drops any blank `MemberRef` id.

No `CHECK` constraint is added yet — deferred until production rows are confirmed clean. Classification (every state and each `INVALID` combination) and each ledger transition's resulting state (`markPushed` → SYNCED, `markVerified` → VERIFIED, `markDrifted` → DESIRED, `upsertStranger` → STRANGER, `foldStrangerIntoDesired` → VERIFIED) are covered by unit tests; 141 unit/architecture tests pass.