### PR TITLE
refactor(cohort): page the all-users reconcile instead of one transaction

### DIFF
--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/domain/user/persistence/UserRepositoryPagingIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/domain/user/persistence/UserRepositoryPagingIT.kt
@@ -1,0 +1,38 @@
+package net.blueshell.api.domain.user.persistence
+
+import net.blueshell.api.domain.user.persistence.repository.UserRepository
+import net.blueshell.api.shared.enums.Role
+import net.blueshell.api.testsupport.UserTestSupport
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
+
+/**
+ * Real-MariaDB checks for the keyset query backing the cohort all-users
+ * reconcile: ascending by id, strictly after the cursor, honouring the limit.
+ */
+@SpringBootTest
+class UserRepositoryPagingIT : UserTestSupport() {
+
+    @Autowired private lateinit var users: UserRepository
+
+    @Test
+    fun `findActiveIdsAfter walks active ids ascending, after the cursor, within the limit`() {
+        val a = createUserWithRole(Role.MEMBER).id!!
+        val b = createUserWithRole(Role.MEMBER).id!!
+        val c = createUserWithRole(Role.MEMBER).id!!
+
+        // Limit caps the page; the single id after `a` is the next one, `b`.
+        assertThat(users.findActiveIdsAfter(a, PageRequest.of(0, 1))).containsExactly(b)
+
+        // Strictly-after semantics + ascending order.
+        val afterB = users.findActiveIdsAfter(b, PageRequest.of(0, 100))
+        assertThat(afterB).contains(c).doesNotContain(a, b)
+
+        val afterA = users.findActiveIdsAfter(a, PageRequest.of(0, 100))
+        assertThat(afterA).isSorted()
+        assertThat(afterA).containsSubsequence(b, c)
+    }
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/domain/user/application/UserService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/domain/user/application/UserService.kt
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.core.userdetails.UsernameNotFoundException
@@ -136,6 +137,14 @@ class UserService @Autowired constructor(
 
     fun findSoftDeletedIds(userIds: Collection<Long>): Set<Long> =
         if (userIds.isEmpty()) emptySet() else repository.findSoftDeletedUserIds(userIds).toSet()
+
+    /**
+     * Up to [limit] active user ids greater than [afterId], ascending — keyset
+     * pagination for bulk fan-out (e.g. the cohort all-users reconcile) so a
+     * sweep never loads the whole user table or holds one transaction across it.
+     */
+    fun findActiveIdsAfter(afterId: Long, limit: Int): List<Long> =
+        repository.findActiveIdsAfter(afterId, PageRequest.of(0, limit))
 
     @Transactional
     fun toggleRole(id: Long, role: Role): User {

--- a/services/api/src/main/kotlin/net/blueshell/api/domain/user/persistence/repository/UserRepository.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/domain/user/persistence/repository/UserRepository.kt
@@ -2,6 +2,7 @@ package net.blueshell.api.domain.user.persistence.repository
 
 import net.blueshell.api.domain.user.persistence.User
 import net.blueshell.api.shared.repository.BaseRepository
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
@@ -46,4 +47,12 @@ interface UserRepository : BaseRepository<User, Long> {
         nativeQuery = true,
     )
     fun findSoftDeletedUserIds(@Param("userIds") userIds: Collection<Long>): List<Long>
+
+    /**
+     * Active user ids greater than [afterId], ascending — keyset pagination for
+     * bulk fan-out that does not hold one transaction (or one big result set)
+     * across the whole user table. Respects the `@SQLRestriction` on [User].
+     */
+    @Query("SELECT u.id FROM User u WHERE u.id > :afterId ORDER BY u.id")
+    fun findActiveIdsAfter(@Param("afterId") afterId: Long, pageable: Pageable): List<Long>
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortReconciliationService.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortReconciliationService.kt
@@ -7,7 +7,10 @@ import net.blueshell.api.shared.job.CohortJobs
 import net.blueshell.api.shared.job.TrackedJobDispatcher
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
 
 /**
  * Application implementation of the [CohortReconciliation] inbound
@@ -22,7 +25,15 @@ class CohortReconciliationService(
     private val contributionPeriodCohorts: ContributionPeriodCohortResolver,
     private val evaluator: CohortRuleEvaluator,
     private val jobs: TrackedJobDispatcher,
+    transactionManager: PlatformTransactionManager,
 ) : CohortReconciliation {
+
+    // One short transaction per page (REQUIRES_NEW), so each page's child jobs
+    // commit and dispatch incrementally instead of the whole scan running under
+    // the single transaction AbstractJsonJobHandler opens around the spawn job.
+    private val pageTransaction = TransactionTemplate(transactionManager).apply {
+        propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
+    }
 
     @Transactional
     override fun evaluateUserCohorts(userId: Long) {
@@ -42,24 +53,38 @@ class CohortReconciliationService(
         }
     }
 
-    @Transactional
     override fun reconcileAllUserCohorts() {
-        val all = users.findAll()
-        log.info("Enqueueing per-user cohort evaluation for {} users", all.size)
-        all.forEach { user ->
-            val userId = user.id ?: return@forEach
-            runCatching {
-                jobs.enqueue(
-                    CohortJobs.EvaluateUserCohorts,
-                    CohortJobs.EvaluateUserCohortsPayload(userId),
-                )
-            }.onFailure { e ->
-                log.error("Failed to enqueue evaluation for user {}: {}", userId, e.message)
-            }
+        var afterId = 0L
+        var total = 0
+        while (true) {
+            // Read + enqueue one page in its own short transaction. A page that
+            // commits has dispatched its jobs even if a later page fails, and
+            // per-user runCatching keeps one bad enqueue from dropping its page.
+            val page = pageTransaction.execute {
+                val ids = users.findActiveIdsAfter(afterId, PAGE_SIZE)
+                ids.forEach { userId ->
+                    runCatching {
+                        jobs.enqueue(
+                            CohortJobs.EvaluateUserCohorts,
+                            CohortJobs.EvaluateUserCohortsPayload(userId),
+                        )
+                    }.onFailure { e ->
+                        log.error("Failed to enqueue evaluation for user {}: {}", userId, e.message)
+                    }
+                }
+                ids
+            }!!
+            if (page.isEmpty()) break
+            afterId = page.last()
+            total += page.size
         }
+        log.info("Enqueued per-user cohort evaluation across {} users in pages of {}", total, PAGE_SIZE)
     }
 
     companion object {
+        /** Users per page for the all-users reconcile sweep. */
+        const val PAGE_SIZE = 500
+
         private val log = LoggerFactory.getLogger(CohortReconciliationService::class.java)
     }
 }

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/adapter/job/ReconcileAllUserCohortsJobHandlerTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/adapter/job/ReconcileAllUserCohortsJobHandlerTest.kt
@@ -1,0 +1,27 @@
+package net.blueshell.api.platform.integration.cohort.adapter.job
+
+import io.mockk.mockk
+import io.mockk.verify
+import net.blueshell.api.platform.integration.cohort.port.`in`.CohortReconciliation
+import net.blueshell.api.shared.job.CohortJobs
+import org.junit.jupiter.api.Test
+import tools.jackson.databind.ObjectMapper
+
+/**
+ * Thin driving-adapter test: the spawn job still delegates to the inbound
+ * port. The paged fan-out itself is covered by
+ * [CohortReconciliationServiceTest][net.blueshell.api.platform.integration.cohort.application.CohortReconciliationServiceTest].
+ */
+class ReconcileAllUserCohortsJobHandlerTest {
+
+    private val objectMapper = ObjectMapper()
+    private val reconciliation: CohortReconciliation = mockk(relaxed = true)
+    private val handler = ReconcileAllUserCohortsJobHandler(objectMapper, reconciliation)
+
+    @Test
+    fun `delegates to reconcileAllUserCohorts`() {
+        handler.handle(objectMapper.writeValueAsString(CohortJobs.ReconcileAllUserCohortsPayload()), executionId = null)
+
+        verify { reconciliation.reconcileAllUserCohorts() }
+    }
+}

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortReconciliationServiceTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortReconciliationServiceTest.kt
@@ -6,7 +6,6 @@ import io.mockk.verify
 import net.blueshell.api.domain.contribution.application.ContributionPeriodService
 import net.blueshell.api.domain.contribution.persistence.ContributionPeriod
 import net.blueshell.api.domain.user.application.UserService
-import net.blueshell.api.domain.user.persistence.User
 import net.blueshell.api.shared.job.CohortJobs
 import net.blueshell.api.shared.job.TrackedJobDispatcher
 import org.junit.jupiter.api.Test
@@ -20,7 +19,11 @@ class CohortReconciliationServiceTest {
     private val jobs: TrackedJobDispatcher = mockk(relaxed = true)
     private val service = CohortReconciliationService(
         periods, users, resolver, evaluator, jobs,
+        // A relaxed manager runs the per-page TransactionTemplate callbacks inline.
+        transactionManager = mockk(relaxed = true),
     )
+
+    private val pageSize = CohortReconciliationService.PAGE_SIZE
 
     @Test
     fun `evaluateUserCohorts delegates to the rule evaluator`() {
@@ -53,34 +56,39 @@ class CohortReconciliationServiceTest {
     }
 
     @Test
-    fun `reconcileAllUserCohorts enqueues one EvaluateUserCohorts per user`() {
-        every { users.findAll() } returns mutableListOf(user(10L), user(11L))
+    fun `reconcileAllUserCohorts enqueues one EvaluateUserCohorts per user across paged ids`() {
+        // Two pages then empty — proves it reads incrementally by keyset rather
+        // than loading every user in one query/transaction.
+        every { users.findActiveIdsAfter(0L, pageSize) } returns listOf(10L, 11L)
+        every { users.findActiveIdsAfter(11L, pageSize) } returns emptyList()
 
         service.reconcileAllUserCohorts()
 
-        verify {
-            jobs.enqueue(
-                CohortJobs.EvaluateUserCohorts,
-                CohortJobs.EvaluateUserCohortsPayload(10L),
-            )
-        }
-        verify {
-            jobs.enqueue(
-                CohortJobs.EvaluateUserCohorts,
-                CohortJobs.EvaluateUserCohortsPayload(11L),
-            )
-        }
+        verify { users.findActiveIdsAfter(0L, pageSize) }
+        verify { users.findActiveIdsAfter(11L, pageSize) }
+        verify { jobs.enqueue(CohortJobs.EvaluateUserCohorts, CohortJobs.EvaluateUserCohortsPayload(10L)) }
+        verify { jobs.enqueue(CohortJobs.EvaluateUserCohorts, CohortJobs.EvaluateUserCohortsPayload(11L)) }
+    }
+
+    @Test
+    fun `reconcileAllUserCohorts keeps going past a failed enqueue and a later page`() {
+        every { users.findActiveIdsAfter(0L, pageSize) } returns listOf(10L, 11L)
+        every { users.findActiveIdsAfter(11L, pageSize) } returns listOf(12L)
+        every { users.findActiveIdsAfter(12L, pageSize) } returns emptyList()
+        every {
+            jobs.enqueue(CohortJobs.EvaluateUserCohorts, CohortJobs.EvaluateUserCohortsPayload(11L))
+        } throws RuntimeException("boom")
+
+        service.reconcileAllUserCohorts()
+
+        // 10 (before the failure) and 12 (a later page) are still enqueued.
+        verify { jobs.enqueue(CohortJobs.EvaluateUserCohorts, CohortJobs.EvaluateUserCohortsPayload(10L)) }
+        verify { jobs.enqueue(CohortJobs.EvaluateUserCohorts, CohortJobs.EvaluateUserCohortsPayload(12L)) }
     }
 
     private fun period(id: Long): ContributionPeriod {
         val p = mockk<ContributionPeriod>()
         every { p.id } returns id
         return p
-    }
-
-    private fun user(id: Long): User {
-        val u = mockk<User>()
-        every { u.id } returns id
-        return u
     }
 }


### PR DESCRIPTION
## Why
`reconcileAllUserCohorts` loaded every user with `users.findAll()` and enqueued inside one `@Transactional` method. Because `AbstractJsonJobHandler.handle()` is also `@Transactional`, the entire scan ran under a single transaction — a large user table means one long-held transaction, and an enqueue failure rolls back every enqueue done so far.

## What this achieves
The sweep now processes users in bounded pages, each committing on its own, so it never holds one transaction across the whole table and a late failure cannot undo the pages already dispatched. The admin-facing surface is unchanged.

## How
- `UserRepository.findActiveIdsAfter(afterId, pageable)` — a keyset (`id > :afterId ORDER BY id`) query returning active user ids only, exposed via `UserService.findActiveIdsAfter(afterId, limit)`.
- `CohortReconciliationService.reconcileAllUserCohorts` walks those ids in pages of 500, each page read-and-enqueued inside a `PROPAGATION_REQUIRES_NEW` `TransactionTemplate`. A committed page has already dispatched its `cohort.evaluate-user` jobs even if a later page throws; per-user `runCatching` keeps one bad enqueue from dropping its page.
- The job type stays `cohort.reconcile-all-users` and `ReconcileAllUserCohortsJobHandler` still calls the same port method, so the dashboard button and Job Manager are untouched. The per-user `EvaluateUserCohorts` job remains the retry boundary and the sweep stays idempotent.

## Verification
Unit tests: the sweep advances its cursor page by page and enqueues one job per id; a failed enqueue plus a later page still proceed; the spawn-job handler still delegates. A real-MariaDB `UserRepositoryPagingIT` pins the keyset query's ascending / strictly-after / limit semantics. 165 unit/architecture tests pass; no schema or contract change.