### PR TITLE
refactor(frontend): share the member type label formatter

### DIFF
--- a/services/frontend/src/components/common/modals/ManageMembershipDialog.vue
+++ b/services/frontend/src/components/common/modals/ManageMembershipDialog.vue
@@ -16,6 +16,7 @@ import {
 } from "@/services/api"
 import {$handleNetworkError} from "@/plugins/handleNetworkError.ts"
 import type {TypedStore} from "@/plugins/store"
+import {memberTypeLabel} from "@/utils/memberType"
 
 defineOptions({name: "ManageMembershipDialog"})
 
@@ -301,7 +302,7 @@ defineExpose({
                   <span v-else>active</span>
                 </div>
                 <div class="text-medium-emphasis text-body-2">
-                  <span class="text-capitalize">{{ m.memberType?.toLowerCase() }}</span>
+                  <span>{{ memberTypeLabel(m.memberType) }}</span>
                   <v-icon
                     v-if="m.incasso"
                     class="ml-1"
@@ -460,7 +461,7 @@ defineExpose({
                 <span v-if="m.endDate"> – {{ m.endDate }}</span>
               </div>
               <div class="text-medium-emphasis text-body-2">
-                <span class="text-capitalize">{{ m.memberType?.toLowerCase() }}</span>
+                <span>{{ memberTypeLabel(m.memberType) }}</span>
                 <span class="ml-2 text-error">(deleted)</span>
               </div>
             </div>

--- a/services/frontend/src/utils/memberType.ts
+++ b/services/frontend/src/utils/memberType.ts
@@ -1,0 +1,21 @@
+import {MemberType} from "@/services/api"
+
+// Keyed by MemberType, so a backend enum change fails the typecheck until
+// this map is updated.
+const MEMBER_TYPE_LABELS: Record<MemberType, string> = {
+  [MemberType.REGULAR]: "Regular",
+  [MemberType.ALUMNI]: "Alumni",
+  [MemberType.HONORARY]: "Honorary",
+  [MemberType.NONE]: "None",
+}
+
+/** Formats a member type for display; null/undefined renders as an em dash. */
+export function memberTypeLabel(type: MemberType | string | null | undefined): string {
+  if (type == null) return "—"
+
+  const known = MEMBER_TYPE_LABELS[type as MemberType]
+  if (known != null) return known
+
+  // Defensive: a value outside the generated enum still renders readably.
+  return type.charAt(0).toUpperCase() + type.slice(1).toLowerCase()
+}

--- a/services/frontend/src/utils/memberType.ts
+++ b/services/frontend/src/utils/memberType.ts
@@ -1,21 +1,4 @@
-import {MemberType} from "@/services/api"
-
-// Keyed by MemberType, so a backend enum change fails the typecheck until
-// this map is updated.
-const MEMBER_TYPE_LABELS: Record<MemberType, string> = {
-  [MemberType.REGULAR]: "Regular",
-  [MemberType.ALUMNI]: "Alumni",
-  [MemberType.HONORARY]: "Honorary",
-  [MemberType.NONE]: "None",
-}
-
-/** Formats a member type for display; null/undefined renders as an em dash. */
-export function memberTypeLabel(type: MemberType | string | null | undefined): string {
-  if (type == null) return "—"
-
-  const known = MEMBER_TYPE_LABELS[type as MemberType]
-  if (known != null) return known
-
-  // Defensive: a value outside the generated enum still renders readably.
-  return type.charAt(0).toUpperCase() + type.slice(1).toLowerCase()
+/** Formats a member type for display; null and undefined render as an em dash. */
+export function memberTypeLabel(type: string | null | undefined): string {
+  return type ? type.charAt(0) + type.slice(1).toLowerCase() : "—"
 }

--- a/services/frontend/tests/unit/utils/memberType.test.ts
+++ b/services/frontend/tests/unit/utils/memberType.test.ts
@@ -1,34 +1,19 @@
-import {describe, it, expect} from "vitest"
-import {memberTypeLabel} from "@/utils/memberType"
+import {describe, expect, it} from "vitest"
 import {MemberType} from "@/services/api"
+import {memberTypeLabel} from "@/utils/memberType"
 
 describe("memberTypeLabel", () => {
-  it("maps REGULAR to 'Regular'", () => {
-    expect(memberTypeLabel(MemberType.REGULAR)).toBe("Regular")
+  it("title-cases every member type", () => {
+    expect(Object.values(MemberType).map(memberTypeLabel)).toEqual([
+      "Alumni",
+      "Honorary",
+      "Regular",
+      "None",
+    ])
   })
 
-  it("maps ALUMNI to 'Alumni'", () => {
-    expect(memberTypeLabel(MemberType.ALUMNI)).toBe("Alumni")
-  })
-
-  it("maps HONORARY to 'Honorary'", () => {
-    expect(memberTypeLabel(MemberType.HONORARY)).toBe("Honorary")
-  })
-
-  it("maps NONE to 'None'", () => {
-    expect(memberTypeLabel(MemberType.NONE)).toBe("None")
-  })
-
-  it("returns '—' for null", () => {
+  it("renders a missing member type as an em dash", () => {
     expect(memberTypeLabel(null)).toBe("—")
-  })
-
-  it("returns '—' for undefined", () => {
     expect(memberTypeLabel(undefined)).toBe("—")
-  })
-
-  it("title-cases unknown values outside the enum", () => {
-    expect(memberTypeLabel("unknown")).toBe("Unknown")
-    expect(memberTypeLabel("CUSTOM")).toBe("Custom")
   })
 })

--- a/services/frontend/tests/unit/utils/memberType.test.ts
+++ b/services/frontend/tests/unit/utils/memberType.test.ts
@@ -1,0 +1,34 @@
+import {describe, it, expect} from "vitest"
+import {memberTypeLabel} from "@/utils/memberType"
+import {MemberType} from "@/services/api"
+
+describe("memberTypeLabel", () => {
+  it("maps REGULAR to 'Regular'", () => {
+    expect(memberTypeLabel(MemberType.REGULAR)).toBe("Regular")
+  })
+
+  it("maps ALUMNI to 'Alumni'", () => {
+    expect(memberTypeLabel(MemberType.ALUMNI)).toBe("Alumni")
+  })
+
+  it("maps HONORARY to 'Honorary'", () => {
+    expect(memberTypeLabel(MemberType.HONORARY)).toBe("Honorary")
+  })
+
+  it("maps NONE to 'None'", () => {
+    expect(memberTypeLabel(MemberType.NONE)).toBe("None")
+  })
+
+  it("returns '—' for null", () => {
+    expect(memberTypeLabel(null)).toBe("—")
+  })
+
+  it("returns '—' for undefined", () => {
+    expect(memberTypeLabel(undefined)).toBe("—")
+  })
+
+  it("title-cases unknown values outside the enum", () => {
+    expect(memberTypeLabel("unknown")).toBe("Unknown")
+    expect(memberTypeLabel("CUSTOM")).toBe("Custom")
+  })
+})


### PR DESCRIPTION
## Why

Two places in `ManageMembershipDialog` rendered a member type the same way: lowercase the enum value in the template, then let `text-capitalize` put the first letter back. Duplicated presentation logic, and a missing member type rendered as nothing at all rather than as a visible placeholder.

## What this achieves

One formatter both call sites share, and an absent member type shows an em dash instead of a blank gap. A third caller is coming, so the shared form pays for itself rather than staying duplicated.

## How

- `services/frontend/src/utils/memberType.ts` — `memberTypeLabel()` title-cases the value and returns an em dash for null and undefined. It takes a plain string, so it needs no change when the backend enum does.
- `services/frontend/src/components/common/modals/ManageMembershipDialog.vue` — both the active and deleted membership lists call it and drop the `text-capitalize` class.
- `services/frontend/tests/unit/utils/memberType.test.ts` — asserts the rendered label for every value of the generated `MemberType` enum, so a new value that does not title-case cleanly fails here, plus the null and undefined cases.

<!-- diff-stats:start -->
---
**Diff breakdown** — `█` added `░` removed, scaled to the largest row.

```text
frontend                                           +26     -2    3
  production         ██████████░░░                  +7     -2    2
  unit tests         ██████████████████████████    +19     -0    1

──────────────────────────────────────────────────────────────────
production                                          +7     -2
tests                                              +19     -0  2.71 test lines per prod line
total (hand-written)                               +26     -2  3 files
```
<!-- diff-stats:end -->