### PR TITLE
fix(ci): let the release run workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,4 +26,7 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Anything GITHUB_TOKEN does raises no events, so with it the published
+          # release never reaches build.yml and :latest never moves. Falls back
+          # only so the workflow still runs if the secret is absent.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

Anything done with the built-in `GITHUB_TOKEN` raises no events, by design, so that a workflow cannot trigger itself into a loop. That single rule breaks the release path in three places, of which the visible one is the least serious.

The release pull request runs no tests. `validate.yml` triggers on `push`, and the branch push came from `GITHUB_TOKEN`, so it never started. The path filters do match the files a release touches — `build.gradle.kts`, `services/api/build.gradle.kts`, `services/frontend/package.json` — so the suite would run if the push were attributable to anyone else.

The workflows that do run wait for manual approval. `github-actions[bot]` has no write association with the repository, so its pull requests hit the first-time-contributor approval gate. Dependabot does not, because GitHub special-cases `dependabot[bot]` explicitly; that exemption does not extend to other bots.

Most seriously, **the published release raises no event either**. `build.yml` listens for `release: published` to rebuild every service and move `:latest`, which is the tag Keel polls. A release created with `GITHUB_TOKEN` never fires it, so merging a release pull request would tag and write a changelog while the cluster kept running the previous image. Gating rollout on releases would have meant nothing rolling out at all, silently, with a green release to suggest otherwise.

## What this achieves

Releases behave like the change that introduced them intended: the release pull request runs the full suite before it is approved, without anyone clicking through an approval prompt, and merging it actually deploys.

## How

`.github/workflows/release-please.yml` prefers a `RELEASE_PLEASE_TOKEN` secret and falls back to `GITHUB_TOKEN`, so the workflow keeps working before the secret exists and upgrades the moment it does.

**This needs a secret to be created before it takes effect.** A fine-grained personal access token scoped to this repository, with `Contents: read and write` and `Pull requests: read and write`, stored as the repository secret `RELEASE_PLEASE_TOKEN`. A GitHub App installation token is the better long-term option, since it is not tied to a person and rotates on its own, but it is more setup for the same result.

Until the secret exists nothing changes: the fallback keeps the current behaviour, including the approval prompts.

<!-- diff-stats:start -->
---
**Diff breakdown** — `█` added `░` removed, scaled to the largest row.

```text
ci                                                  +4     -1    1
  build & config     █████████████████████░░░░░     +4     -1    1

──────────────────────────────────────────────────────────────────
total (hand-written)                                +4     -1  1 file
```
<!-- diff-stats:end -->