### PR TITLE
fix(style): render text crisply on the dark theme

### DIFF
--- a/services/frontend/src/styles/fonts.scss
+++ b/services/frontend/src/styles/fonts.scss
@@ -4,16 +4,25 @@
   font-display: swap;
 }
 
+// Every requested weight maps to a real face, so the browser never synthesizes.
+@font-face {
+  font-family: 'Barlow Semi Condensed';
+  src: url('@/assets/fonts/BarlowSemiCondensed-Light.ttf') format('truetype');
+  font-weight: 100 300;
+  font-display: swap;
+}
+
 @font-face {
   font-family: 'Barlow Semi Condensed';
   src: url('@/assets/fonts/BarlowSemiCondensed-Regular.ttf') format('truetype');
+  font-weight: 400 500;
   font-display: swap;
 }
 
 @font-face {
   font-family: 'Barlow Semi Condensed';
   src: url('@/assets/fonts/BarlowSemiCondensed-SemiBold.ttf') format('truetype');
-  font-weight: bold;
+  font-weight: 600 900;
   font-display: swap;
 }
 

--- a/services/frontend/src/styles/housestyle.scss
+++ b/services/frontend/src/styles/housestyle.scss
@@ -4,6 +4,13 @@
 
 $accent: rgb(var(--v-theme-accent));
 
+// Subpixel AA fringes saturated text on dark backgrounds; grayscale AA also
+// keeps composited (scrolling/sticky) regions consistent with the rest.
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
 // Don't force the house border-radius onto rounded/pill/icon buttons —
 // Vuetify 4 applies `rounded="pill"` as the `.rounded-pill` utility (not
 // `.v-btn--rounded`), and an unlayered rule here would otherwise flatten it


### PR DESCRIPTION
## Why

Text across the app read as slightly blurred, most noticeably on the dark theme and wherever text is saturated. Two independent causes were at work, and both are font-rendering rather than layout.

The stylesheet declared only a Regular and a SemiBold face, and bound the SemiBold face to `font-weight: bold`. Every other weight the app asks for was therefore synthesized by the browser, and faux-bold smears glyph edges rather than swapping in a real face. Separately, the browser's default subpixel antialiasing fringes saturated text on dark backgrounds with RGB artifacts.

## What this achieves

Text renders at its intended weight from a real font file, and stays crisp on dark backgrounds. Scrolling and sticky regions, which the compositor renders on their own layer, now match the rest of the page instead of shifting appearance as they move.

## How

- `services/frontend/src/styles/fonts.scss` — declares the Barlow Semi Condensed Light face, which was already committed under `src/assets/fonts/` but never referenced, and gives all three faces explicit weight ranges (`100 300`, `400 500`, `600 900`) so the full 100-900 span maps onto a real face. Replaces the previous `font-weight: bold` binding on the SemiBold face.
- `services/frontend/src/styles/housestyle.scss` — opts `html` into `-webkit-font-smoothing: antialiased` and `-moz-osx-font-smoothing: grayscale`.

No new assets: the Light `.ttf` is already in the repo.

<!-- diff-stats:start -->
---
**Diff breakdown** — `█` added `░` removed, scaled to the largest row.

```text
frontend                                           +17     -1    2
  production         █████████████████████████░    +17     -1    2

──────────────────────────────────────────────────────────────────
production                                         +17     -1
tests                                               +0     -0  0.00 test lines per prod line
total (hand-written)                               +17     -1  2 files
```
<!-- diff-stats:end -->