### PR TITLE
feat(cohort): own the external target id on the cohort row

### DIFF
--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/cohort/adapter/web/CohortSubjectControllerIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/cohort/adapter/web/CohortSubjectControllerIT.kt
@@ -177,6 +177,21 @@ class CohortSubjectControllerIT : UserTestSupport() {
             .isEqualTo("new-list")
     }
 
+    @Test
+    fun `switching a cohort that belongs to another subject returns 404`() {
+        val admin = createUserWithRole(Role.ADMIN)
+        val ownerSubject = newSubject()
+        val otherSubject = newSubject()
+        val cohort = newCohort(ownerSubject)
+
+        mvc.perform(
+            put("/management/cohort-subjects/{id}/targets/{cohortId}", otherSubject.id, cohort.id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"externalId":"new-list","deletePrevious":false,"reconcileNow":false}""")
+                .with(bearer(admin)),
+        ).andExpect(status().isNotFound)
+    }
+
     private fun newSubject(): CohortSubject =
         subjects.save(CohortSubject(type = CohortSubjectType.CUSTOM, label = "Members"))
 

--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/cohort/persistence/CohortExternalIdMigrationIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/cohort/persistence/CohortExternalIdMigrationIT.kt
@@ -1,0 +1,74 @@
+package net.blueshell.api.platform.integration.cohort.persistence
+
+import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
+import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.COHORT_AGGREGATE
+import net.blueshell.api.platform.integration.sync.persistence.ExternalIdMapping
+import net.blueshell.api.platform.integration.sync.persistence.repository.ExternalIdMappingRepository
+import net.blueshell.api.platform.integration.sync.port.TargetSystem
+import net.blueshell.api.testsupport.UserTestSupport
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.jdbc.core.JdbcTemplate
+
+/**
+ * Real-MariaDB checks for V77: the `cohort.external_id` column round-trips
+ * through the entity, the `(system, external_id, deleted_at)` index exists,
+ * and the backfill statement copies the legacy `external_id_mapping` id into
+ * the column.
+ */
+@SpringBootTest
+class CohortExternalIdMigrationIT : UserTestSupport() {
+
+    @Autowired private lateinit var cohorts: CohortRepository
+
+    @Autowired private lateinit var externalIds: ExternalIdMappingRepository
+
+    @Autowired private lateinit var jdbc: JdbcTemplate
+
+    @Test
+    fun `external_id column round-trips through the entity`() {
+        val saved = cohorts.save(
+            Cohort(system = TargetSystem.BREVO.name, kind = CohortKind.LIST, label = "Members", externalId = "list-1"),
+        )
+        assertThat(cohorts.findById(saved.id!!).orElseThrow().externalId).isEqualTo("list-1")
+    }
+
+    @Test
+    fun `the system + external_id index exists`() {
+        val count = jdbc.queryForObject(
+            """
+            SELECT COUNT(*) FROM information_schema.statistics
+            WHERE table_schema = DATABASE() AND table_name = 'cohort'
+              AND index_name = 'idx_cohort_external_id'
+            """.trimIndent(),
+            Int::class.java,
+        )
+        assertThat(count).isGreaterThan(0)
+    }
+
+    @Test
+    fun `the V77 backfill copies the legacy mapping id into the column`() {
+        val cohort = cohorts.save(
+            Cohort(system = TargetSystem.BREVO.name, kind = CohortKind.LIST, label = "Members", externalId = null),
+        )
+        externalIds.saveAndFlush(
+            ExternalIdMapping(COHORT_AGGREGATE, cohort.id!!, TargetSystem.BREVO.name, "legacy-9"),
+        )
+
+        // The backfill statement from V77 (re-run here against a row left in the
+        // pre-migration shape: column null, legacy mapping present).
+        jdbc.update(
+            """
+            UPDATE cohort c
+            JOIN external_id_mapping m
+              ON m.aggregate_type = 'COHORT' AND m.aggregate_id = c.id AND m.system = c.system
+            SET c.external_id = m.external_id
+            WHERE c.external_id IS NULL
+            """.trimIndent(),
+        )
+
+        assertThat(cohorts.findById(cohort.id!!).orElseThrow().externalId).isEqualTo("legacy-9")
+    }
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/adapter/job/MaterializeCohortTargetJobHandler.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/adapter/job/MaterializeCohortTargetJobHandler.kt
@@ -1,0 +1,27 @@
+package net.blueshell.api.platform.integration.cohort.adapter.job
+
+import net.blueshell.api.platform.integration.cohort.port.`in`.CohortTargeting
+import net.blueshell.api.platform.integration.queue.AbstractJsonJobHandler
+import net.blueshell.api.shared.job.CohortJobs
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+
+/**
+ * Driving adapter: invokes [CohortTargeting.materialize]. Creates one
+ * cohort's external target when it has none yet, so a per-member ADD that
+ * found no target id can retry once it exists. Deduplicated per cohort.
+ */
+@Component
+class MaterializeCohortTargetJobHandler(
+    objectMapper: ObjectMapper,
+    private val targeting: CohortTargeting,
+) : AbstractJsonJobHandler<CohortJobs.MaterializeCohortTargetPayload>(
+    objectMapper,
+    CohortJobs.MaterializeCohortTarget.payloadType,
+) {
+    override val jobType: String = CohortJobs.MaterializeCohortTarget.type
+
+    override fun handlePayload(payload: CohortJobs.MaterializeCohortTargetPayload) {
+        targeting.materialize(payload.cohortId)
+    }
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/adapter/web/CohortSubjectController.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/adapter/web/CohortSubjectController.kt
@@ -103,7 +103,7 @@ class CohortSubjectController(
         @PathVariable cohortId: Long,
         @RequestBody @Valid body: SwitchTargetRequest,
     ): CohortMappingResponse =
-        targeting.switchTarget(cohortId, body.externalId, body.deletePrevious, body.reconcileNow).toResponse()
+        targeting.switchTarget(id, cohortId, body.externalId, body.deletePrevious, body.reconcileNow).toResponse()
 }
 
 // ── Request / response DTOs ──────────────────────────────────────────────────

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortDriftService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortDriftService.kt
@@ -8,7 +8,6 @@ import net.blueshell.api.platform.integration.cohort.persistence.repository.Coho
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
 import net.blueshell.api.platform.integration.cohort.port.`in`.CohortDrift
 import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService
-import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.COHORT_AGGREGATE
 import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.USER_AGGREGATE
 import net.blueshell.api.platform.integration.sync.port.TargetSystem
 import org.springframework.http.HttpStatus
@@ -32,6 +31,7 @@ class CohortDriftService(
     private val cohortRepo: CohortRepository,
     private val memberRepo: CohortMemberRepository,
     private val externalIds: ExternalIdMappingService,
+    private val targetIds: CohortTargetIds,
     private val users: UserService,
 ) : CohortDrift {
 
@@ -39,7 +39,7 @@ class CohortDriftService(
         val cohort = cohortRepo.findBySubjectIdAndSystem(subjectId, system.name)
             ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "No $system mapping for subject $subjectId")
 
-        val externalCohortId = externalIds.find(COHORT_AGGREGATE, cohort.id!!, system.name)?.externalId
+        val externalCohortId = targetIds.find(cohort)
             ?: return DriftReport.notMaterialised(cohort.id!!, system)
 
         val allRows = memberRepo.findAllByCohortId(cohort.id!!)

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortMembershipSyncService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortMembershipSyncService.kt
@@ -1,15 +1,16 @@
 package net.blueshell.api.platform.integration.cohort.application
 
 import net.blueshell.api.platform.integration.cohort.application.ledger.CohortLedger
+import net.blueshell.api.platform.integration.cohort.persistence.Cohort
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
 import net.blueshell.api.platform.integration.cohort.port.`in`.CohortMembershipSync
 import net.blueshell.api.platform.integration.cohort.port.`in`.SyncCohortMembershipIntent
 import net.blueshell.api.platform.integration.cohort.port.out.CohortPort
 import net.blueshell.api.platform.integration.cohort.port.out.CohortPortRegistry
 import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService
-import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.COHORT_AGGREGATE
 import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.USER_AGGREGATE
 import net.blueshell.api.platform.integration.sync.port.TargetSystem
+import net.blueshell.api.shared.job.CohortJobs
 import net.blueshell.api.shared.job.ContactJobs
 import net.blueshell.api.shared.job.NonRetryableJobException
 import net.blueshell.api.shared.job.TrackedJobDispatcher
@@ -23,16 +24,18 @@ import java.time.LocalDateTime
 
 /**
  * Application implementation of the [CohortMembershipSync] inbound
- * port. Drives one `(user, cohort)` sync end-to-end: resolves the
- * external ids through the unified `external_id_mapping` table,
- * picks the right [CohortPort] for the cohort's system, lazily
- * materialises the cohort's external counterpart on first `ADD`,
- * and asks the outbound port to apply the change.
+ * port. Drives one `(user, cohort)` sync end-to-end: resolves the user
+ * external id, resolves the cohort target id through [CohortTargetIds],
+ * picks the right [CohortPort] for the cohort's system, and asks the
+ * outbound port to apply the change.
  *
  * Recovery semantics:
  * - `ADD` with no user external id enqueues `SyncContact` and throws
  *   a retryable exception so the retry picks up after the contact
  *   has materialised externally.
+ * - `ADD` with no cohort target id enqueues `cohort.materialize-target`
+ *   and throws a retryable exception — it never creates the target
+ *   itself, so two racing ADDs cannot create two remote targets.
  * - `REMOVE` with no external state on either side is a no-op —
  *   there is nothing to converge to.
  */
@@ -42,6 +45,7 @@ class CohortMembershipSyncService(
     private val ledger: CohortLedger,
     private val registry: CohortPortRegistry,
     private val externalIds: ExternalIdMappingService,
+    private val targetIds: CohortTargetIds,
     private val jobs: TrackedJobDispatcher,
     transactionManager: PlatformTransactionManager,
 ) : CohortMembershipSync {
@@ -66,12 +70,14 @@ class CohortMembershipSyncService(
         val port = registry.require(system)
 
         when (intent) {
-            SyncCohortMembershipIntent.ADD -> add(userId, cohort.id!!, cohort.label, cohort.system, port)
-            SyncCohortMembershipIntent.REMOVE -> remove(userId, cohort.id!!, cohort.system, port)
+            SyncCohortMembershipIntent.ADD -> add(userId, cohort, port)
+            SyncCohortMembershipIntent.REMOVE -> remove(userId, cohort, port)
         }
     }
 
-    private fun add(userId: Long, cohortId: Long, cohortLabel: String, system: String, port: CohortPort) {
+    private fun add(userId: Long, cohort: Cohort, port: CohortPort) {
+        val cohortId = cohort.id!!
+        val system = cohort.system
         val externalUserId = externalIds.find(USER_AGGREGATE, userId, system)?.externalId
         if (externalUserId == null) {
             jobs.enqueue(ContactJobs.SyncContact, ContactJobs.SyncContactPayload(userId))
@@ -79,7 +85,13 @@ class CohortMembershipSyncService(
                 "user $userId has no $system external id — enqueued SyncContact, will retry",
             )
         }
-        val externalCohortId = findOrCreateExternalCohortId(cohortId, cohortLabel, system, port)
+        val externalCohortId = targetIds.find(cohort)
+        if (externalCohortId == null) {
+            jobs.enqueue(CohortJobs.MaterializeCohortTarget, CohortJobs.MaterializeCohortTargetPayload(cohortId))
+            throw CohortMembershipNotReadyException(
+                "cohort $cohortId has no $system target — enqueued materialize-target, will retry",
+            )
+        }
         outsideTransaction.executeWithoutResult { port.addMember(externalUserId, externalCohortId) }
 
         // Stamp the ledger so the desired row reads as synced. This is the
@@ -90,9 +102,11 @@ class CohortMembershipSyncService(
         log.debug("Added user {} to {} cohort {} (ext={})", userId, system, cohortId, externalCohortId)
     }
 
-    private fun remove(userId: Long, cohortId: Long, system: String, port: CohortPort) {
+    private fun remove(userId: Long, cohort: Cohort, port: CohortPort) {
+        val cohortId = cohort.id!!
+        val system = cohort.system
         val externalUserId = externalIds.find(USER_AGGREGATE, userId, system)?.externalId
-        val externalCohortId = externalIds.find(COHORT_AGGREGATE, cohortId, system)?.externalId
+        val externalCohortId = targetIds.find(cohort)
         if (externalUserId == null || externalCohortId == null) {
             log.debug(
                 "No $system external ids for user {} / cohort {} — skipping removal",
@@ -102,25 +116,6 @@ class CohortMembershipSyncService(
         }
         outsideTransaction.executeWithoutResult { port.removeMember(externalUserId, externalCohortId) }
         log.debug("Removed user {} from {} cohort {} (ext={})", userId, system, cohortId, externalCohortId)
-    }
-
-    /**
-     * Returns the cohort's external id on `system`, creating the external
-     * counterpart through [CohortPort.createCohort] on first use and
-     * recording the new id in `external_id_mapping`. Mirrors the existing
-     * `findOrCreateList` lazy-resolution idiom.
-     */
-    private fun findOrCreateExternalCohortId(
-        cohortId: Long,
-        cohortLabel: String,
-        system: String,
-        port: CohortPort,
-    ): String {
-        externalIds.find(COHORT_AGGREGATE, cohortId, system)?.externalId?.let { return it }
-        log.info("Creating $system cohort {} ('{}') externally", cohortId, cohortLabel)
-        val created = outsideTransaction.execute { port.createCohort(cohortLabel) }!!
-        externalIds.upsert(COHORT_AGGREGATE, cohortId, system, created)
-        return created
     }
 
     companion object {

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortQueryService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortQueryService.kt
@@ -8,8 +8,6 @@ import net.blueshell.api.platform.integration.cohort.persistence.CohortRule
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortMemberRepository
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRuleRepository
-import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService
-import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.COHORT_AGGREGATE
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -28,7 +26,7 @@ class CohortQueryService(
     private val cohortMembers: CohortMemberRepository,
     private val cohortRules: CohortRuleRepository,
     private val users: UserService,
-    private val externalIds: ExternalIdMappingService,
+    private val targetIds: CohortTargetIds,
 ) {
     @Transactional(readOnly = true)
     fun summaries(): List<CohortSummary> =
@@ -36,7 +34,7 @@ class CohortQueryService(
             CohortSummary(
                 cohort = cohort,
                 memberCount = cohortMembers.findAllByCohortIdAndUserIdIsNotNull(cohort.id!!).size,
-                externalId = externalIds.find(COHORT_AGGREGATE, cohort.id!!, cohort.system)?.externalId,
+                externalId = targetIds.find(cohort),
             )
         }
 
@@ -61,7 +59,7 @@ class CohortQueryService(
 
         return CohortDetail(
             cohort = cohort,
-            externalId = externalIds.find(COHORT_AGGREGATE, cohortId, cohort.system)?.externalId,
+            externalId = targetIds.find(cohort),
             members = members.map { member ->
                 CohortMemberRow(
                     member = member,

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRemediationService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRemediationService.kt
@@ -11,7 +11,6 @@ import net.blueshell.api.platform.integration.cohort.port.`in`.SyncCohortMembers
 import net.blueshell.api.platform.integration.cohort.port.out.CohortPortRegistry
 import net.blueshell.api.platform.integration.cohort.port.out.MemberRef
 import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService
-import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.COHORT_AGGREGATE
 import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.USER_AGGREGATE
 import net.blueshell.api.platform.integration.sync.persistence.ExternalIdMapping
 import net.blueshell.api.platform.integration.sync.port.TargetSystem
@@ -42,6 +41,7 @@ class CohortRemediationService(
     private val memberRepo: CohortMemberRepository,
     private val ledger: CohortLedger,
     private val externalIds: ExternalIdMappingService,
+    private val targetIds: CohortTargetIds,
     private val registry: CohortPortRegistry,
     private val jobs: TrackedJobDispatcher,
     transactionManager: PlatformTransactionManager,
@@ -74,8 +74,7 @@ class CohortRemediationService(
             NonRetryableJobException("Cohort $cohortId not found")
         }
         val system = TargetSystem.valueOf(cohort.system)
-        val externalCohortId = externalIds.find(COHORT_AGGREGATE, cohortId, cohort.system)?.externalId
-            ?: throw NonRetryableJobException("Cohort $cohortId has no external id on $system")
+        val externalCohortId = targetIds.require(cohort)
 
         outsideTransaction.executeWithoutResult { registry.require(system).removeMember(externalUserId, externalCohortId) }
         ledger.removeStranger(cohortId, externalUserId)
@@ -102,8 +101,7 @@ class CohortRemediationService(
             NonRetryableJobException("Cohort $cohortId references missing subject $subjectId")
         }
         val system = TargetSystem.valueOf(cohort.system)
-        val externalCohortId = externalIds.find(COHORT_AGGREGATE, cohortId, cohort.system)?.externalId
-            ?: throw NonRetryableJobException("Cohort $cohortId has no external id on $system")
+        val externalCohortId = targetIds.require(cohort)
 
         val desiredUserIds = memberRepo.findAllByCohortIdAndUserIdIsNotNull(cohortId)
             .mapNotNull { it.userId }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortSubjectQueryService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortSubjectQueryService.kt
@@ -11,8 +11,6 @@ import net.blueshell.api.platform.integration.cohort.persistence.repository.Coho
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRuleRepository
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortSubjectRepository
-import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService
-import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.COHORT_AGGREGATE
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -31,7 +29,7 @@ class CohortSubjectQueryService(
     private val cohortMembers: CohortMemberRepository,
     private val cohortRules: CohortRuleRepository,
     private val users: UserService,
-    private val externalIds: ExternalIdMappingService,
+    private val targetIds: CohortTargetIds,
 ) {
     @Transactional(readOnly = true)
     fun summaries(): List<CohortSubjectSummary> {
@@ -60,7 +58,7 @@ class CohortSubjectQueryService(
         val mappings = cohorts.findAllBySubjectId(subjectId).map { cohort ->
             CohortMappingRow(
                 cohort = cohort,
-                externalId = externalIds.find(COHORT_AGGREGATE, cohort.id!!, cohort.system)?.externalId,
+                externalId = targetIds.find(cohort),
             )
         }.sortedBy { it.cohort.system }
 

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortTargetIds.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortTargetIds.kt
@@ -1,0 +1,61 @@
+package net.blueshell.api.platform.integration.cohort.application
+
+import net.blueshell.api.platform.integration.cohort.persistence.Cohort
+import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
+import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService
+import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.COHORT_AGGREGATE
+import net.blueshell.api.shared.job.NonRetryableJobException
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.server.ResponseStatusException
+
+/**
+ * Sole owner of a cohort's external target id. Reads it from
+ * [Cohort.externalId], falling back to the legacy
+ * `external_id_mapping(aggregate_type='COHORT')` row for cohorts an older
+ * replica wrote during a deploy overlap. Item 8 runs the final backfill and
+ * drops the fallback.
+ *
+ * This is field ownership, not a use case, so it is a plain component rather
+ * than an inbound port: every cohort path that needs the target id resolves
+ * it here, and [record] is the only writer of the column.
+ */
+@Component
+class CohortTargetIds(
+    private val externalIds: ExternalIdMappingService,
+    private val cohorts: CohortRepository,
+) {
+    /**
+     * The cohort's target id — the column first, then the legacy mapping.
+     * Read-only: never back-fills the column, so read-only callers stay so.
+     */
+    fun find(cohort: Cohort): String? =
+        cohort.externalId?.takeIf { it.isNotBlank() }
+            ?: externalIds.find(COHORT_AGGREGATE, cohort.id!!, cohort.system)?.externalId
+
+    /** The target id, or a terminal failure when the cohort is not materialised. */
+    fun require(cohort: Cohort): String =
+        find(cohort) ?: throw NonRetryableJobException("Cohort ${cohort.id} has no external id on ${cohort.system}")
+
+    /**
+     * Records [externalId] as this cohort's target. Rejects blanks and refuses
+     * to point a second active cohort at an id already in use. Writes the
+     * column and keeps the legacy mapping in step for the compatibility window.
+     */
+    @Transactional
+    fun record(cohort: Cohort, externalId: String): Cohort {
+        require(externalId.isNotBlank()) { "Cohort external id must not be blank" }
+        val owner = cohorts.findFirstBySystemAndExternalId(cohort.system, externalId)
+        if (owner != null && owner.id != cohort.id) {
+            throw ResponseStatusException(
+                HttpStatus.CONFLICT,
+                "${cohort.system} target $externalId is already linked to cohort ${owner.id}",
+            )
+        }
+        cohort.externalId = externalId
+        val saved = cohorts.save(cohort)
+        externalIds.upsert(COHORT_AGGREGATE, cohort.id!!, cohort.system, externalId)
+        return saved
+    }
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortTargetingService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortTargetingService.kt
@@ -5,11 +5,11 @@ import net.blueshell.api.platform.integration.cohort.persistence.CohortKind
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortSubjectRepository
 import net.blueshell.api.platform.integration.cohort.port.`in`.CohortTargeting
+import net.blueshell.api.platform.integration.cohort.port.`in`.CohortTargetRef
 import net.blueshell.api.platform.integration.cohort.port.out.CohortPortRegistry
-import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService
-import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.COHORT_AGGREGATE
 import net.blueshell.api.platform.integration.sync.port.TargetSystem
 import net.blueshell.api.shared.job.CohortJobs
+import net.blueshell.api.shared.job.NonRetryableJobException
 import net.blueshell.api.shared.job.TrackedJobDispatcher
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
@@ -19,27 +19,27 @@ import org.springframework.transaction.support.TransactionTemplate
 import org.springframework.web.server.ResponseStatusException
 
 /**
- * Application implementation of [CohortTargeting]. External target
- * creation runs outside any DB transaction (the PR A reconcile pattern);
- * the local `Cohort` row and its `external_id_mapping` are persisted in a
- * short write transaction afterwards so a provider failure leaves no
- * orphan mapping.
+ * Application implementation of [CohortTargeting]. External target creation
+ * runs outside any DB transaction; the local `Cohort` row and its external id
+ * are persisted in a short write transaction afterwards so a provider failure
+ * leaves no half-written row. [CohortTargetIds] owns every write of the id.
  */
 @Service
 class CohortTargetingService(
     private val cohortRepo: CohortRepository,
     private val subjectRepo: CohortSubjectRepository,
-    private val externalIds: ExternalIdMappingService,
+    private val targetIds: CohortTargetIds,
     private val registry: CohortPortRegistry,
     private val jobs: TrackedJobDispatcher,
     transactionManager: PlatformTransactionManager,
 ) : CohortTargeting {
 
+    private val readOnlyTransaction = TransactionTemplate(transactionManager).apply { isReadOnly = true }
     private val writeTransaction = TransactionTemplate(transactionManager)
 
     // Suspends any active transaction (e.g. the one AbstractJsonJobHandler opens
-    // around deleteTarget) so provider HTTP calls hold no DB connection —
-    // ADR-006/ADR-023.
+    // around deleteTarget / materialize) so provider HTTP calls hold no DB
+    // connection — ADR-006/ADR-023.
     private val outsideTransaction = TransactionTemplate(transactionManager).apply {
         propagationBehavior = TransactionDefinition.PROPAGATION_NOT_SUPPORTED
     }
@@ -49,7 +49,7 @@ class CohortTargetingService(
             val subject = requireSubject(subjectId)
             requireNoExistingMapping(subjectId, system)
             val cohort = cohortRepo.save(newCohort(system, subject.label, folder = null, subjectId = subjectId))
-            externalIds.upsert(COHORT_AGGREGATE, cohort.id!!, system.name, externalId)
+            targetIds.record(cohort, externalId)
             CohortMappingRow(cohort, externalId)
         }!!
 
@@ -65,12 +65,13 @@ class CohortTargetingService(
 
         return writeTransaction.execute {
             val cohort = cohortRepo.save(newCohort(system, label, folder = folderHint, subjectId = subjectId))
-            externalIds.upsert(COHORT_AGGREGATE, cohort.id!!, system.name, externalId)
+            targetIds.record(cohort, externalId)
             CohortMappingRow(cohort, externalId)
         }!!
     }
 
     override fun switchTarget(
+        subjectId: Long,
         cohortId: Long,
         externalId: String,
         deletePrevious: Boolean,
@@ -80,9 +81,14 @@ class CohortTargetingService(
             val cohort = cohortRepo.findById(cohortId).orElseThrow {
                 ResponseStatusException(HttpStatus.NOT_FOUND, "Cohort $cohortId not found")
             }
+            // The route carries the subject id; reject a cohort that is not its
+            // target so a wrong-path admin call cannot repoint another subject's.
+            if (cohort.subjectId != subjectId) {
+                throw ResponseStatusException(HttpStatus.NOT_FOUND, "Cohort $cohortId is not a target of subject $subjectId")
+            }
             val system = TargetSystem.valueOf(cohort.system)
-            val previousExternalId = externalIds.find(COHORT_AGGREGATE, cohortId, cohort.system)?.externalId
-            externalIds.switchCohortTarget(cohortId, system, externalId)
+            val previousExternalId = targetIds.find(cohort)
+            targetIds.record(cohort, externalId)
             Switched(cohort, system, previousExternalId)
         }!!
 
@@ -96,6 +102,41 @@ class CohortTargetingService(
             jobs.enqueue(CohortJobs.ReconcileList, CohortJobs.ReconcileListPayload(cohortId))
         }
         return CohortMappingRow(switched.cohort, externalId)
+    }
+
+    override fun materialize(cohortId: Long): CohortTargetRef {
+        // Re-check the id first: the job is cohort-deduped, but a target may have
+        // been recorded (admin link, an earlier run) since this job was enqueued.
+        val prep = readOnlyTransaction.execute {
+            val cohort = cohortRepo.findById(cohortId).orElseThrow {
+                NonRetryableJobException("Cohort $cohortId not found")
+            }
+            MaterializePrep(TargetSystem.valueOf(cohort.system), cohort.label, cohort.folder, targetIds.find(cohort))
+        }!!
+        prep.existingExternalId?.let { return CohortTargetRef(cohortId, it) }
+
+        // Pass the folder — the old lazy ADD path created the list with no
+        // folder while admin creation passed it.
+        val created = outsideTransaction.execute { registry.require(prep.system).createCohort(prep.label, prep.folder) }!!
+
+        return writeTransaction.execute {
+            val cohort = cohortRepo.findById(cohortId).orElseThrow {
+                NonRetryableJobException("Cohort $cohortId not found")
+            }
+            targetIds.find(cohort)?.let { return@execute CohortTargetRef(cohortId, it) }
+            try {
+                targetIds.record(cohort, created)
+            } catch (e: Exception) {
+                // The remote target exists but could not be recorded. Fail
+                // terminally carrying its id so an operator links it, rather
+                // than letting retries create a second remote target.
+                throw NonRetryableJobException(
+                    "Created ${prep.system} target '$created' for cohort $cohortId but could not record it; link it manually",
+                    e,
+                )
+            }
+            CohortTargetRef(cohortId, created)
+        }!!
     }
 
     override fun deleteTarget(system: TargetSystem, externalTargetId: String) {
@@ -132,4 +173,11 @@ class CohortTargetingService(
     }
 
     private data class Switched(val cohort: Cohort, val system: TargetSystem, val previousExternalId: String?)
+
+    private data class MaterializePrep(
+        val system: TargetSystem,
+        val label: String,
+        val folder: String?,
+        val existingExternalId: String?,
+    )
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortVerificationScheduler.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortVerificationScheduler.kt
@@ -1,8 +1,6 @@
 package net.blueshell.api.platform.integration.cohort.application
 
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
-import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService
-import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.COHORT_AGGREGATE
 import net.blueshell.api.shared.job.CohortJobs
 import net.blueshell.api.shared.job.TrackedJobDispatcher
 import org.slf4j.LoggerFactory
@@ -19,13 +17,13 @@ import org.springframework.stereotype.Component
 @Component
 class CohortVerificationScheduler(
     private val cohorts: CohortRepository,
-    private val externalIds: ExternalIdMappingService,
+    private val targetIds: CohortTargetIds,
     private val jobs: TrackedJobDispatcher,
 ) {
     @Scheduled(cron = "\${cohort.verify-cron:0 0 3 * * *}")
     fun verifyAllCohorts() {
         val mapped = cohorts.findAll().filter { cohort ->
-            externalIds.find(COHORT_AGGREGATE, cohort.id!!, cohort.system) != null
+            targetIds.find(cohort) != null
         }
         log.info("Scheduling reconcile for {} externally-mapped cohorts", mapped.size)
         mapped.forEach { jobs.enqueue(CohortJobs.ReconcileList, CohortJobs.ReconcileListPayload(it.id!!)) }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/persistence/Cohort.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/persistence/Cohort.kt
@@ -13,10 +13,11 @@ import org.hibernate.annotations.SQLRestriction
 /**
  * A named group on one external system: a defined population of users
  * sharing one or more facts. Brevo lists, Discord roles and Google
- * groups all map to one row here. The native-side id lives in the
- * existing `external_id_mapping` table with `aggregate_type='COHORT'`,
- * so a brand-new cohort can exist locally before it has been
- * materialised externally (and adapters create it lazily on first use).
+ * groups all map to one row here. The native-side id lives in
+ * [externalId] (owned by `CohortTargetIds`), which is `null` until the
+ * cohort has been materialised externally by the `cohort.materialize-target`
+ * job. During the compatibility window `CohortTargetIds` also falls back to
+ * the legacy `external_id_mapping` row with `aggregate_type='COHORT'`.
  *
  * `system` is stored as a plain string holding a `TargetSystem.name()`;
  * the persistence layer cannot depend on the `sync.port` package per the
@@ -64,4 +65,12 @@ class Cohort(
      */
     @Column(name = "subject_id", nullable = true)
     var subjectId: Long? = null,
+
+    /**
+     * Native id of this cohort's target on [system] (e.g. a Brevo list id).
+     * `null` until materialised. Written only through `CohortTargetIds`;
+     * `1024` matches the widened `external_id_mapping.external_id` (V61).
+     */
+    @Column(name = "external_id", nullable = true, length = 1024)
+    var externalId: String? = null,
 ) : AuditedAutoIdEntity()

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/persistence/repository/CohortRepository.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/persistence/repository/CohortRepository.kt
@@ -19,4 +19,7 @@ interface CohortRepository : BaseRepository<Cohort, Long> {
     fun findAllBySubjectId(subjectId: Long): List<Cohort>
 
     fun findBySubjectIdAndSystem(subjectId: Long, system: String): Cohort?
+
+    /** Active cohort already owning [externalId] on [system], if any (CohortTargetIds uniqueness guard). */
+    fun findFirstBySystemAndExternalId(system: String, externalId: String): Cohort?
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/port/in/CohortTargeting.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/port/in/CohortTargeting.kt
@@ -31,12 +31,30 @@ interface CohortTargeting {
     fun create(subjectId: Long, system: TargetSystem, label: String, folderHint: String?): CohortMappingRow
 
     /**
-     * Repoints [cohortId]'s external mapping at [externalId], keeping the
-     * same local `Cohort` row. Optionally enqueues `cohort.delete-external-
-     * target` for the previous target and `cohort.reconcile-list` for the
-     * new one.
+     * Repoints [cohortId]'s external target at [externalId], keeping the same
+     * local `Cohort` row. [subjectId] is the subject the cohort must belong to
+     * (the route carries it); a mismatch is rejected so a wrong-path admin call
+     * cannot repoint another subject's cohort. Optionally enqueues
+     * `cohort.delete-external-target` for the previous target and
+     * `cohort.reconcile-list` for the new one.
      */
-    fun switchTarget(cohortId: Long, externalId: String, deletePrevious: Boolean, reconcileNow: Boolean): CohortMappingRow
+    fun switchTarget(
+        subjectId: Long,
+        cohortId: Long,
+        externalId: String,
+        deletePrevious: Boolean,
+        reconcileNow: Boolean,
+    ): CohortMappingRow
+
+    /**
+     * Materialises [cohortId]'s external target: re-checks the id, and only when
+     * still missing creates it through the
+     * [net.blueshell.api.platform.integration.cohort.port.out.CohortPort]
+     * (passing the cohort's folder) and records it. Driven by the
+     * `cohort.materialize-target` job, which is deduplicated per cohort so only
+     * one create runs. Idempotent: returns the existing id when already set.
+     */
+    fun materialize(cohortId: Long): CohortTargetRef
 
     /**
      * Deletes an external target. Driven by
@@ -45,3 +63,6 @@ interface CohortTargeting {
      */
     fun deleteTarget(system: TargetSystem, externalTargetId: String)
 }
+
+/** Result of [CohortTargeting.materialize]: a cohort and its resolved target id. */
+data class CohortTargetRef(val cohortId: Long, val externalId: String)

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/sync/application/ExternalIdMappingService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/sync/application/ExternalIdMappingService.kt
@@ -58,13 +58,6 @@ class ExternalIdMappingService(
         return repository.findByAggregateTypeAndAggregateIdAndSystem(USER_AGGREGATE, userId, system.name)!!
     }
 
-    /** Updates the mapping row for [cohortId]/[system] to point at [externalTargetId]. */
-    @Transactional
-    fun switchCohortTarget(cohortId: Long, system: TargetSystem, externalTargetId: String): ExternalIdMapping {
-        upsert(COHORT_AGGREGATE, cohortId, system.name, externalTargetId)
-        return repository.findByAggregateTypeAndAggregateIdAndSystem(COHORT_AGGREGATE, cohortId, system.name)!!
-    }
-
     companion object {
         const val USER_AGGREGATE = "USER"
         const val COHORT_AGGREGATE = "COHORT"

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/sync/persistence/ExternalIdMapping.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/sync/persistence/ExternalIdMapping.kt
@@ -23,7 +23,7 @@ class ExternalIdMapping(
     @Column(name = "system", nullable = false, length = 64)
     val system: String,
 
-    @Column(name = "external_id", length = 255)
+    @Column(name = "external_id", length = 1024)
     var externalId: String? = null,
 
     @Column(name = "synced_version")

--- a/services/api/src/main/kotlin/net/blueshell/api/shared/job/CohortJobs.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/shared/job/CohortJobs.kt
@@ -94,6 +94,19 @@ object CohortJobs {
             DeleteExternalTargetPayload::class.java
     }
 
+    /**
+     * Creates one cohort's external target when it has none yet, and records
+     * the new id. Enqueued by a per-member ADD that found no target id, so the
+     * ADD can retry once the target exists. Deduplicated by cohort id, so only
+     * one create runs per cohort however many ADDs raced.
+     */
+    object MaterializeCohortTarget : JobDefinition<MaterializeCohortTargetPayload> {
+        override val type: String = "cohort.materialize-target"
+        override val payloadType: Class<MaterializeCohortTargetPayload> =
+            MaterializeCohortTargetPayload::class.java
+        override fun dedupKey(payload: MaterializeCohortTargetPayload): String = "cohort=${payload.cohortId}"
+    }
+
     data class SyncCohortMembershipPayload(
         val userId: Long,
         val cohortId: Long,
@@ -107,4 +120,5 @@ object CohortJobs {
     data class ReconcileListPayload(val cohortId: Long)
     /** `system` holds a `TargetSystem.name()`; shared/job cannot depend on the sync.port package. */
     data class DeleteExternalTargetPayload(val system: String, val externalTargetId: String)
+    data class MaterializeCohortTargetPayload(val cohortId: Long)
 }

--- a/services/api/src/main/resources/db/migration/V77__cohort_external_id.sql
+++ b/services/api/src/main/resources/db/migration/V77__cohort_external_id.sql
@@ -1,0 +1,26 @@
+-- Move the per-target external id onto the cohort row itself. Until item 8
+-- removes the fallback, cohort code reads cohort.external_id first and falls
+-- back to the legacy external_id_mapping(aggregate_type='COHORT') row, so a
+-- replica running older code keeps resolving during the deploy overlap.
+--
+-- Preflight (run manually before deploy): CohortTargetIds treats
+-- (system, external_id) as a single owner. Confirm the legacy mapping holds no
+-- duplicate (system, external_id) for COHORT first — resolve any rows it
+-- returns before deploying:
+--
+--   SELECT system, external_id, COUNT(*) AS cnt
+--   FROM external_id_mapping
+--   WHERE aggregate_type = 'COHORT' AND external_id IS NOT NULL
+--   GROUP BY system, external_id HAVING COUNT(*) > 1;
+
+ALTER TABLE cohort ADD COLUMN external_id VARCHAR(1024) NULL;
+
+UPDATE cohort c
+JOIN external_id_mapping m
+  ON m.aggregate_type = 'COHORT' AND m.aggregate_id = c.id AND m.system = c.system
+SET c.external_id = m.external_id
+WHERE c.external_id IS NULL;
+
+-- 191-char prefix keeps the key within the utf8mb4 index-length limit;
+-- external_id is far shorter in practice (a Brevo list id).
+CREATE INDEX idx_cohort_external_id ON cohort (system, external_id(191), deleted_at);

--- a/services/api/src/test/kotlin/net/blueshell/api/architecture/CohortTargetIdOwnershipTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/architecture/CohortTargetIdOwnershipTest.kt
@@ -1,0 +1,35 @@
+package net.blueshell.api.architecture
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * `CohortTargetIds` is the single owner of a cohort's external target id.
+ * Other cohort code resolves the id through it rather than reaching into the
+ * legacy `external_id_mapping(aggregate_type='COHORT')` directly.
+ *
+ * `COHORT_AGGREGATE` is a `const val`, so a reference is inlined at compile
+ * time and ArchUnit cannot see it as a dependency — hence a source scan.
+ * Item 8 removes the legacy fallback; until then this stops the indirection
+ * leaking back into other cohort classes.
+ */
+class CohortTargetIdOwnershipTest {
+
+    @Test
+    fun `only CohortTargetIds references COHORT_AGGREGATE in cohort code`() {
+        val root = listOf(
+            File("src/main/kotlin/net/blueshell/api/platform/integration/cohort"),
+            File("services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort"),
+        ).firstOrNull { it.isDirectory }
+            ?: error("cohort source root not found from ${File("").absolutePath}")
+
+        val referencingFiles = root.walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .filter { it.readText().contains("COHORT_AGGREGATE") }
+            .map { it.name }
+            .toList()
+
+        assertThat(referencingFiles).containsExactly("CohortTargetIds.kt")
+    }
+}

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortDriftServiceTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortDriftServiceTest.kt
@@ -25,8 +25,9 @@ class CohortDriftServiceTest {
     private val cohorts: CohortRepository = mockk()
     private val members: CohortMemberRepository = mockk()
     private val externalIds: ExternalIdMappingService = mockk()
+    private val targetIds: CohortTargetIds = mockk()
     private val users: UserService = mockk()
-    private val service = CohortDriftService(cohorts, members, externalIds, users)
+    private val service = CohortDriftService(cohorts, members, externalIds, targetIds, users)
 
     @Test
     fun `compute classifies ledger rows without external port calls`() {
@@ -34,8 +35,7 @@ class CohortDriftServiceTest {
         val cohort = cohort(99L, subject.id!!)
         val lastObserved = LocalDateTime.parse("2026-05-03T10:15:30")
         every { cohorts.findBySubjectIdAndSystem(7L, TargetSystem.BREVO.name) } returns cohort
-        every { externalIds.find("COHORT", 99L, TargetSystem.BREVO.name) } returns
-            ExternalIdMapping("COHORT", 99L, TargetSystem.BREVO.name, "list-99")
+        every { targetIds.find(any()) } returns "list-99"
         every { members.findAllByCohortId(99L) } returns listOf(
             member(cohort, subject, userId = 1L),
             member(cohort, subject, userId = 2L),
@@ -101,7 +101,7 @@ class CohortDriftServiceTest {
         val subject = subject(7L)
         val cohort = cohort(99L, subject.id!!)
         every { cohorts.findBySubjectIdAndSystem(7L, TargetSystem.BREVO.name) } returns cohort
-        every { externalIds.find("COHORT", 99L, TargetSystem.BREVO.name) } returns null
+        every { targetIds.find(any()) } returns null
 
         val report = service.compute(7L, TargetSystem.BREVO)
 

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortMembershipSyncServiceTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortMembershipSyncServiceTest.kt
@@ -13,6 +13,7 @@ import net.blueshell.api.platform.integration.cohort.port.out.CohortPortRegistry
 import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService
 import net.blueshell.api.platform.integration.sync.persistence.ExternalIdMapping
 import net.blueshell.api.platform.integration.sync.port.TargetSystem
+import net.blueshell.api.shared.job.CohortJobs
 import net.blueshell.api.shared.job.ContactJobs
 import net.blueshell.api.shared.job.NonRetryableJobException
 import net.blueshell.api.shared.job.TrackedJobDispatcher
@@ -28,12 +29,14 @@ class CohortMembershipSyncServiceTest {
         every { system } returns TargetSystem.BREVO
     }
     private val externalIds: ExternalIdMappingService = mockk(relaxed = true)
+    private val targetIds: CohortTargetIds = mockk(relaxed = true)
     private val jobs: TrackedJobDispatcher = mockk(relaxed = true)
     private val service = CohortMembershipSyncService(
         cohorts = cohorts,
         ledger = ledger,
         registry = CohortPortRegistry(listOf(brevoPort)),
         externalIds = externalIds,
+        targetIds = targetIds,
         jobs = jobs,
         // A relaxed manager still runs the TransactionTemplate callbacks; the
         // real no-active-transaction guarantee is asserted in
@@ -49,7 +52,7 @@ class CohortMembershipSyncServiceTest {
     fun `ADD calls port when both external ids exist`() {
         givenCohort(id = 10L, system = "BREVO", label = "Members")
         every { externalIds.find("USER", 1L, "BREVO") } returns mapping("USER", 1L, "BREVO", "777")
-        every { externalIds.find("COHORT", 10L, "BREVO") } returns mapping("COHORT", 10L, "BREVO", "42")
+        every { targetIds.find(any()) } returns "42"
 
         service.sync(userId = 1L, cohortId = 10L, intent = SyncCohortMembershipIntent.ADD)
 
@@ -57,24 +60,27 @@ class CohortMembershipSyncServiceTest {
     }
 
     @Test
-    fun `ADD lazy-creates the cohort externally on first use and stores its id`() {
+    fun `ADD without a cohort target enqueues materialize-target, throws retryable and never creates a target`() {
         givenCohort(id = 10L, system = "BREVO", label = "Members")
         every { externalIds.find("USER", 1L, "BREVO") } returns mapping("USER", 1L, "BREVO", "777")
-        every { externalIds.find("COHORT", 10L, "BREVO") } returns null
-        every { brevoPort.createCohort("Members", null) } returns "99"
+        every { targetIds.find(any()) } returns null
 
-        service.sync(userId = 1L, cohortId = 10L, intent = SyncCohortMembershipIntent.ADD)
+        assertThatThrownBy {
+            service.sync(userId = 1L, cohortId = 10L, intent = SyncCohortMembershipIntent.ADD)
+        }.isInstanceOf(CohortMembershipNotReadyException::class.java)
 
-        verify { brevoPort.createCohort("Members", null) }
-        verify { externalIds.upsert("COHORT", 10L, "BREVO", "99") }
-        verify { brevoPort.addMember("777", "99") }
+        verify {
+            jobs.enqueue(CohortJobs.MaterializeCohortTarget, CohortJobs.MaterializeCohortTargetPayload(10L))
+        }
+        verify(exactly = 0) { brevoPort.addMember(any(), any()) }
+        verify(exactly = 0) { brevoPort.createCohort(any(), any()) }
     }
 
     @Test
     fun `ADD marks the desired row pushed after a successful external add`() {
         givenCohort(id = 10L, system = "BREVO", label = "Members")
         every { externalIds.find("USER", 1L, "BREVO") } returns mapping("USER", 1L, "BREVO", "777")
-        every { externalIds.find("COHORT", 10L, "BREVO") } returns mapping("COHORT", 10L, "BREVO", "42")
+        every { targetIds.find(any()) } returns "42"
 
         service.sync(userId = 1L, cohortId = 10L, intent = SyncCohortMembershipIntent.ADD)
 
@@ -101,7 +107,7 @@ class CohortMembershipSyncServiceTest {
     fun `REMOVE calls port when both external ids exist`() {
         givenCohort(id = 10L, system = "BREVO", label = "Members")
         every { externalIds.find("USER", 1L, "BREVO") } returns mapping("USER", 1L, "BREVO", "777")
-        every { externalIds.find("COHORT", 10L, "BREVO") } returns mapping("COHORT", 10L, "BREVO", "42")
+        every { targetIds.find(any()) } returns "42"
 
         service.sync(userId = 1L, cohortId = 10L, intent = SyncCohortMembershipIntent.REMOVE)
 
@@ -112,7 +118,7 @@ class CohortMembershipSyncServiceTest {
     fun `REMOVE is a no-op when an external id is missing`() {
         givenCohort(id = 10L, system = "BREVO", label = "Members")
         every { externalIds.find("USER", 1L, "BREVO") } returns null
-        every { externalIds.find("COHORT", 10L, "BREVO") } returns null
+        every { targetIds.find(any()) } returns null
 
         service.sync(userId = 1L, cohortId = 10L, intent = SyncCohortMembershipIntent.REMOVE)
 

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRemediationServiceTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortRemediationServiceTest.kt
@@ -37,6 +37,7 @@ class CohortRemediationServiceTest {
     private val subjects: CohortSubjectRepository = mockk()
     private val members: CohortMemberRepository = mockk(relaxed = true)
     private val externalIds: ExternalIdMappingService = mockk()
+    private val targetIds: CohortTargetIds = mockk()
     private val jobs: TrackedJobDispatcher = mockk(relaxed = true)
     private val port = RecordingCohortPort()
     private val service = CohortRemediationService(
@@ -45,6 +46,7 @@ class CohortRemediationServiceTest {
         memberRepo = members,
         ledger = CohortLedger(members),
         externalIds = externalIds,
+        targetIds = targetIds,
         registry = CohortPortRegistry(listOf(port)),
         jobs = jobs,
         transactionManager = ImmediateTransactionManager(),
@@ -86,8 +88,7 @@ class CohortRemediationServiceTest {
 
         every { cohorts.findById(99L) } returns Optional.of(cohort)
         every { subjects.findById(7L) } returns Optional.of(subject)
-        every { externalIds.find("COHORT", 99L, TargetSystem.BREVO.name) } returns
-            ExternalIdMapping("COHORT", 99L, TargetSystem.BREVO.name, "list-99")
+        every { targetIds.require(any()) } returns "list-99"
         every {
             externalIds.findBatch("USER", setOf(1L, 2L, 3L), TargetSystem.BREVO.name)
         } returns listOf(
@@ -151,8 +152,7 @@ class CohortRemediationServiceTest {
             verifiedAt = LocalDateTime.parse("2026-03-01T08:00:00"),
         )
         every { cohorts.findById(99L) } returns Optional.of(cohort)
-        every { externalIds.find("COHORT", 99L, TargetSystem.BREVO.name) } returns
-            ExternalIdMapping("COHORT", 99L, TargetSystem.BREVO.name, "list-99")
+        every { targetIds.require(any()) } returns "list-99"
         every { members.findByCohortIdAndExternalUserIdAndUserIdIsNull(99L, "ext-9") } returns stranger
 
         service.removeExternalMember(99L, "ext-9")

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortTargetIdsTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortTargetIdsTest.kt
@@ -1,0 +1,87 @@
+package net.blueshell.api.platform.integration.cohort.application
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.blueshell.api.platform.integration.cohort.persistence.Cohort
+import net.blueshell.api.platform.integration.cohort.persistence.CohortKind
+import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
+import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService
+import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.COHORT_AGGREGATE
+import net.blueshell.api.platform.integration.sync.persistence.ExternalIdMapping
+import net.blueshell.api.shared.job.NonRetryableJobException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.springframework.web.server.ResponseStatusException
+
+class CohortTargetIdsTest {
+
+    private val externalIds: ExternalIdMappingService = mockk(relaxed = true)
+    private val cohorts: CohortRepository = mockk(relaxed = true)
+    private val targetIds = CohortTargetIds(externalIds, cohorts)
+
+    private fun cohort(id: Long, externalId: String? = null) =
+        Cohort(system = "BREVO", kind = CohortKind.LIST, label = "Members").apply {
+            this.id = id
+            this.externalId = externalId
+        }
+
+    @Test
+    fun `find reads the column first and does not touch the mapping`() {
+        val cohort = cohort(5L, externalId = "col-1")
+
+        assertThat(targetIds.find(cohort)).isEqualTo("col-1")
+        verify(exactly = 0) { externalIds.find(any(), any(), any()) }
+    }
+
+    @Test
+    fun `find falls back to the legacy mapping when the column is blank, without writing`() {
+        val cohort = cohort(5L, externalId = null)
+        every { externalIds.find(COHORT_AGGREGATE, 5L, "BREVO") } returns
+            ExternalIdMapping(COHORT_AGGREGATE, 5L, "BREVO", "legacy-1")
+
+        assertThat(targetIds.find(cohort)).isEqualTo("legacy-1")
+        verify(exactly = 0) { cohorts.save(any()) }
+        verify(exactly = 0) { externalIds.upsert(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `require throws a terminal failure when the cohort is not materialised`() {
+        val cohort = cohort(5L, externalId = null)
+        every { externalIds.find(COHORT_AGGREGATE, 5L, "BREVO") } returns null
+
+        assertThatThrownBy { targetIds.require(cohort) }
+            .isInstanceOf(NonRetryableJobException::class.java)
+    }
+
+    @Test
+    fun `record writes the column and the legacy mapping`() {
+        val cohort = cohort(5L, externalId = null)
+        every { cohorts.findFirstBySystemAndExternalId("BREVO", "list-9") } returns null
+        every { cohorts.save(cohort) } returns cohort
+
+        targetIds.record(cohort, "list-9")
+
+        assertThat(cohort.externalId).isEqualTo("list-9")
+        verify { cohorts.save(cohort) }
+        verify { externalIds.upsert(COHORT_AGGREGATE, 5L, "BREVO", "list-9") }
+    }
+
+    @Test
+    fun `record rejects a blank external id`() {
+        assertThatThrownBy { targetIds.record(cohort(5L), "  ") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+        verify(exactly = 0) { cohorts.save(any()) }
+    }
+
+    @Test
+    fun `record refuses to relink an id already owned by another active cohort`() {
+        val cohort = cohort(5L)
+        every { cohorts.findFirstBySystemAndExternalId("BREVO", "list-9") } returns cohort(99L, "list-9")
+
+        assertThatThrownBy { targetIds.record(cohort, "list-9") }
+            .isInstanceOf(ResponseStatusException::class.java)
+        verify(exactly = 0) { cohorts.save(any()) }
+    }
+}

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortTargetingServiceTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortTargetingServiceTest.kt
@@ -5,8 +5,6 @@ import net.blueshell.api.platform.integration.cohort.persistence.repository.Coho
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortSubjectRepository
 import net.blueshell.api.platform.integration.cohort.port.out.CohortPort
 import net.blueshell.api.platform.integration.cohort.port.out.CohortPortRegistry
-import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService
-import net.blueshell.api.platform.integration.sync.persistence.ExternalIdMapping
 import net.blueshell.api.platform.integration.sync.port.TargetSystem
 import net.blueshell.api.shared.job.CohortJobs
 import net.blueshell.api.shared.job.TrackedJobDispatcher
@@ -29,15 +27,14 @@ import java.util.Optional
 
 /**
  * Unit test for [CohortTargetingService]. The port edges (CohortPort,
- * ExternalIdMappingService, job dispatcher) are the seams — no Spring
- * context. A no-op transaction manager runs the TransactionTemplate
- * callbacks inline.
+ * CohortTargetIds, job dispatcher) are the seams — no Spring context.
+ * A no-op transaction manager runs the TransactionTemplate callbacks inline.
  */
 class CohortTargetingServiceTest {
 
     private val cohortRepo = mock<CohortRepository>()
     private val subjectRepo = mock<CohortSubjectRepository>()
-    private val externalIds = mock<ExternalIdMappingService>()
+    private val targetIds = mock<CohortTargetIds>()
     private val registry = mock<CohortPortRegistry>()
     private val jobs = mock<TrackedJobDispatcher>()
     private val port = mock<CohortPort>()
@@ -48,7 +45,7 @@ class CohortTargetingServiceTest {
         override fun rollback(status: TransactionStatus) {}
     }
 
-    private val service = CohortTargetingService(cohortRepo, subjectRepo, externalIds, registry, jobs, txManager)
+    private val service = CohortTargetingService(cohortRepo, subjectRepo, targetIds, registry, jobs, txManager)
 
     @Test
     fun `create does not touch the provider when the subject already maps the system`() {
@@ -64,7 +61,7 @@ class CohortTargetingServiceTest {
     }
 
     @Test
-    fun `create materialises the target and stores the mapping`() {
+    fun `create materialises the target and records the id`() {
         val saved = mock<Cohort> { on { id } doReturn 42L }
         whenever(subjectRepo.findById(1L)).thenReturn(Optional.of(mock()))
         whenever(cohortRepo.findBySubjectIdAndSystem(1L, "BREVO")).thenReturn(null)
@@ -75,21 +72,52 @@ class CohortTargetingServiceTest {
         val row = service.create(1L, TargetSystem.BREVO, "Members", "Lists")
 
         verify(port).createCohort("Members", "Lists")
-        verify(externalIds).upsert(ExternalIdMappingService.COHORT_AGGREGATE, 42L, "BREVO", "999")
+        verify(targetIds).record(saved, "999")
         assert(row.externalId == "999")
     }
 
     @Test
-    fun `switch enqueues delete-previous and reconcile when asked`() {
-        val cohort = mock<Cohort> { on { system } doReturn "BREVO" }
+    fun `materialize creates the target with the cohort folder and records it`() {
+        val cohort = mock<Cohort> {
+            on { id } doReturn 7L
+            on { system } doReturn "BREVO"
+            on { label } doReturn "Members"
+            on { folder } doReturn "Committees"
+        }
         whenever(cohortRepo.findById(7L)).thenReturn(Optional.of(cohort))
-        whenever(externalIds.find(ExternalIdMappingService.COHORT_AGGREGATE, 7L, "BREVO"))
-            .thenReturn(ExternalIdMapping(ExternalIdMappingService.COHORT_AGGREGATE, 7L, "BREVO", "old-list"))
-        whenever(externalIds.switchCohortTarget(7L, TargetSystem.BREVO, "new-list")).thenReturn(mock<ExternalIdMapping>())
+        whenever(targetIds.find(cohort)).thenReturn(null)
+        whenever(registry.require(TargetSystem.BREVO)).thenReturn(port)
+        whenever(port.createCohort("Members", "Committees")).thenReturn("999")
 
-        service.switchTarget(7L, "new-list", deletePrevious = true, reconcileNow = true)
+        val ref = service.materialize(7L)
 
-        verify(externalIds).switchCohortTarget(7L, TargetSystem.BREVO, "new-list")
+        verify(port).createCohort("Members", "Committees")
+        verify(targetIds).record(cohort, "999")
+        assert(ref.externalId == "999")
+    }
+
+    @Test
+    fun `materialize is a no-op when the target already exists`() {
+        val cohort = mock<Cohort> { on { id } doReturn 7L; on { system } doReturn "BREVO"; on { label } doReturn "Members" }
+        whenever(cohortRepo.findById(7L)).thenReturn(Optional.of(cohort))
+        whenever(targetIds.find(cohort)).thenReturn("existing")
+
+        val ref = service.materialize(7L)
+
+        assert(ref.externalId == "existing")
+        verifyNoInteractions(registry)
+        verify(targetIds, never()).record(any(), any())
+    }
+
+    @Test
+    fun `switch enqueues delete-previous and reconcile when asked`() {
+        val cohort = mock<Cohort> { on { system } doReturn "BREVO"; on { subjectId } doReturn 1L }
+        whenever(cohortRepo.findById(7L)).thenReturn(Optional.of(cohort))
+        whenever(targetIds.find(cohort)).thenReturn("old-list")
+
+        service.switchTarget(1L, 7L, "new-list", deletePrevious = true, reconcileNow = true)
+
+        verify(targetIds).record(cohort, "new-list")
         verify(jobs).enqueue(
             eq(CohortJobs.DeleteExternalTarget),
             eq(CohortJobs.DeleteExternalTargetPayload("BREVO", "old-list")),
@@ -102,15 +130,26 @@ class CohortTargetingServiceTest {
 
     @Test
     fun `switch does not enqueue a delete when there is no previous target`() {
-        val cohort = mock<Cohort> { on { system } doReturn "BREVO" }
+        val cohort = mock<Cohort> { on { system } doReturn "BREVO"; on { subjectId } doReturn 1L }
         whenever(cohortRepo.findById(7L)).thenReturn(Optional.of(cohort))
-        whenever(externalIds.find(ExternalIdMappingService.COHORT_AGGREGATE, 7L, "BREVO")).thenReturn(null)
-        whenever(externalIds.switchCohortTarget(7L, TargetSystem.BREVO, "new-list")).thenReturn(mock<ExternalIdMapping>())
+        whenever(targetIds.find(cohort)).thenReturn(null)
 
-        service.switchTarget(7L, "new-list", deletePrevious = true, reconcileNow = false)
+        service.switchTarget(1L, 7L, "new-list", deletePrevious = true, reconcileNow = false)
 
         verify(jobs, never()).enqueue(eq(CohortJobs.DeleteExternalTarget), any())
         verify(jobs, never()).enqueue(eq(CohortJobs.ReconcileList), any())
+    }
+
+    @Test
+    fun `switch rejects a cohort that is not a target of the path subject`() {
+        val cohort = mock<Cohort> { on { subjectId } doReturn 99L }
+        whenever(cohortRepo.findById(7L)).thenReturn(Optional.of(cohort))
+
+        assertThrows<ResponseStatusException> {
+            service.switchTarget(1L, 7L, "new-list", deletePrevious = false, reconcileNow = false)
+        }
+
+        verify(targetIds, never()).record(any(), any())
     }
 
     @Test


### PR DESCRIPTION
## Why
Every cohort path resolved its external target id through `external_id_mapping(aggregate_type='COHORT')` — an extra lookup on every read and write. A `Cohort` row is already scoped to one system, so the indirection bought nothing. Worse, the lazy-create path raced: two `ADD` jobs for the same brand-new cohort both saw "no target id" and both created a remote target.

## What this achieves
The target id lives on the cohort row, resolved through one owner, and a new cohort's target is created exactly once by a deduplicated job rather than by whichever per-member ADD happens to run first. Two latent bugs are fixed along the way: the lazy path created Brevo lists with no folder, and `switchTarget` ignored the subject in its route.

## How
- `Cohort.external_id` column (V77) owned by `CohortTargetIds`:
  - `find` reads the column first, then falls back to the legacy `COHORT` mapping for rows an older replica wrote during a deploy overlap — never writing from a read path.
  - `require` fails terminally when the cohort is not materialised.
  - `record` rejects blank ids, refuses to relink an id already owned by another active cohort, and writes both the column and the legacy mapping for the compatibility window.
- `CohortMembershipSyncService`, `CohortRemediationService`, `CohortDriftService`, `CohortQueryService`, `CohortSubjectQueryService` and `CohortVerificationScheduler` resolve through `CohortTargetIds`. `CohortTargetIdOwnershipTest` (a source scan, since `COHORT_AGGREGATE` is an inlined `const`) keeps the constant out of the rest of the cohort code. The now-unused `ExternalIdMappingService.switchCohortTarget` is removed so the column has a single writer.
- Per-member `ADD` no longer creates targets: with no target id it enqueues the cohort-deduped `cohort.materialize-target` job and throws the retryable `CohortMembershipNotReadyException`, mirroring how a missing user external id enqueues `SyncContact`. `MaterializeCohortTargetJobHandler` → `CohortTargeting.materialize` re-checks the id, creates through `CohortPort` only when still missing (passing `cohort.folder`), and records it; if the remote target is created but cannot be recorded it fails terminally carrying the id so an operator links it rather than letting retries create a second target. New port use case `materialize(cohortId): CohortTargetRef`.
- `CohortSubjectController.switchTarget` passes the route's `{id}` (subject id) into the service, which rejects a cohort that is not that subject's target (404). `ExternalIdMapping.externalId` length annotation corrected to `1024` (V61 widened the column).

Migration V77 adds the column, backfills it from the legacy mapping, and indexes `(system, external_id, deleted_at)`. The new release reads/writes the column and falls back to the mapping only during deploy overlap; item 8 runs the final backfill and removes the fallback.

Verified locally against a throwaway MariaDB: all 22 cohort integration tests (including the V77 add/backfill/index IT and the switch-wrong-subject IT) and 151 unit/architecture tests pass.