### PR TITLE
test(system): pin a desktop viewport for the Playwright context

### DIFF
--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/PlaywrightTestBase.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/PlaywrightTestBase.kt
@@ -49,7 +49,11 @@ abstract class PlaywrightTestBase {
     @BeforeEach
     fun createContext() {
         context = browser.newContext(
-            Browser.NewContextOptions().setIgnoreHTTPSErrors(true),
+            Browser.NewContextOptions()
+                .setIgnoreHTTPSErrors(true)
+                // Playwright's 1280 default sits exactly on Vuetify's lgAndUp
+                // breakpoint, so a scrollbar tips layouts to their mobile variant.
+                .setViewportSize(1600, 900),
         )
         context.setDefaultTimeout(DEFAULT_TIMEOUT_MS)
         context.setDefaultNavigationTimeout(DEFAULT_TIMEOUT_MS)


### PR DESCRIPTION
## Why

The Playwright browser context inherited the default 1280x720 viewport. Vuetify's `lgAndUp` breakpoint is 1280px, so the default sits exactly on the boundary. As soon as a page grows a vertical scrollbar the layout viewport loses roughly 15px, falls under 1280, and the page silently renders its mobile variant instead of the desktop one.

The failure this produces is misleading. A locator targeting a desktop-only control times out, so the test appears to fail on the interaction under test, when the real trigger is that the list got long enough to scroll. It also makes failures depend on data volume rather than on behaviour, which is how a suite acquires flakes that reproduce only on a full dataset.

## What this achieves

Layout no longer depends on scrollbar width. Desktop-only controls stay rendered regardless of how much content a test seeds, so a timeout on one of them means the control is genuinely absent.

## How

`services/system-tests/src/test/kotlin/net/blueshell/systemtests/PlaywrightTestBase.kt` sets `setViewportSize(1600, 900)` on the shared `Browser.NewContextOptions()` in `createContext()`. 1600 leaves ample margin above the 1280 breakpoint. Applying it on the context means every test inherits it, rather than each test hardening itself.

<!-- diff-stats:start -->
---
**Diff breakdown** — `█` added `░` removed, scaled to the largest row.

```text
system-tests                                        +5     -1    1
  system tests       ██████████████████████░░░░     +5     -1    1

──────────────────────────────────────────────────────────────────
production                                          +0     -0
tests                                               +5     -1
total (hand-written)                                +5     -1  1 files
```
<!-- diff-stats:end -->