### PR TITLE
fix(ci): classify repository-level tooling in the diff breakdown

### DIFF
--- a/.github/diff-stats.yml
+++ b/.github/diff-stats.yml
@@ -1,21 +1,7 @@
-# Taxonomy for the PR diff breakdown rendered by .github/scripts/pr_diff_stats.py.
-#
-# Rules are ORDERED and the first match wins, so narrow rules go above broad
-# ones. Adding a service or a test type is one new entry.
-#
-# Glob syntax: `*` matches within a path segment, `**` spans segments, and a
-# trailing `/**` also matches the directory itself. Paths are repo-relative and
-# always the NEW path for a rename.
-#
-# Categories drive the rollups at the bottom of the block:
-#   prod                                     -> "production"
-#   unit, integration, e2e, system, fixtures -> "tests"
-#   generated                                -> excluded from every total
-#   build, infra, docs, other                -> counted in the total only
-#
-# Parsed by a strict reader that accepts this shape only: a top-level sequence
-# of mappings with the three scalar keys below, plus `#` comments and blank
-# lines. Keep it that way and it stays valid YAML for any other reader.
+# Taxonomy for the diff breakdown. Ordered: first match wins.
+# `*` stops at a path separator, `**` spans them, a trailing `/**` also matches the dir.
+# `prod` and the test kinds roll up at the bottom of the block; `generated` is
+# excluded from every total.
 
 # --- generated and vendored: must stay first so they win over the src rules ---
 - glob: "services/frontend/src/services/api/**"
@@ -154,6 +140,28 @@
 
 - glob: "*.gradle.kts"
   service: ci
+  category: build
+
+# --- repo tooling: below everything path-specific, so a service keeps its own dotfiles ---
+- glob: ".idea/**"
+  service: repo
+  category: build
+
+# Only files sitting directly under services/, e.g. the shared .dockerignore.
+- glob: "services/*"
+  service: repo
+  category: build
+
+- glob: ".*"
+  service: repo
+  category: build
+
+- glob: "*.json"
+  service: repo
+  category: build
+
+- glob: "*.sh"
+  service: repo
   category: build
 
 # --- docs ---

--- a/.github/scripts/pr_diff_stats.py
+++ b/.github/scripts/pr_diff_stats.py
@@ -1,18 +1,9 @@
 #!/usr/bin/env python3
 """Render a per-service, per-category diff breakdown into a pull request body.
 
-File counts and line counts come from the GitHub pulls/{n}/files API, which
-already reports the three-dot (merge-base) diff and pre-resolves renames, so
-no checkout of the head ref is needed.
-
-Environment:
-    GH_TOKEN    token for `gh` (required unless --dry-run)
-    REPO        owner/name (required)
-    PR_NUMBER   pull request number (required)
-
-Usage:
-    pr_diff_stats.py             fetch, render, splice into the PR body
-    pr_diff_stats.py --dry-run   fetch and render to stdout, write nothing
+Counts come from the pulls/{n}/files API, which is already a merge-base diff with
+renames resolved, so no head checkout is needed. Reads GH_TOKEN, REPO, PR_NUMBER.
+Pass --dry-run to render to stdout and write nothing.
 """
 
 from __future__ import annotations
@@ -41,7 +32,7 @@ DEL_GLYPH = "░"  # light shade
 
 BODY_LIMIT = 65000
 
-SERVICE_ORDER = ["api", "frontend", "system-tests", "libs", "platform", "ci", "docs"]
+SERVICE_ORDER = ["api", "frontend", "system-tests", "libs", "platform", "ci", "repo", "docs"]
 CATEGORY_ORDER = [
     "prod",
     "unit",
@@ -115,11 +106,10 @@ def _scalar(value: str, where: str) -> str:
 
 
 def parse_rules(text: str, source: str = "<rules>") -> list[dict[str, str]]:
-    """Read the documented subset: a sequence of mappings with three scalar keys.
+    """Read a sequence of mappings with three scalar keys, raising on anything else.
 
-    Deliberately not PyYAML, which is absent from the runner image; pip
-    installing it would put a network dependency inside a privileged workflow.
-    Anything outside the documented shape raises rather than being skipped.
+    Not PyYAML: it is absent from the runner, and pip installing it would put a
+    network dependency inside a privileged workflow.
     """
     entries: list[dict[str, str]] = []
     for lineno, raw in enumerate(text.splitlines(), start=1):
@@ -173,11 +163,10 @@ def fetch_files(repo: str, pr: str) -> list[dict]:
 
 
 def bar(add: int, dele: int, scale: int) -> str:
-    """Bar length encodes churn against `scale`; its split encodes added vs removed.
+    """Length encodes churn against `scale`, the split encodes added vs removed.
 
-    A generated row can exceed `scale`, since the scale covers hand-written rows
-    only. Such a row is clamped to full width, and the split is taken from the
-    row's own ratio so clamping cannot misreport it.
+    A generated row can exceed `scale` and is clamped to full width; the split
+    comes from the row's own ratio so clamping cannot misreport it.
     """
     total = add + dele
     if scale <= 0 or total <= 0:
@@ -229,9 +218,8 @@ def render(files: list[dict], rules) -> str:
     def category_key(name: str) -> tuple[int, str]:
         return (CATEGORY_ORDER.index(name), "") if name in CATEGORY_ORDER else (len(CATEGORY_ORDER), name)
 
-    # Hand-written rows set the scale so generated churn cannot dwarf them. A
-    # dependency bump may have no hand-written rows at all; fall back to the
-    # generated ones so the bars still say something.
+    # Hand-written rows set the scale so generated churn cannot dwarf them, but a
+    # dependency bump has none, so fall back to generated rather than draw nothing.
     scale = max((c["add"] + c["del"] for (_, cat), c in buckets.items() if cat not in EXCLUDED), default=0)
     if scale == 0:
         scale = max((c["add"] + c["del"] for c in buckets.values()), default=0)


### PR DESCRIPTION
## Why

The diff breakdown fell back to an `unclassified` row for root-level tooling, because every rule in the taxonomy was path-specific and nothing matched a bare dotfile or a root config. A recent pull request reported 3 files and 38 lines as unclassified, which reads as a gap in the tool rather than as information about the change.

The fallback row exists so a new top-level directory is visible rather than silently dropped. It doing real work on an ordinary change means the taxonomy is incomplete, not that the change was unusual.

## What this achieves

Every tracked file in the repository classifies, so the `unclassified` row goes back to meaning "something new appeared that the taxonomy has not been told about" — which is the only reason to keep it.

## How

Rather than patch the three paths that happened to surface, I classified all 1739 tracked files and found exactly 13 unmatched, with nothing else outstanding:

- `.dockerignore`, `.editorconfig`, `.env`, `.gitattributes`, `.gitignore`
- `.idea/.gitignore`, `.idea/encodings.xml`, `.idea/misc.xml`, `.idea/vcs.xml`
- `services/.dockerignore`
- `dev-setup.sh`
- `release-please-config.json`, `.release-please-manifest.json`

A `repo` service under the existing `build` category now covers them, via `.idea/**`, `services/*`, `.*`, `*.json` and `*.sh`. The rules sit below everything path-specific, so a dotfile belonging to a service still lands with that service.

`services/*` deserves a note: it matches files directly under `services/` such as the shared `.dockerignore`, and cannot match anything inside a service, because `*` stops at a separator. It is not a catch-all for future services — a new `services/<name>/**` tree still surfaces as unclassified, which is the intended behaviour.

`repo` is added to the service ordering so it renders in a fixed position rather than sorting with unknown services.

Verified across every tracked file: nothing unclassified afterwards, and no file that already had a bucket changed one.

<!-- diff-stats:start -->
---
**Diff breakdown** — `█` added `░` removed, scaled to the largest row.

```text
ci                                                 +38    -42    2
  build & config     ████████████░░░░░░░░░░░░░░    +38    -42    2

──────────────────────────────────────────────────────────────────
total (hand-written)                               +38    -42  2 files
```
<!-- diff-stats:end -->