### PR TITLE
refactor(cohort): derive user facts from one shared lazy context

### DIFF
--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/UserFactCollector.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/UserFactCollector.kt
@@ -6,6 +6,7 @@ import net.blueshell.api.domain.contribution.application.ContributionPeriodServi
 import net.blueshell.api.domain.contribution.persistence.ContributionPeriod
 import net.blueshell.api.domain.user.application.UserService
 import net.blueshell.api.domain.user.persistence.Membership
+import net.blueshell.api.domain.user.persistence.User
 import net.blueshell.api.platform.integration.cohort.persistence.CohortFactKind
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,12 +15,16 @@ import java.time.ZoneOffset
 
 /**
  * Computes the set of [UserFact]s currently true for a user, by reading
- * the canonical sources on the [net.blueshell.api.domain.user.persistence.User]
- * entity graph.
+ * the canonical sources on the [User] entity graph.
  *
- * Single place to extend when a new [CohortFactKind] is added. Lazy
- * associations on `User` are walked inside the read-only transaction,
- * so callers can pass just the user id.
+ * The user is loaded once into a [UserFactContext]; each fact kind is a
+ * small private unit deriving from that shared context. Period data is
+ * loaded lazily and only when a membership or committee window makes it
+ * relevant. Single place to extend when a new [CohortFactKind] is added.
+ *
+ * Lazy associations on `User` are walked inside the read-only transaction,
+ * so callers can pass just the user id; the units do not rely on
+ * `hibernate.enable_lazy_load_no_trans`.
  */
 @Service
 class UserFactCollector(
@@ -28,66 +33,81 @@ class UserFactCollector(
     private val committeeMembers: CommitteeMemberService,
 ) {
     @Transactional(readOnly = true)
-    fun collect(userId: Long): Set<UserFact> {
+    fun collect(userId: Long): Set<UserFact> = collect(userId, LocalDate.now())
+
+    /**
+     * Overload taking an explicit [today], so open-ended overlap is
+     * deterministic in tests. Helpers never call `LocalDate.now()` themselves.
+     */
+    @Transactional(readOnly = true)
+    fun collect(userId: Long, today: LocalDate): Set<UserFact> {
         val user = runCatching { users.findById(userId) }.getOrNull() ?: return emptySet()
+        val ctx = UserFactContext(
+            userId = userId,
+            user = user,
+            today = today,
+            periodsLoader = { periods.findAll() },
+            windowsLoader = { committeeMembers.findMembershipWindowsForUser(userId) },
+        )
+        return buildSet {
+            addAll(roleFacts(ctx))
+            addAll(committeeFacts(ctx))
+            addAll(contributionPaidFacts(ctx))
+            addAll(membershipPeriodFacts(ctx))
+            addAll(newsletterFacts(ctx))
+        }
+    }
+
+    /** User.roles is the source of truth — membership/committee/board listeners grant the Role values. */
+    private fun roleFacts(ctx: UserFactContext): Set<UserFact> =
+        ctx.user.roles.mapTo(mutableSetOf()) { UserFact(CohortFactKind.ROLE, it.name) }
+
+    /** One fact per committee the user is currently a member of. */
+    private fun committeeFacts(ctx: UserFactContext): Set<UserFact> =
+        ctx.user.committeeMembers.mapNotNullTo(mutableSetOf()) { membership ->
+            membership.committee.id?.let { UserFact(CohortFactKind.COMMITTEE, it.toString()) }
+        }
+
+    /** One fact per period the user has an active contribution row for (soft-deleted rows filtered by @SQLRestriction). */
+    private fun contributionPaidFacts(ctx: UserFactContext): Set<UserFact> =
+        ctx.user.contributions.mapNotNullTo(mutableSetOf()) { contribution ->
+            contribution.id.contributionPeriodId?.let { UserFact(CohortFactKind.CONTRIBUTION_PAID, it.toString()) }
+        }
+
+    /**
+     * Per-period overlap facts:
+     *   - MEMBER_IN_PERIOD: a [Membership] [startDate, endDate] intersects the period; an open-ended
+     *     membership (endDate=null) extends to [UserFactContext.today].
+     *   - ACTIVE_IN_PERIOD: a committee membership window (including soft-deleted "left on" rows) intersects.
+     *
+     * Loads periods only when there is a membership or window candidate, so a user with neither never
+     * calls `periods.findAll()`.
+     */
+    private fun membershipPeriodFacts(ctx: UserFactContext): Set<UserFact> {
+        val hasMembership = ctx.user.memberships.isNotEmpty()
+        val hasWindow = ctx.committeeWindows.isNotEmpty()
+        if (!hasMembership && !hasWindow) return emptySet()
+
         val facts = mutableSetOf<UserFact>()
-
-        // ROLE: User.roles is the source of truth (membership / committee /
-        // board listeners grant the matching Role values).
-        user.roles.forEach { role ->
-            facts.add(UserFact(CohortFactKind.ROLE, role.name))
-        }
-
-        // COMMITTEE: one fact per committee the user is currently a member of.
-        user.committeeMembers.forEach { membership ->
-            val committeeId = membership.committee.id ?: return@forEach
-            facts.add(UserFact(CohortFactKind.COMMITTEE, committeeId.toString()))
-        }
-
-        // CONTRIBUTION_PAID: one fact per contribution-period the user has
-        // an active contribution row for (soft-deleted rows are filtered
-        // by @SQLRestriction).
-        user.contributions.forEach { contribution ->
-            val periodId = contribution.id.contributionPeriodId ?: return@forEach
-            facts.add(UserFact(CohortFactKind.CONTRIBUTION_PAID, periodId.toString()))
-        }
-
-        // MEMBER_IN_PERIOD / ACTIVE_IN_PERIOD: per-period overlap facts.
-        //   - MEMBER_IN_PERIOD: any Membership row whose [startDate, endDate]
-        //     intersects the period dates. An open-ended membership
-        //     (endDate=null) extends to "today" for overlap purposes.
-        //   - ACTIVE_IN_PERIOD: any committee_members row (including
-        //     soft-deleted ones, which represent "left the committee on
-        //     this date") whose [joinedAt, leftAt] intersects the period.
-        //     Esports-team activity will slot into the same fact kind
-        //     once teams gain a persistence layer.
-        val allPeriods = periods.findAll()
-        if (allPeriods.isNotEmpty()) {
-            val committeeWindows = committeeMembers.findMembershipWindowsForUser(userId)
-
-            allPeriods.forEach { period ->
-                val periodId = period.id ?: return@forEach
-                if (user.memberships.any { it.overlaps(period) }) {
-                    facts.add(UserFact(CohortFactKind.MEMBER_IN_PERIOD, periodId.toString()))
-                }
-                if (committeeWindows.any { it.overlaps(period) }) {
-                    facts.add(UserFact(CohortFactKind.ACTIVE_IN_PERIOD, periodId.toString()))
-                }
+        ctx.periods.forEach { period ->
+            val periodId = period.id ?: return@forEach
+            if (hasMembership && ctx.user.memberships.any { it.overlaps(period, ctx.today) }) {
+                facts.add(UserFact(CohortFactKind.MEMBER_IN_PERIOD, periodId.toString()))
+            }
+            if (hasWindow && ctx.committeeWindows.any { it.overlaps(period) }) {
+                facts.add(UserFact(CohortFactKind.ACTIVE_IN_PERIOD, periodId.toString()))
             }
         }
-
-        // NEWSLETTER: a single boolean fact; opt-out is represented by
-        // the *absence* of a rule, not a "false" fact.
-        if (user.newsletter) {
-            facts.add(UserFact(CohortFactKind.NEWSLETTER, "true"))
-        }
-
         return facts
     }
 
-    private fun Membership.overlaps(period: ContributionPeriod): Boolean {
+    /** A single boolean fact; opt-out is the absence of a rule, not a "false" fact. */
+    private fun newsletterFacts(ctx: UserFactContext): Set<UserFact> =
+        if (ctx.user.newsletter) setOf(UserFact(CohortFactKind.NEWSLETTER, "true")) else emptySet()
+
+    private fun Membership.overlaps(period: ContributionPeriod, today: LocalDate): Boolean {
         val start = startDate
-        val end = endDate ?: LocalDate.now()
+        val end = endDate ?: today
         return !start.isAfter(period.endDate) && !end.isBefore(period.startDate)
     }
 
@@ -97,5 +117,20 @@ class UserFactCollector(
         // overlap = joinedAt < periodEnd && leftAt > periodStart
         return joinedAt.isBefore(periodEnd) && leftAt.isAfter(periodStart)
     }
+}
 
+/**
+ * The shared, lazily-loaded read context for one [UserFactCollector.collect] call.
+ * The user is loaded once; [periods] and [committeeWindows] load on first access so a
+ * fact kind that does not need them never triggers the query.
+ */
+class UserFactContext(
+    val userId: Long,
+    val user: User,
+    val today: LocalDate,
+    periodsLoader: () -> List<ContributionPeriod>,
+    windowsLoader: () -> List<CommitteeMembershipWindow>,
+) {
+    val periods by lazy(periodsLoader)
+    val committeeWindows by lazy(windowsLoader)
 }

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/UserFactCollectorTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/UserFactCollectorTest.kt
@@ -2,6 +2,7 @@ package net.blueshell.api.platform.integration.cohort.application
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import net.blueshell.api.domain.committee.application.CommitteeMemberService
 import net.blueshell.api.domain.committee.application.CommitteeMembershipWindow
 import net.blueshell.api.domain.committee.persistence.Committee
@@ -170,6 +171,57 @@ class UserFactCollectorTest {
 
         assertThat(facts).contains(UserFact(CohortFactKind.ACTIVE_IN_PERIOD, "20"))
         assertThat(facts).doesNotContain(UserFact(CohortFactKind.ACTIVE_IN_PERIOD, "21"))
+    }
+
+    @Test
+    fun `loads the user exactly once`() {
+        every { users.findById(1L) } returns userWith(roles = setOf(Role.MEMBER))
+
+        collector.collect(1L)
+
+        verify(exactly = 1) { users.findById(1L) }
+    }
+
+    @Test
+    fun `does not query periods when the user has no memberships or committee windows`() {
+        every { users.findById(1L) } returns userWith(roles = setOf(Role.MEMBER))
+
+        collector.collect(1L)
+
+        verify(exactly = 0) { periods.findAll() }
+    }
+
+    @Test
+    fun `queries periods once when there is a membership candidate`() {
+        every { periods.findAll() } returns mutableListOf(periodFixture(10L, "2023-09-01", "2024-08-31"))
+        every { users.findById(1L) } returns userWith(memberships = setOf(membership("2024-01-01", "2024-06-01")))
+
+        collector.collect(1L)
+
+        verify(exactly = 1) { periods.findAll() }
+    }
+
+    @Test
+    fun `open-ended membership overlaps periods up to the given today`() {
+        val today = LocalDate.parse("2025-03-01")
+        every { periods.findAll() } returns mutableListOf(
+            periodFixture(id = 10L, start = "2023-09-01", end = "2024-08-31"),
+            periodFixture(id = 11L, start = "2024-09-01", end = "2025-08-31"),
+            periodFixture(id = 12L, start = "2025-09-01", end = "2026-08-31"),
+        )
+        every { users.findById(1L) } returns userWith(
+            memberships = setOf(membership(start = "2024-01-01", end = null)),
+        )
+
+        val facts = collector.collect(1L, today)
+
+        // The open-ended membership extends to today (2025-03-01), so it overlaps the
+        // 2023-24 and 2024-25 periods but not the period starting 2025-09.
+        assertThat(facts).contains(
+            UserFact(CohortFactKind.MEMBER_IN_PERIOD, "10"),
+            UserFact(CohortFactKind.MEMBER_IN_PERIOD, "11"),
+        )
+        assertThat(facts).doesNotContain(UserFact(CohortFactKind.MEMBER_IN_PERIOD, "12"))
     }
 
     private fun periodFixture(id: Long, start: String, end: String): ContributionPeriod {


### PR DESCRIPTION
## Why
`UserFactCollector.collect` computed every fact kind inline in one method and always called `periods.findAll()` whenever any contribution period existed — even for a user with no membership or committee window that could possibly match one. It read fine at five fact kinds but had no seam to grow along, and the unconditional period scan was wasted work on the common path.

## What this achieves
Each fact kind is now an isolated unit over a context that loads the user once and loads period data only when it can matter. A user with no membership and no committee window never queries the period table.

## How
- `collect` builds a `UserFactContext` holding the user (loaded once), `today`, and lazily-loaded `periods` / `committeeWindows`. Each fact kind is a small private function on the collector: `roleFacts`, `committeeFacts`, `contributionPaidFacts`, `membershipPeriodFacts` (emitting both `MEMBER_IN_PERIOD` and `ACTIVE_IN_PERIOD`) and `newsletterFacts`. They stay private functions rather than injected beans — there is no runtime selection among them, so an interface would add wiring and mock surface for no polymorphism.
- `membershipPeriodFacts` returns early when the user has neither a membership nor a committee window, so `periods.findAll()` is never called for that user; periods and windows load lazily on first access.
- Open-ended membership overlap reads `context.today` instead of calling `LocalDate.now()` inside a helper; a `collect(userId, today)` overload makes date-sensitive overlap deterministic in tests.

Added tests cover: the user is loaded exactly once, periods are queried once when a candidate exists and not at all otherwise, and an open-ended membership overlaps only up to the supplied day. All 155 cohort + architecture unit tests pass. No schema or behaviour change beyond the avoided query.