### PR TITLE
fix(api): stop Redis repository scanning at startup

### DIFF
--- a/services/api/src/main/resources/application.yaml
+++ b/services/api/src/main/resources/application.yaml
@@ -45,6 +45,9 @@ spring:
       host: ${VALKEY_HOST:localhost}
       port: ${VALKEY_PORT:6379}
       timeout: 500ms
+      # Valkey backs sessions and the cache only, never Spring Data repositories.
+      repositories:
+        enabled: false
 
   jpa:
     hibernate:


### PR DESCRIPTION
## Why

Spring Data Redis is on the classpath because Valkey backs HTTP sessions and the cache layer. Spring Data's repository infrastructure defaults to scanning for Redis-backed repositories, and with JPA present as a second store, that scan inspects every JPA repository in strict mode and emits a `Could not safely identify store assignment for repository candidate` warning for each one.

No repository in this application is Redis-backed, so the scan can only ever find nothing. The warnings are pure noise, and one line per repository at every boot is enough to bury a real startup diagnostic.

## What this achieves

Startup logs stay readable, so a genuine repository or datasource problem is visible instead of being lost among warnings that never indicated anything. The pointless scan is also skipped.

## How

`services/api/src/main/resources/application.yaml` sets `spring.data.redis.repositories.enabled: false`, alongside the existing Valkey host, port and timeout settings. Sessions and caching are unaffected, since neither goes through the repository abstraction.

<!-- diff-stats:start -->
---
**Diff breakdown** — `█` added `░` removed, scaled to the largest row.

```text
api                                                 +3     -0    1
  production         ██████████████████████████     +3     -0    1

──────────────────────────────────────────────────────────────────
production                                          +3     -0
tests                                               +0     -0  0.00 test lines per prod line
total (hand-written)                                +3     -0  1 files
```
<!-- diff-stats:end -->