### PR TITLE
ci: annotate dependency bumps and fix the diff-stats bar split

### DIFF
--- a/.github/scripts/pr_diff_stats.py
+++ b/.github/scripts/pr_diff_stats.py
@@ -173,15 +173,27 @@ def fetch_files(repo: str, pr: str) -> list[dict]:
 
 
 def bar(add: int, dele: int, scale: int) -> str:
-    if scale <= 0:
+    """Bar length encodes churn against `scale`; its split encodes added vs removed.
+
+    A generated row can exceed `scale`, since the scale covers hand-written rows
+    only. Such a row is clamped to full width, and the split is taken from the
+    row's own ratio so clamping cannot misreport it.
+    """
+    total = add + dele
+    if scale <= 0 or total <= 0:
         return ""
-    cells = lambda v: max(1, round(v / scale * BAR_WIDTH)) if v > 0 else 0  # noqa: E731
-    a, d = cells(add), cells(dele)
-    if a + d > BAR_WIDTH:
-        # Clamp overflow (generated rows share the hand-written scale).
-        keep = BAR_WIDTH - min(d, BAR_WIDTH - 1) if d else BAR_WIDTH
-        a, d = max(0, keep), min(d, BAR_WIDTH - max(0, keep))
-    return ADD_GLYPH * a + DEL_GLYPH * d
+    floor = 2 if add > 0 and dele > 0 else 1  # both glyphs need somewhere to go
+    width = min(BAR_WIDTH, max(floor, round(total / scale * BAR_WIDTH)))
+    added = round(width * add / total)
+    if add > 0 and added == 0:
+        added = 1
+    if dele > 0 and added == width:
+        added = width - 1
+    return ADD_GLYPH * added + DEL_GLYPH * (width - added)
+
+
+def plural(count: int, noun: str) -> str:
+    return f"{count} {noun}" if count == 1 else f"{count} {noun}s"
 
 
 def row(label: str, bar_text: str, add: int, dele: int, files: int, marker: str = "") -> str:
@@ -217,10 +229,12 @@ def render(files: list[dict], rules) -> str:
     def category_key(name: str) -> tuple[int, str]:
         return (CATEGORY_ORDER.index(name), "") if name in CATEGORY_ORDER else (len(CATEGORY_ORDER), name)
 
-    scale = max(
-        (c["add"] + c["del"] for (_, cat), c in buckets.items() if cat not in EXCLUDED),
-        default=0,
-    )
+    # Hand-written rows set the scale so generated churn cannot dwarf them. A
+    # dependency bump may have no hand-written rows at all; fall back to the
+    # generated ones so the bars still say something.
+    scale = max((c["add"] + c["del"] for (_, cat), c in buckets.items() if cat not in EXCLUDED), default=0)
+    if scale == 0:
+        scale = max((c["add"] + c["del"] for c in buckets.values()), default=0)
 
     lines: list[str] = []
     for service in sorted({s for s, _ in buckets}, key=service_key):
@@ -260,12 +274,14 @@ def render(files: list[dict], rules) -> str:
         return (line + ("  " + note if note else "")).rstrip()
 
     lines.append("─" * TOTAL_WIDTH)
-    lines.append(summary("production", prod["add"], prod["del"]))
-    ratio = f"{test['add'] / prod['add']:.2f} test lines per prod line" if prod["add"] else ""
-    lines.append(summary("tests", test["add"], test["del"], ratio))
-    lines.append(summary("total (hand-written)", kept["add"], kept["del"], f"{kept['files']} files"))
+    # A dependency bump touches neither, and two zero rows say less than no rows.
+    if prod["add"] or prod["del"] or test["add"] or test["del"]:
+        lines.append(summary("production", prod["add"], prod["del"]))
+        ratio = f"{test['add'] / prod['add']:.2f} test lines per prod line" if prod["add"] else ""
+        lines.append(summary("tests", test["add"], test["del"], ratio))
+    lines.append(summary("total (hand-written)", kept["add"], kept["del"], plural(kept["files"], "file")))
     if gen["files"]:
-        lines.append(summary("~ generated (excluded)", gen["add"], gen["del"], f"{gen['files']} files"))
+        lines.append(summary("~ generated (excluded)", gen["add"], gen["del"], plural(gen["files"], "file")))
 
     table = "\n".join(lines).rstrip()
     return (

--- a/.github/workflows/pr-diff-stats.yml
+++ b/.github/workflows/pr-diff-stats.yml
@@ -27,11 +27,11 @@ jobs:
     name: Annotate PR body with diff breakdown
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Dependabot pull requests are almost entirely lockfile churn, and the
-    # sender guard stops this job's own body edit from retriggering `edited`.
-    if: >-
-      github.event.pull_request.user.login != 'dependabot[bot]' &&
-      github.event.sender.login != 'github-actions[bot]'
+    # Stops this job's own body edit from retriggering on `edited`. Dependabot
+    # pull requests are included: separating a hand-written fix from lockfile
+    # churn is exactly what the generated split is for. Their token stays
+    # read/write because the base ref is not itself Dependabot-authored.
+    if: github.event.sender.login != 'github-actions[bot]'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Why

Dependency pull requests were excluded from the diff breakdown on the grounds that they are lockfile churn. That reasoning is backwards. A bump that needed a hand-written fix alongside it is precisely the case where the generated-versus-hand-written split is worth having, because it separates the part a reviewer must actually read from the part a tool produced. Excluded, that distinction is unavailable exactly where it is most useful.

Including them surfaced three rendering faults that had gone unnoticed, because until now no pull request had a row large enough to overflow the scale.

## What this achieves

A dependency bump now shows, at a glance, whether it is purely regenerated or carries hand-written changes, and how large those changes are. Bars report the added-to-removed ratio faithfully at every magnitude, including rows that exceed the chart scale.

## How

- `.github/workflows/pr-diff-stats.yml` — drops the Dependabot exclusion, keeping only the sender guard that prevents the job's own body edit from retriggering it. The elevated token remains available: the read-only restriction on `pull_request_target` applies when the base ref is itself Dependabot-authored, which is not the case for pull requests targeting the default branch.
- `.github/scripts/pr_diff_stats.py`:
  - Bar length is derived from the row total against the scale, and the added/removed split from the row's own ratio. Previously each component was scaled independently and then clamped, which inverted the proportion on any overflowing row: a `+1461 -1190` generated row rendered as one added cell followed by twenty-five removed. A row with both components non-zero now also reserves at least two cells, so neither can be rounded out of existence.
  - The scale falls back to the generated rows when a change has no hand-written ones, instead of staying at zero and suppressing every bar.
  - The production and tests rollups are omitted when a change touches neither, rather than stating two zero rows. File counts are pluralised.

Rendered against a current dependency bump:

```text
frontend                                           +25    -25    1
  build & config     █████████████░░░░░░░░░░░░░    +25    -25    1
  generated          ██████████████░░░░░░░░░░░░  +1461  -1190    3  ~

──────────────────────────────────────────────────────────────────
total (hand-written)                               +25    -25  1 file
~ generated (excluded)                           +1461  -1190  3 files
```

The 25 hand-written lines are a workflow change carried alongside the bump, and they are legible rather than buried under 2651 lines of regenerated lockfile.

<!-- diff-stats:start -->
---
**Diff breakdown** — `█` added `░` removed, scaled to the largest row.

```text
ci                                                 +38    -22    2
  build & config     ████████████████░░░░░░░░░░    +38    -22    2

──────────────────────────────────────────────────────────────────
production                                          +0     -0
tests                                               +0     -0
total (hand-written)                               +38    -22  2 files
```
<!-- diff-stats:end -->