### PR TITLE
Derive the association's age from its founding date

### DIFF
--- a/services/frontend/src/pages/AboutUs.vue
+++ b/services/frontend/src/pages/AboutUs.vue
@@ -57,34 +57,10 @@
 <script lang="ts" setup>
 import {computed} from "vue"
 import TopBanner from "@/components/common/banners/TopBanner.vue"
-import {DateTime} from "luxon"
+import {associationYearOrdinal} from "@/utils/association"
 
 defineOptions({name: "AboutUs"})
 
-const getOrdinalWord = (n: number): string => {
-  const ordinals = [
-    "first", "second", "third", "fourth", "fifth",
-    "sixth", "seventh", "eighth", "ninth", "tenth",
-    "eleventh", "twelfth",
-  ] as const
-
-  if (n <= ordinals.length) {
-    return ordinals[n - 1]!
-  }
-
-  let suffix = "th"
-  if (n % 10 === 1 && n % 100 !== 11) suffix = "st"
-  else if (n % 10 === 2 && n % 100 !== 12) suffix = "nd"
-  else if (n % 10 === 3 && n % 100 !== 13) suffix = "rd"
-  return `${n}${suffix}`
-}
-
-const FOUNDED = DateTime.fromISO("2017-12-12")
-
-const boardYear = computed<number>(() =>
-  Math.floor(DateTime.now().diff(FOUNDED, "years").years),
-)
-
-const boardYearOrdinal = computed<string>(() => getOrdinalWord(boardYear.value))
+const boardYearOrdinal = computed<string>(() => associationYearOrdinal())
 </script>
 

--- a/services/frontend/src/pages/Home.vue
+++ b/services/frontend/src/pages/Home.vue
@@ -107,6 +107,7 @@ import GamesWePlay from "@/components/base/GamesWePlay.vue"
 
 import {$require} from "@/plugins/require.js"
 import {$goto} from "@/plugins/goto"
+import {associationYears} from "@/utils/association"
 
 interface GameTitle {
   title: string
@@ -229,7 +230,7 @@ const columns = ref<Column[]>([
     title: "About us",
     url: "/aboutus",
     text:
-      "Despite its memberbase, Blueshell Esports is a relatively young student association with only 5 years since its inception. Learn all about our association by clicking above!",
+      `Despite its memberbase, Blueshell Esports is a relatively young student association with only ${associationYears()} years since its inception. Learn all about our association by clicking above!`,
   },
   {
     icon: "mdi-trophy",

--- a/services/frontend/src/utils/association.ts
+++ b/services/frontend/src/utils/association.ts
@@ -1,0 +1,32 @@
+import {DateTime} from "luxon"
+
+/** The day the first board signed Blueshell Esports' official Statutes. */
+export const ASSOCIATION_FOUNDED = DateTime.fromISO("2017-12-12")
+
+/** Completed years since the association was founded. */
+export function associationYears(now: DateTime = DateTime.now()): number {
+  return Math.floor(now.diff(ASSOCIATION_FOUNDED, "years").years)
+}
+
+const ORDINAL_WORDS = [
+  "first", "second", "third", "fourth", "fifth",
+  "sixth", "seventh", "eighth", "ninth", "tenth",
+  "eleventh", "twelfth",
+] as const
+
+/** Ordinal word for a count, falling back to numeric ordinals (13th, 21st …). */
+export function ordinalWord(n: number): string {
+  if (n >= 1 && n <= ORDINAL_WORDS.length) {
+    return ORDINAL_WORDS[n - 1]!
+  }
+  let suffix = "th"
+  if (n % 10 === 1 && n % 100 !== 11) suffix = "st"
+  else if (n % 10 === 2 && n % 100 !== 12) suffix = "nd"
+  else if (n % 10 === 3 && n % 100 !== 13) suffix = "rd"
+  return `${n}${suffix}`
+}
+
+/** Ordinal word for the association's current year of existence. */
+export function associationYearOrdinal(now: DateTime = DateTime.now()): string {
+  return ordinalWord(associationYears(now))
+}

--- a/services/frontend/tests/unit/utils/association.test.ts
+++ b/services/frontend/tests/unit/utils/association.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it} from "vitest"
+import {DateTime} from "luxon"
+import {ASSOCIATION_FOUNDED, associationYearOrdinal, associationYears, ordinalWord} from "@/utils/association"
+
+describe("association utils", () => {
+  it("anchors the founding date to the day the Statutes were signed", () => {
+    expect(ASSOCIATION_FOUNDED.toISODate()).toBe("2017-12-12")
+  })
+
+  it("counts completed years since founding", () => {
+    expect(associationYears(DateTime.fromISO("2026-06-04"))).toBe(8)
+  })
+
+  it("rolls over only after the anniversary", () => {
+    expect(associationYears(DateTime.fromISO("2027-12-11"))).toBe(9)
+    expect(associationYears(DateTime.fromISO("2027-12-12"))).toBe(10)
+  })
+
+  it("renders ordinal words for small counts", () => {
+    expect(ordinalWord(1)).toBe("first")
+    expect(ordinalWord(8)).toBe("eighth")
+    expect(ordinalWord(12)).toBe("twelfth")
+  })
+
+  it("falls back to numeric ordinals past the word table", () => {
+    expect(ordinalWord(13)).toBe("13th")
+    expect(ordinalWord(21)).toBe("21st")
+    expect(ordinalWord(22)).toBe("22nd")
+    expect(ordinalWord(23)).toBe("23rd")
+  })
+
+  it("renders the current year of existence as an ordinal word", () => {
+    expect(associationYearOrdinal(DateTime.fromISO("2026-06-04"))).toBe("eighth")
+  })
+})


### PR DESCRIPTION
## Why
The home page "About us" card described Blueshell Esports as having "only 5 years since its inception". That number was a hardcoded literal: it never recomputed, so as the association aged the figure silently drifted out of date — the regression that prompted this fix. The about page computed its "Nth year of existence" text dynamically from a founding-date constant, but that constant and its ordinal helper lived inline and were not reused, leaving every other age reference free to fall out of sync.

## What this achieves
Every place in the frontend that mentions how long the association has existed now derives from a single founding date and tracks the current date. The home card reads the real elapsed years, the about page keeps its dynamic ordinal text, and neither can regress to a frozen literal again.

## How
- New `services/frontend/src/utils/association.ts` is the single source of truth: `ASSOCIATION_FOUNDED` (2017-12-12, the day the first board signed the official Statutes), `associationYears()` for completed years since founding, `ordinalWord()` for word-form ordinals with a numeric fallback past twelve, and `associationYearOrdinal()` composing the two.
- `pages/Home.vue` now interpolates `associationYears()` into the card text instead of the hardcoded "5 years".
- `pages/AboutUs.vue` drops its inline `FOUNDED` constant and `getOrdinalWord` helper and calls `associationYearOrdinal()`.
- `tests/unit/utils/association.test.ts` covers the founding anchor, the anniversary roll-over boundary, the ordinal word table and its numeric fallback.