### PR TITLE
docs(ci): shorten the pull request workflow comments

### DIFF
--- a/.github/workflows/pr-diff-stats.yml
+++ b/.github/workflows/pr-diff-stats.yml
@@ -1,15 +1,10 @@
 name: PR diff stats
 
-# Renders a per-service, per-category breakdown of the diff into the bottom of
-# the pull request body.
+# Renders a per-service diff breakdown into the bottom of the pull request body.
 #
-# `pull_request_target` rather than `pull_request`: the latter hands out a
-# read-only token for dependabot and fork pull requests, which is most of this
-# repo's volume, and the body cannot be written with it. The elevated token is
-# safe here only because the job never checks out or executes head-ref code —
-# the diff is read from the pulls/{n}/files API, which also gives merge-base
-# semantics and pre-resolved renames for free. Do not add a `ref:` to the
-# checkout step below.
+# `pull_request_target` because `pull_request` gives dependabot and fork pull
+# requests a read-only token. Safe only because no head-ref code is checked out
+# or run, so do not add a `ref:` to the checkout below.
 
 on:
   pull_request_target:
@@ -27,16 +22,13 @@ jobs:
     name: Annotate PR body with diff breakdown
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Stops this job's own body edit from retriggering on `edited`. Dependabot
-    # pull requests are included: separating a hand-written fix from lockfile
-    # churn is exactly what the generated split is for. Their token stays
-    # read/write because the base ref is not itself Dependabot-authored.
+    # Stops this job's own body edit from retriggering on `edited`.
     if: github.event.sender.login != 'github-actions[bot]'
     permissions:
       contents: read
       pull-requests: write
     steps:
-      # No `ref:` — this must stay on the trusted base ref. See the note above.
+      # No `ref:` — must stay on the trusted base ref.
       - name: Check out the base ref
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,11 +1,8 @@
 name: PR title
 
-# The squash-merge subject is taken from the pull request title, so the title
-# is what lands in history and what release-please reads to decide a version.
-#
-# `synchronize` is included even though a push cannot change the title: a
-# required check is recorded against the head commit, so without it a new push
-# would leave this check absent rather than green.
+# The squash-merge subject comes from the title, so it is what lands in history
+# and what release-please reads. `synchronize` keeps the required check present
+# on each new head commit.
 
 on:
   pull_request:
@@ -26,14 +23,10 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      # Types are left at the action's default, which is the standard
-      # conventional-commit-types set. Scopes are unrestricted on purpose:
-      # this repo uses compound scopes such as `api,frontend` and `cohort+jobs`.
+      # Default types. Scopes unrestricted: this repo uses `api,frontend`-style scopes.
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # On a single-commit pull request GitHub offers that commit's message
-          # as the squash subject, so the commit has to hold up as well as the
-          # title. Most pull requests here are single-commit.
+          # A single-commit PR can squash with the commit message, not the title.
           validateSingleCommit: true


### PR DESCRIPTION
## Why

The comments in the two pull request workflows explained their reasoning at a length that belongs in a commit message or a pull request body. `CLAUDE.md` asks for one line, two at most, and only where the reason is not obvious from the code; these ran to ten and six lines of narration.

## What this achieves

Both files read at a glance, and the comments that remain each earn their place.

## How

- `.github/workflows/pr-diff-stats.yml` — 15 comment lines down to 7.
- `.github/workflows/pr-title.yml` — 12 down to 5.

One comment is deliberately kept: the warning that the privileged checkout must not gain a `ref:`. Adding one would make `pull_request_target` execute head-ref code with a write token, so that note prevents a real mistake rather than restating the code. It is now two lines instead of six.

No behaviour changes; both files still parse as valid workflow YAML.

<!-- diff-stats:start -->
---
**Diff breakdown** — `█` added `░` removed, scaled to the largest row.

```text
ci                                                 +11    -26    2
  build & config     ████████░░░░░░░░░░░░░░░░░░    +11    -26    2

──────────────────────────────────────────────────────────────────
total (hand-written)                               +11    -26  2 files
```
<!-- diff-stats:end -->