### PR TITLE
refactor(cohort): retire the external-id mapping fallback and fix job wording

### DIFF
--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/cohort/adapter/job/CohortProviderTransactionBoundaryIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/cohort/adapter/job/CohortProviderTransactionBoundaryIT.kt
@@ -8,7 +8,6 @@ import net.blueshell.api.platform.integration.cohort.persistence.repository.Coho
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortSubjectRepository
 import net.blueshell.api.platform.integration.cohort.port.`in`.SyncCohortMembershipIntent
 import net.blueshell.api.platform.integration.mock.MockCohortPort
-import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.COHORT_AGGREGATE
 import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.USER_AGGREGATE
 import net.blueshell.api.platform.integration.sync.persistence.ExternalIdMapping
 import net.blueshell.api.platform.integration.sync.persistence.repository.ExternalIdMappingRepository
@@ -53,7 +52,6 @@ class CohortProviderTransactionBoundaryIT : UserTestSupport() {
         val user = createUserWithRole(Role.MEMBER)
         val cohort = newCohort(newSubject())
         externalIds.saveAndFlush(ExternalIdMapping(USER_AGGREGATE, user.id!!, TargetSystem.BREVO.name, "ext-user"))
-        externalIds.saveAndFlush(ExternalIdMapping(COHORT_AGGREGATE, cohort.id!!, TargetSystem.BREVO.name, "ext-cohort"))
         port.transactionActiveDuringCalls.clear()
 
         syncHandler.handle(
@@ -69,7 +67,6 @@ class CohortProviderTransactionBoundaryIT : UserTestSupport() {
     @Test
     fun `reconcile-list verify fetches the member list outside any transaction`() {
         val cohort = newCohort(newSubject())
-        externalIds.saveAndFlush(ExternalIdMapping(COHORT_AGGREGATE, cohort.id!!, TargetSystem.BREVO.name, "ext-cohort"))
         port.transactionActiveDuringCalls.clear()
 
         verifyHandler.handle(
@@ -90,6 +87,7 @@ class CohortProviderTransactionBoundaryIT : UserTestSupport() {
                 kind = CohortKind.LIST,
                 label = "Members",
                 subjectId = subject.id,
+                externalId = "ext-cohort",
             ),
         )
 }

--- a/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/cohort/adapter/web/CohortSubjectControllerIT.kt
+++ b/services/api/src/integrationTest/kotlin/net/blueshell/api/platform/integration/cohort/adapter/web/CohortSubjectControllerIT.kt
@@ -6,7 +6,6 @@ import net.blueshell.api.platform.integration.cohort.persistence.CohortSubject
 import net.blueshell.api.platform.integration.cohort.persistence.CohortSubjectType
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortSubjectRepository
-import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.COHORT_AGGREGATE
 import net.blueshell.api.platform.integration.sync.persistence.ExternalIdMapping
 import net.blueshell.api.platform.integration.sync.persistence.repository.ExternalIdMappingRepository
 import net.blueshell.api.platform.integration.sync.port.TargetSystem
@@ -116,8 +115,7 @@ class CohortSubjectControllerIT : UserTestSupport() {
             .andExpect(jsonPath("$.externalId").value("list-123"))
 
         val cohort = cohorts.findBySubjectIdAndSystem(subject.id!!, TargetSystem.BREVO.name)!!
-        assertThat(externalIds.findByAggregateTypeAndAggregateIdAndSystem(COHORT_AGGREGATE, cohort.id!!, TargetSystem.BREVO.name)?.externalId)
-            .isEqualTo("list-123")
+        assertThat(cohort.externalId).isEqualTo("list-123")
     }
 
     @Test
@@ -137,8 +135,7 @@ class CohortSubjectControllerIT : UserTestSupport() {
 
         val cohort = cohorts.findBySubjectIdAndSystem(subject.id!!, TargetSystem.BREVO.name)!!
         assertThat(cohort.folder).isEqualTo("Lists")
-        assertThat(externalIds.findByAggregateTypeAndAggregateIdAndSystem(COHORT_AGGREGATE, cohort.id!!, TargetSystem.BREVO.name)?.externalId)
-            .isNotBlank()
+        assertThat(cohort.externalId).isNotBlank()
     }
 
     @Test
@@ -159,10 +156,7 @@ class CohortSubjectControllerIT : UserTestSupport() {
     fun `admin switches a cohort to a new external target`() {
         val admin = createUserWithRole(Role.ADMIN)
         val subject = newSubject()
-        val cohort = newCohort(subject)
-        externalIds.saveAndFlush(
-            ExternalIdMapping(COHORT_AGGREGATE, cohort.id!!, TargetSystem.BREVO.name, "old-list"),
-        )
+        val cohort = newCohort(subject, externalId = "old-list")
 
         mvc.perform(
             put("/management/cohort-subjects/{id}/targets/{cohortId}", subject.id, cohort.id)
@@ -173,8 +167,7 @@ class CohortSubjectControllerIT : UserTestSupport() {
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.externalId").value("new-list"))
 
-        assertThat(externalIds.findByAggregateTypeAndAggregateIdAndSystem(COHORT_AGGREGATE, cohort.id!!, TargetSystem.BREVO.name)?.externalId)
-            .isEqualTo("new-list")
+        assertThat(cohorts.findById(cohort.id!!).orElseThrow().externalId).isEqualTo("new-list")
     }
 
     @Test
@@ -195,13 +188,14 @@ class CohortSubjectControllerIT : UserTestSupport() {
     private fun newSubject(): CohortSubject =
         subjects.save(CohortSubject(type = CohortSubjectType.CUSTOM, label = "Members"))
 
-    private fun newCohort(subject: CohortSubject): Cohort =
+    private fun newCohort(subject: CohortSubject, externalId: String? = null): Cohort =
         cohorts.save(
             Cohort(
                 system = TargetSystem.BREVO.name,
                 kind = CohortKind.LIST,
                 label = "Members",
                 subjectId = subject.id,
+                externalId = externalId,
             ),
         )
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortTargetIds.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortTargetIds.kt
@@ -2,8 +2,6 @@ package net.blueshell.api.platform.integration.cohort.application
 
 import net.blueshell.api.platform.integration.cohort.persistence.Cohort
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
-import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService
-import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.COHORT_AGGREGATE
 import net.blueshell.api.shared.job.NonRetryableJobException
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
@@ -11,11 +9,11 @@ import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.server.ResponseStatusException
 
 /**
- * Sole owner of a cohort's external target id. Reads it from
- * [Cohort.externalId], falling back to the legacy
- * `external_id_mapping(aggregate_type='COHORT')` row for cohorts an older
- * replica wrote during a deploy overlap. Item 8 runs the final backfill and
- * drops the fallback.
+ * Sole owner of a cohort's external target id, which lives in
+ * [Cohort.externalId]. V79 backfilled the column from the legacy
+ * `external_id_mapping(aggregate_type='COHORT')` rows, so the read no longer
+ * falls back to that mapping (the rows themselves are dropped in a later
+ * migration).
  *
  * This is field ownership, not a use case, so it is a plain component rather
  * than an inbound port: every cohort path that needs the target id resolves
@@ -23,16 +21,10 @@ import org.springframework.web.server.ResponseStatusException
  */
 @Component
 class CohortTargetIds(
-    private val externalIds: ExternalIdMappingService,
     private val cohorts: CohortRepository,
 ) {
-    /**
-     * The cohort's target id — the column first, then the legacy mapping.
-     * Read-only: never back-fills the column, so read-only callers stay so.
-     */
-    fun find(cohort: Cohort): String? =
-        cohort.externalId?.takeIf { it.isNotBlank() }
-            ?: externalIds.find(COHORT_AGGREGATE, cohort.id!!, cohort.system)?.externalId
+    /** The cohort's target id, or null when it has not been materialised. */
+    fun find(cohort: Cohort): String? = cohort.externalId?.takeIf { it.isNotBlank() }
 
     /** The target id, or a terminal failure when the cohort is not materialised. */
     fun require(cohort: Cohort): String =
@@ -40,8 +32,7 @@ class CohortTargetIds(
 
     /**
      * Records [externalId] as this cohort's target. Rejects blanks and refuses
-     * to point a second active cohort at an id already in use. Writes the
-     * column and keeps the legacy mapping in step for the compatibility window.
+     * to point a second active cohort at an id already in use.
      */
     @Transactional
     fun record(cohort: Cohort, externalId: String): Cohort {
@@ -54,8 +45,6 @@ class CohortTargetIds(
             )
         }
         cohort.externalId = externalId
-        val saved = cohorts.save(cohort)
-        externalIds.upsert(COHORT_AGGREGATE, cohort.id!!, cohort.system, externalId)
-        return saved
+        return cohorts.save(cohort)
     }
 }

--- a/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/port/in/CohortReconciliation.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort/port/in/CohortReconciliation.kt
@@ -20,9 +20,9 @@ interface CohortReconciliation {
     fun evaluateUserCohorts(userId: Long)
 
     /**
-     * Walks every active `ContributionPeriod` and ensures its
-     * cohort + `(CONTRIBUTION_PAID, <periodId>)` rule exist. No-op
-     * for periods that already have both rows.
+     * Walks every active `ContributionPeriod` and ensures its three period
+     * cohorts — contribution-paid, members and active-members — and their
+     * subjects exist. No-op for periods already provisioned.
      */
     fun reconcileAllContributionPeriodCohorts()
 

--- a/services/api/src/main/kotlin/net/blueshell/api/shared/job/CohortJobs.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/shared/job/CohortJobs.kt
@@ -23,8 +23,9 @@ object CohortJobs {
     }
 
     /**
-     * Walks every active contribution period and ensures its cohort +
-     * `(CONTRIBUTION_PAID, <periodId>)` rule exist. Idempotent.
+     * Walks every active contribution period and ensures its three period
+     * cohorts — contribution-paid, members and active-members — and their
+     * subjects exist. Idempotent.
      */
     object ReconcileAllContributionPeriodCohorts : JobDefinition<ReconcileAllContributionPeriodCohortsPayload> {
         override val type: String = "cohort.reconcile-contribution-periods"

--- a/services/api/src/main/resources/db/migration/V79__cohort_external_id_final_backfill.sql
+++ b/services/api/src/main/resources/db/migration/V79__cohort_external_id_final_backfill.sql
@@ -1,0 +1,14 @@
+-- Final backfill of cohort.external_id from the legacy
+-- external_id_mapping(aggregate_type='COHORT') rows, closing the V77 deploy
+-- window: this release stops reading that mapping (CohortTargetIds.find no
+-- longer falls back to it), so any cohort an older replica materialised during
+-- the overlap — column NULL, mapping set — is copied across one last time.
+--
+-- Idempotent: only fills rows still missing the column. The legacy COHORT
+-- mapping rows are left in place and dropped in a later migration.
+
+UPDATE cohort c
+JOIN external_id_mapping m
+  ON m.aggregate_type = 'COHORT' AND m.aggregate_id = c.id AND m.system = c.system
+SET c.external_id = m.external_id
+WHERE c.external_id IS NULL;

--- a/services/api/src/test/kotlin/net/blueshell/api/architecture/CohortTargetIdOwnershipTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/architecture/CohortTargetIdOwnershipTest.kt
@@ -5,19 +5,18 @@ import org.junit.jupiter.api.Test
 import java.io.File
 
 /**
- * `CohortTargetIds` is the single owner of a cohort's external target id.
- * Other cohort code resolves the id through it rather than reaching into the
- * legacy `external_id_mapping(aggregate_type='COHORT')` directly.
+ * The cohort external target id now lives solely on `cohort.external_id`
+ * (owned by `CohortTargetIds`). With the V77 compatibility window closed (V79
+ * final backfill), no cohort code should reach into the legacy
+ * `external_id_mapping(aggregate_type='COHORT')` via `COHORT_AGGREGATE` at all.
  *
  * `COHORT_AGGREGATE` is a `const val`, so a reference is inlined at compile
  * time and ArchUnit cannot see it as a dependency — hence a source scan.
- * Item 8 removes the legacy fallback; until then this stops the indirection
- * leaking back into other cohort classes.
  */
 class CohortTargetIdOwnershipTest {
 
     @Test
-    fun `only CohortTargetIds references COHORT_AGGREGATE in cohort code`() {
+    fun `no cohort code references COHORT_AGGREGATE`() {
         val root = listOf(
             File("src/main/kotlin/net/blueshell/api/platform/integration/cohort"),
             File("services/api/src/main/kotlin/net/blueshell/api/platform/integration/cohort"),
@@ -30,6 +29,6 @@ class CohortTargetIdOwnershipTest {
             .map { it.name }
             .toList()
 
-        assertThat(referencingFiles).containsExactly("CohortTargetIds.kt")
+        assertThat(referencingFiles).isEmpty()
     }
 }

--- a/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortTargetIdsTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/platform/integration/cohort/application/CohortTargetIdsTest.kt
@@ -6,9 +6,6 @@ import io.mockk.verify
 import net.blueshell.api.platform.integration.cohort.persistence.Cohort
 import net.blueshell.api.platform.integration.cohort.persistence.CohortKind
 import net.blueshell.api.platform.integration.cohort.persistence.repository.CohortRepository
-import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService
-import net.blueshell.api.platform.integration.sync.application.ExternalIdMappingService.Companion.COHORT_AGGREGATE
-import net.blueshell.api.platform.integration.sync.persistence.ExternalIdMapping
 import net.blueshell.api.shared.job.NonRetryableJobException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -17,9 +14,8 @@ import org.springframework.web.server.ResponseStatusException
 
 class CohortTargetIdsTest {
 
-    private val externalIds: ExternalIdMappingService = mockk(relaxed = true)
     private val cohorts: CohortRepository = mockk(relaxed = true)
-    private val targetIds = CohortTargetIds(externalIds, cohorts)
+    private val targetIds = CohortTargetIds(cohorts)
 
     private fun cohort(id: Long, externalId: String? = null) =
         Cohort(system = "BREVO", kind = CohortKind.LIST, label = "Members").apply {
@@ -28,35 +24,24 @@ class CohortTargetIdsTest {
         }
 
     @Test
-    fun `find reads the column first and does not touch the mapping`() {
-        val cohort = cohort(5L, externalId = "col-1")
-
-        assertThat(targetIds.find(cohort)).isEqualTo("col-1")
-        verify(exactly = 0) { externalIds.find(any(), any(), any()) }
+    fun `find reads the column`() {
+        assertThat(targetIds.find(cohort(5L, externalId = "col-1"))).isEqualTo("col-1")
     }
 
     @Test
-    fun `find falls back to the legacy mapping when the column is blank, without writing`() {
-        val cohort = cohort(5L, externalId = null)
-        every { externalIds.find(COHORT_AGGREGATE, 5L, "BREVO") } returns
-            ExternalIdMapping(COHORT_AGGREGATE, 5L, "BREVO", "legacy-1")
-
-        assertThat(targetIds.find(cohort)).isEqualTo("legacy-1")
-        verify(exactly = 0) { cohorts.save(any()) }
-        verify(exactly = 0) { externalIds.upsert(any(), any(), any(), any()) }
+    fun `find returns null when the column is unset`() {
+        assertThat(targetIds.find(cohort(5L, externalId = null))).isNull()
+        assertThat(targetIds.find(cohort(5L, externalId = "  "))).isNull()
     }
 
     @Test
     fun `require throws a terminal failure when the cohort is not materialised`() {
-        val cohort = cohort(5L, externalId = null)
-        every { externalIds.find(COHORT_AGGREGATE, 5L, "BREVO") } returns null
-
-        assertThatThrownBy { targetIds.require(cohort) }
+        assertThatThrownBy { targetIds.require(cohort(5L, externalId = null)) }
             .isInstanceOf(NonRetryableJobException::class.java)
     }
 
     @Test
-    fun `record writes the column and the legacy mapping`() {
+    fun `record writes the column`() {
         val cohort = cohort(5L, externalId = null)
         every { cohorts.findFirstBySystemAndExternalId("BREVO", "list-9") } returns null
         every { cohorts.save(cohort) } returns cohort
@@ -65,7 +50,6 @@ class CohortTargetIdsTest {
 
         assertThat(cohort.externalId).isEqualTo("list-9")
         verify { cohorts.save(cohort) }
-        verify { externalIds.upsert(COHORT_AGGREGATE, 5L, "BREVO", "list-9") }
     }
 
     @Test

--- a/services/frontend/src/utils/jobCatalog.ts
+++ b/services/frontend/src/utils/jobCatalog.ts
@@ -81,24 +81,25 @@ export const JOB_CATALOG: Record<string, JobCatalogEntry> = {
   "cohort.reconcile-contribution-periods": {
     title: "Reconcile contribution-period cohorts",
     description:
-      "Walks every contribution period and makes sure its 'contribution paid' cohort " +
-      "and matching rule exist locally. Does not touch external systems on its own — " +
-      "subsequent user re-evaluations push any resulting changes outward. Safe to run.",
+      "Walks every contribution period and makes sure all three of its cohorts — " +
+      "contribution paid, members, and active members — exist locally. Does not touch " +
+      "external systems on its own; subsequent user re-evaluations push any resulting " +
+      "changes outward. Safe to run.",
   },
   "cohort.reconcile-all-users": {
     title: "Re-evaluate every user's cohorts",
     description:
       "Fans out one Re-evaluate-user-cohorts job per active user. Each child job " +
       "recomputes that user's cohort memberships from current facts (role, committee " +
-      "membership, contribution payments, newsletter opt-in) and enqueues list " +
-      "reconciliation for any cohort whose desired membership changed.",
+      "membership, contribution payments, newsletter opt-in) and enqueues a per-member " +
+      "membership-sync job for any cohort the user joins or leaves.",
   },
   "cohort.evaluate-user": {
     title: "Re-evaluate one user's cohorts",
     description:
-      "Recomputes one user's desired cohort memberships locally, then enqueues " +
-      "cohort-level list reconciliation for touched external mappings. Does not call " +
-      "external systems directly.",
+      "Recomputes one user's desired cohort memberships locally, then enqueues a " +
+      "per-member membership-sync job (add or remove) for each cohort the user joins " +
+      "or leaves. Does not call external systems directly.",
   },
   "cohort.remove-external-member": {
     title: "Remove from external list",
@@ -107,11 +108,12 @@ export const JOB_CATALOG: Record<string, JobCatalogEntry> = {
       "(e.g. a Brevo list). Used to clean up drift detected by the drift inspector.",
   },
   "cohort.reconcile-list": {
-    title: "Reconcile list",
+    title: "Verify cohort",
     description:
-      "Fetches the full external member list for one cohort mapping, updates the " +
-      "membership ledger, and enqueues ADD or contact-sync follow-ups for missing " +
-      "desired members. Extras are recorded for admin remediation.",
+      "Fetches the full external member list for one cohort and verifies the ledger " +
+      "against it: confirms members present, demotes ones that vanished, records " +
+      "strangers, and enqueues ADD or contact-sync follow-ups for missing desired " +
+      "members. One external call per run; extras are recorded for admin remediation.",
   },
   "cohort.delete-external-target": {
     title: "Delete external target",


### PR DESCRIPTION
## Why
PR #332 moved the cohort target id onto `cohort.external_id` but kept reading and writing the legacy `external_id_mapping(aggregate_type='COHORT')` rows as a fallback, to bridge the rolling-deploy window where an older replica might still write the mapping. With that release live, the bridge is dead weight: every cohort path can read the column directly. Separately, several job descriptions in the admin UI (and matching backend KDocs) still described the pre-refactor behaviour.

## What this achieves
The cohort target id has a single home (`cohort.external_id`) with no indirection left anywhere in cohort code, and the Job Manager / trigger dialog describe what the cohort jobs actually do.

## How
- **V79** backfills `cohort.external_id` one last time from any legacy `COHORT` mapping rows (idempotent; only fills rows still null), closing the V77 window.
- `CohortTargetIds.find` no longer falls back to the mapping and `record` no longer writes it; the component drops its `ExternalIdMappingService` dependency and stops referencing `COHORT_AGGREGATE`. `CohortTargetIdOwnershipTest` now asserts **no** cohort code references `COHORT_AGGREGATE`. The legacy `COHORT` mapping rows are left in place — a later migration deletes them.
- Job descriptions (`services/frontend/src/utils/jobCatalog.ts`): `cohort.evaluate-user` and `cohort.reconcile-all-users` enqueue per-member membership-sync jobs (not "list reconciliation"); `cohort.reconcile-list` is titled **Verify cohort** and describes verify/demote/stranger semantics; `cohort.reconcile-contribution-periods` covers all three period cohorts (paid, members, active). Matching backend KDocs (`CohortJobs`, `CohortReconciliation`) updated. The `cohort.reconcile-list` job *type* is unchanged.
- The PR #332 integration tests that seeded/asserted the target id through the legacy mapping now use `cohort.external_id` directly.

## Deploy ordering
⚠️ Deploy this only **after** PR #332 (`cohort.external_id`) is live in production. It removes the fallback that covers the rolling-deploy window PR #332 opened; deploying it alongside or before #332 would leave a replica unable to resolve target ids written the old way. No manual step otherwise — V79 runs at boot.

## Verification
Verified against a throwaway MariaDB: all 25 cohort integration tests (with V79 applied and the fallback removed) and 165 unit/architecture tests pass. No DTO/OpenAPI change — `jobCatalog.ts` is frontend-owned copy, so the generated client is untouched.