### PR TITLE
feat(api): shared vocabulary and fee resolution for bulk actions

### DIFF
--- a/services/api/src/main/kotlin/net/blueshell/api/domain/contribution/domain/service/FeeResolution.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/domain/contribution/domain/service/FeeResolution.kt
@@ -1,0 +1,62 @@
+package net.blueshell.api.domain.contribution.domain.service
+
+import net.blueshell.api.domain.contribution.persistence.ContributionPeriod
+import net.blueshell.api.shared.dto.bulk.BulkFeeType
+import net.blueshell.api.shared.enums.MemberType
+import java.time.LocalDate
+
+/**
+ * Fee type applicable to a member, or null for HONORARY members who are excluded.
+ *
+ * A REGULAR membership starting after the cutoff pays the half-year fee; one
+ * starting on the cutoff itself pays the full year.
+ */
+fun resolveFeeType(
+    memberType: MemberType,
+    membershipStartDate: LocalDate?,
+    cutoffDate: LocalDate,
+): BulkFeeType? = when (memberType) {
+    MemberType.REGULAR -> {
+        if (membershipStartDate != null && membershipStartDate > cutoffDate) {
+            BulkFeeType.HALF_YEAR_FEE
+        } else {
+            BulkFeeType.FULL_YEAR_FEE
+        }
+    }
+    MemberType.ALUMNI -> BulkFeeType.ALUMNI_FEE
+    MemberType.HONORARY -> null // Excluded
+    MemberType.NONE -> BulkFeeType.FULL_YEAR_FEE // Fallback for no membership
+}
+
+/**
+ * Resolves the € amount for a given [BulkFeeType] from the contribution period.
+ * This is a pure function with no side effects.
+ */
+fun resolveFeeAmount(feeType: BulkFeeType, period: ContributionPeriod): Double = when (feeType) {
+    BulkFeeType.FULL_YEAR_FEE -> period.fullYearFee
+    BulkFeeType.HALF_YEAR_FEE -> period.halfYearFee
+    BulkFeeType.ALUMNI_FEE -> period.alumniFee
+}
+
+/**
+ * Best-effort recovery of the [BulkFeeType] that produced a persisted [amount] for a
+ * given [period], by matching the amount against the period's fee options. Used by the
+ * send path, where only the resolved amount is stored on the reminder / incasso record
+ * (the fee type itself is not persisted). Falls back to [BulkFeeType.FULL_YEAR_FEE] when
+ * no fee option matches, so the email always states a reason.
+ */
+fun resolveFeeTypeFromAmount(amount: Double, period: ContributionPeriod): BulkFeeType = when (amount) {
+    period.halfYearFee -> BulkFeeType.HALF_YEAR_FEE
+    period.alumniFee -> BulkFeeType.ALUMNI_FEE
+    else -> BulkFeeType.FULL_YEAR_FEE
+}
+
+/**
+ * Human-readable reason for why a specific [BulkFeeType] applies to a member, stated
+ * inline in reminder / incasso emails so the amount is never quoted without context.
+ */
+fun feeReason(feeType: BulkFeeType): String = when (feeType) {
+    BulkFeeType.ALUMNI_FEE -> "the alumni fee, as you are an alumni member"
+    BulkFeeType.HALF_YEAR_FEE -> "the half-year fee, as your membership started during the second half of the year"
+    BulkFeeType.FULL_YEAR_FEE -> "the full-year fee"
+}

--- a/services/api/src/main/kotlin/net/blueshell/api/shared/dto/bulk/BulkActionEnvelope.kt
+++ b/services/api/src/main/kotlin/net/blueshell/api/shared/dto/bulk/BulkActionEnvelope.kt
@@ -1,0 +1,80 @@
+package net.blueshell.api.shared.dto.bulk
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * Shared preview/execute envelope for member-manager bulk actions.
+ *
+ * Lives in the shared kernel so every domain's bulk endpoints (contributions,
+ * memberships, and — later — reminders/incasso) return the same shape and the
+ * frontend can drive one confirmation dialog. All business logic that produces
+ * these values stays in the per-domain command handlers; this is pure data.
+ */
+
+/**
+ * Fee type used for contribution-reminder and incasso-notification bulk actions.
+ * The server resolves the € amount from the selected period's fee for the chosen type.
+ */
+@Schema(name = "BulkFeeType")
+enum class BulkFeeType {
+    /** Full-year fee — for REGULAR members who started before the half-year cutoff. */
+    FULL_YEAR_FEE,
+
+    /** Half-year fee — for REGULAR members who started on or after the half-year cutoff. */
+    HALF_YEAR_FEE,
+
+    /** Alumni fee — for ALUMNI members. */
+    ALUMNI_FEE,
+}
+
+/** How a selected user will be treated by a bulk action. */
+enum class BulkRowDisposition {
+    /** Will be acted on / emailed. */
+    INCLUDED,
+
+    /** No-op for this action (e.g. already paid, no active membership). */
+    SKIPPED,
+
+    /** Hard-excluded by a business rule and NOT overridable (e.g. honorary). */
+    EXCLUDED,
+
+    /** Excluded by default but the operator may opt the user back in (e.g. already-paid / no incasso). */
+    WARNING,
+}
+
+/** Machine-readable reason code for a non-INCLUDED disposition. */
+@Schema(name = "BulkRowReason")
+enum class BulkRowReason {
+    ALREADY_PAID,
+    NOT_PAID,
+    HONORARY,
+    INCASSO_MISMATCH,
+    NO_ACTIVE_MEMBERSHIP,
+    STARTED_TODAY,
+
+    /**
+     * Email actions (reminder/incasso): the user has no email address on file, so
+     * nothing can be sent. Previously the execute handler skipped these silently and
+     * the preview never surfaced it — now it is a first-class SKIPPED reason visible
+     * in the preview. See docs/proposals/bulk-actions/REDESIGN.md §3.
+     */
+    NO_EMAIL,
+    /** Resume/start-new: the user already has an active (endDate=null) membership. */
+    ALREADY_ACTIVE,
+    /** Resume/start-new: no contribution period exists at all. */
+    NO_CONTRIBUTION_PERIOD,
+    /** Preview outcome for INCLUDED rows: the most-recent membership will be resumed. */
+    WILL_RESUME,
+    /** Preview outcome for INCLUDED rows: a new membership will be inserted starting today. */
+    WILL_START_NEW,
+}
+
+@Schema(name = "BulkActionResult")
+data class BulkActionResult(
+    /** Rows changed (contributions created/deleted, memberships ended). */
+    val applied: Int,
+    /** Rows deliberately not changed (no-ops / excluded). */
+    val skipped: Int,
+    /** Emails queued (0 for non-email actions). */
+    val queued: Int = 0,
+)

--- a/services/api/src/test/kotlin/net/blueshell/api/domain/contribution/domain/service/FeeResolutionTest.kt
+++ b/services/api/src/test/kotlin/net/blueshell/api/domain/contribution/domain/service/FeeResolutionTest.kt
@@ -1,0 +1,106 @@
+package net.blueshell.api.domain.contribution.domain.service
+
+import net.blueshell.api.shared.dto.bulk.BulkFeeType
+import net.blueshell.api.domain.contribution.persistence.ContributionPeriod
+import net.blueshell.api.shared.enums.MemberType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class FeeResolutionTest {
+
+    private val period = ContributionPeriod(
+        startDate = LocalDate.of(2024, 1, 1),
+        endDate = LocalDate.of(2024, 12, 31),
+        halfYearFee = 50.0,
+        fullYearFee = 100.0,
+        alumniFee = 30.0,
+    )
+
+    private val cutoffDate = LocalDate.of(2024, 7, 1)
+
+    private fun feeFor(memberType: MemberType, startDate: LocalDate?): Double? =
+        resolveFeeType(memberType, startDate, cutoffDate)?.let { resolveFeeAmount(it, period) }
+
+    @Nested
+    inner class RegularMembers {
+
+        @Test
+        fun `starting before the cutoff pays the full year fee`() {
+            assertThat(resolveFeeType(MemberType.REGULAR, LocalDate.of(2024, 1, 1), cutoffDate))
+                .isEqualTo(BulkFeeType.FULL_YEAR_FEE)
+            assertThat(feeFor(MemberType.REGULAR, LocalDate.of(2024, 1, 1))).isEqualTo(100.0)
+        }
+
+        @Test
+        fun `starting exactly on the cutoff pays the full year fee`() {
+            assertThat(resolveFeeType(MemberType.REGULAR, cutoffDate, cutoffDate))
+                .isEqualTo(BulkFeeType.FULL_YEAR_FEE)
+            assertThat(feeFor(MemberType.REGULAR, cutoffDate)).isEqualTo(100.0)
+        }
+
+        @Test
+        fun `starting after the cutoff pays the half year fee`() {
+            assertThat(resolveFeeType(MemberType.REGULAR, LocalDate.of(2024, 8, 15), cutoffDate))
+                .isEqualTo(BulkFeeType.HALF_YEAR_FEE)
+            assertThat(feeFor(MemberType.REGULAR, LocalDate.of(2024, 8, 15))).isEqualTo(50.0)
+        }
+
+        @Test
+        fun `an unresolvable start date pays the full year fee`() {
+            assertThat(resolveFeeType(MemberType.REGULAR, null, cutoffDate))
+                .isEqualTo(BulkFeeType.FULL_YEAR_FEE)
+            assertThat(feeFor(MemberType.REGULAR, null)).isEqualTo(100.0)
+        }
+    }
+
+    @Nested
+    inner class AlumniMembers {
+
+        @Test
+        fun `pay the alumni fee regardless of start date`() {
+            listOf(LocalDate.of(2023, 1, 1), LocalDate.of(2024, 8, 1), null).forEach { startDate ->
+                assertThat(resolveFeeType(MemberType.ALUMNI, startDate, cutoffDate))
+                    .isEqualTo(BulkFeeType.ALUMNI_FEE)
+                assertThat(feeFor(MemberType.ALUMNI, startDate)).isEqualTo(30.0)
+            }
+        }
+    }
+
+    @Nested
+    inner class HonoraryMembers {
+
+        @Test
+        fun `are excluded regardless of start date`() {
+            listOf(LocalDate.of(2023, 1, 1), LocalDate.of(2024, 8, 1), null).forEach { startDate ->
+                assertThat(resolveFeeType(MemberType.HONORARY, startDate, cutoffDate)).isNull()
+            }
+        }
+    }
+
+    @Nested
+    inner class AmountRecovery {
+
+        @Test
+        fun `each fee option recovers its own type`() {
+            assertThat(resolveFeeTypeFromAmount(50.0, period)).isEqualTo(BulkFeeType.HALF_YEAR_FEE)
+            assertThat(resolveFeeTypeFromAmount(30.0, period)).isEqualTo(BulkFeeType.ALUMNI_FEE)
+            assertThat(resolveFeeTypeFromAmount(100.0, period)).isEqualTo(BulkFeeType.FULL_YEAR_FEE)
+        }
+
+        @Test
+        fun `an amount matching no fee option falls back to the full year fee`() {
+            assertThat(resolveFeeTypeFromAmount(12.34, period)).isEqualTo(BulkFeeType.FULL_YEAR_FEE)
+        }
+    }
+
+    @Nested
+    inner class Reasons {
+
+        @Test
+        fun `every fee type states a reason`() {
+            BulkFeeType.entries.forEach { assertThat(feeReason(it)).isNotBlank() }
+        }
+    }
+}


### PR DESCRIPTION
## Why

Bulk actions on members span two domains — contributions and memberships — and every one of them needs the same two ingredients. Each has to describe what it did to a given row, in terms a caller can act on rather than a free-text message. And several have to answer the same question: which contribution fee does this member owe for this period?

Fee resolution in particular is a rule that must not be restated per call site. It depends on member type and on where the membership start date falls relative to the half-year cutoff, and it has a boundary case that is easy to get wrong in one place and right in another.

## What this achieves

The fee tier is decided in one set of pure functions, so callers ask rather than re-derive, and the boundary is fixed by test: a REGULAR membership starting **on** the cutoff pays the full year, and only one starting strictly after it pays the half year. Bulk endpoints can report outcomes in a single shared vocabulary rather than each inventing its own.

The functions are pure and take a period rather than reaching for one, so they are exercised directly without a Spring context or a database.

## How

- `services/api/src/main/kotlin/net/blueshell/api/shared/dto/bulk/BulkActionEnvelope.kt` — `BulkFeeType`, `BulkRowDisposition` (included, skipped, hard-excluded, or excluded-but-overridable), `BulkRowReason` for the machine-readable cause, and `BulkActionResult` carrying applied, skipped and queued counts.
- `services/api/src/main/kotlin/net/blueshell/api/domain/contribution/domain/service/FeeResolution.kt` — `resolveFeeType` picks the tier and returns null for honorary members, who are excluded; `resolveFeeAmount` turns a tier into euros; `resolveFeeTypeFromAmount` recovers the tier on the send path, where only the resolved amount is persisted, falling back to the full-year tier so an email always states a reason; `feeReason` supplies that wording.
- `services/api/src/test/kotlin/.../FeeResolutionTest.kt` — covers each member type, both sides of the cutoff and the boundary itself, unresolvable start dates, amount recovery including the no-match fallback, and that every fee type has a reason.

Nothing calls any of this yet. It lands ahead of the endpoints that will, so the rules get reviewed on their own rather than inside a change that also adds HTTP surface.

<!-- diff-stats:start -->
---
**Diff breakdown** — `█` added `░` removed, scaled to the largest row.

```text
api                                               +248     -0    3
  production         ██████████████████████████   +142     -0    2
  unit tests         ███████████████████          +106     -0    1

──────────────────────────────────────────────────────────────────
production                                        +142     -0
tests                                             +106     -0  0.75 test lines per prod line
total (hand-written)                              +248     -0  3 files
```
<!-- diff-stats:end -->