### PR TITLE
fix(ci): name the release pull request after its version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "bootstrap-sha": "c0a61a507906bb692fd0a4fce24bd31ba7ac7257",
   "include-component-in-tag": false,
   "separate-pull-requests": false,
+  "pull-request-title-pattern": "chore: release ${version}",
   "packages": {
     ".": {
       "release-type": "simple",


### PR DESCRIPTION
## Why

The first release pull request came out titled `chore: release main`. In manifest mode with a single root package, release-please titles the aggregate pull request after the target branch rather than the version, so the documented default of `chore(main): release foo-bar v1.2.3` does not apply and the version appears only in the body.

Since pull requests here squash-merge, that title becomes a commit subject on `main`. Every release would land as `chore: release main`, with nothing in history distinguishing one from the next.

## What this achieves

Release commits identify themselves. `git log` shows `chore: release 1.2.0`, so the point a version was cut is readable without opening the pull request or cross-referencing tags.

## How

Sets `pull-request-title-pattern` to `chore: release ${version}` in `release-please-config.json`. The type stays `chore`, so the release commit remains hidden from the changelog and release-neutral, and the title still satisfies the Conventional Commits check.

Separate from the pull request that added release-please because that one has already merged.

<!-- diff-stats:start -->
---
**Diff breakdown** — `█` added `░` removed, scaled to the largest row.

```text
other                                               +1     -0    1
  unclassified       ██████████████████████████     +1     -0    1

──────────────────────────────────────────────────────────────────
total (hand-written)                                +1     -0  1 file
```
<!-- diff-stats:end -->