### PR TITLE
fix(ci): publish release images without a stored token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,10 @@ name: Build
 # into a manifest list, so neither arch waits on QEMU emulation and each gets
 # its own GHA cache scope.
 #
-# main tags :sha-<short> only. release-please calls this with release-tag set,
+# main tags :sha-<short> only. release.yml calls this with release-tag set,
 # which also moves :latest — the tag Keel polls — so only releases reach
-# production. It is called rather than triggered because a release cut with
-# GITHUB_TOKEN raises no event.
+# production. It is called rather than triggered by `release: published`
+# because a release cut with GITHUB_TOKEN raises no event.
 on:
   push:
     branches: [main]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,13 +6,19 @@ name: Build
 # into a manifest list, so neither arch waits on QEMU emulation and each gets
 # its own GHA cache scope.
 #
-# main tags :sha-<short> only; a published release also moves :latest, which is
-# the tag Keel polls, so only releases reach production.
+# main tags :sha-<short> only. release-please calls this with release-tag set,
+# which also moves :latest — the tag Keel polls — so only releases reach
+# production. It is called rather than triggered because a release cut with
+# GITHUB_TOKEN raises no event.
 on:
   push:
     branches: [main]
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      release-tag:
+        description: Tag to publish, e.g. v1.2.0. Empty means an ordinary main build.
+        type: string
+        default: ''
   workflow_dispatch:
 
 # Sequential: two consecutive main commits build one after the other.
@@ -53,7 +59,7 @@ jobs:
       # Skipped on a release: the tag needs a complete set of images.
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
-        if: github.event_name != 'release'
+        if: inputs.release-tag == ''
         with:
           base: ${{ github.event.before }}
           filters: |
@@ -86,7 +92,7 @@ jobs:
           FILTER_BUILD_LOGIC: ${{ steps.filter.outputs.build-logic }}
           FILTER_LIBS: ${{ steps.filter.outputs.libs }}
           FILTER_GRADLE_CONFIG: ${{ steps.filter.outputs.gradle-config }}
-          IS_RELEASE: ${{ github.event_name == 'release' }}
+          IS_RELEASE: ${{ inputs.release-tag != '' }}
         run: |
           set -euo pipefail
           any() { for v in "$@"; do [[ "$v" == "true" ]] && echo "true" && return; done; echo "false"; }
@@ -252,8 +258,8 @@ jobs:
         env:
           IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.service }}
           SHORT: ${{ steps.sha.outputs.short }}
-          # Empty unless this run was triggered by a published release.
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          # Empty unless release-please called this workflow for a release.
+          RELEASE_TAG: ${{ inputs.release-tag }}
         run: |
           set -euo pipefail
           sources=()

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,7 @@ name: Release Please
 
 # Maintains a release pull request and computes the next version from the
 # Conventional Commits merged since the last release. Merging it tags the
-# release, which is what promotes images to :latest in build.yml.
+# release and, in the same run, publishes the images Keel rolls out.
 
 on:
   push:
@@ -23,7 +23,34 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
+    outputs:
+      released: ${{ steps.release.outputs.releases_created }}
+      tag: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      # The release branch push raises no event, and the pull request's own
+      # checks sit behind an approval prompt. workflow_dispatch is the one
+      # trigger GITHUB_TOKEN may fire, so validation runs unattended.
+      - name: Validate the release branch
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run validate.yml --repo "$GITHUB_REPOSITORY" --ref release-please--branches--main
+
+  publish-release-images:
+    # Called rather than triggered by `release: published`: a release cut with
+    # GITHUB_TOKEN raises no event, so nothing would listen.
+    name: Publish release images
+    needs: release-please
+    if: needs.release-please.outputs.released == 'true'
+    uses: ./.github/workflows/build.yml
+    with:
+      release-tag: ${{ needs.release-please.outputs.tag }}
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,22 @@
-name: Release Please
+name: Release
 
-# Maintains a release pull request and computes the next version from the
-# Conventional Commits merged since the last release. Merging it tags the
-# release and, in the same run, publishes the images Keel rolls out.
+# Owns the release path: computes the next version from the Conventional
+# Commits merged since the last release, and once that release is cut,
+# publishes the images Keel rolls out.
 
 on:
   push:
     branches: [main]
 
 concurrency:
-  group: release-please
+  group: release
   cancel-in-progress: false
 
 permissions:
   contents: read
 
 jobs:
-  release-please:
+  version:
     name: Maintain the release pull request
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -33,24 +33,24 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      # The release branch push raises no event, and the pull request's own
-      # checks sit behind an approval prompt. workflow_dispatch is the one
-      # trigger GITHUB_TOKEN may fire, so validation runs unattended.
+      # Dispatched, not called: a reusable workflow would run at this run's ref
+      # (main) rather than the release branch. GITHUB_TOKEN may fire
+      # workflow_dispatch, so this needs no approval.
       - name: Validate the release branch
         if: steps.release.outputs.prs_created == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh workflow run validate.yml --repo "$GITHUB_REPOSITORY" --ref release-please--branches--main
 
-  publish-release-images:
+  publish:
     # Called rather than triggered by `release: published`: a release cut with
     # GITHUB_TOKEN raises no event, so nothing would listen.
     name: Publish release images
-    needs: release-please
-    if: needs.release-please.outputs.released == 'true'
+    needs: version
+    if: needs.version.outputs.released == 'true'
     uses: ./.github/workflows/build.yml
     with:
-      release-tag: ${{ needs.release-please.outputs.tag }}
+      release-tag: ${{ needs.version.outputs.tag }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Why

Anything done with the built-in `GITHUB_TOKEN` raises no events, so a workflow cannot trigger itself into a loop. That rule is not uniform, and the differences decide what is possible here. Measured on the current release pull request, and confirmed against GitHub's documentation:

| Event | Behaviour with `GITHUB_TOKEN` |
|---|---|
| `push` | Fully suppressed — no run object is created at all |
| `pull_request` opened/synchronize/reopened | Run is created but held in `action_required` |
| `release` published | **Fully suppressed** |
| `workflow_dispatch`, `repository_dispatch` | **Exempt — these always run** |

The consequence that matters: `build.yml` listened for `release: published` to rebuild every service and move `:latest`, the tag Keel polls. A release cut with `GITHUB_TOKEN` never fires it. Merging a release pull request would have tagged the version, written the changelog and bumped every version file, while the cluster kept running the previous image — and the release would have looked successful.

Two lesser symptoms share the cause. The release branch push starts no validation, because `push` is suppressed. And the pull request's own checks sit in `action_required`, because GitHub began requiring approval for pull requests authored by `github-actions[bot]` in June 2026, same-repository ones included. Dependabot is exempt from that gate as a built-in service; no equivalent exemption or allowlist exists for other bots.

## What this achieves

Releases publish their images and validate themselves, with no personal access token, no GitHub App private key, and no approval prompt to click.

## How

`release-please.yml` becomes `release.yml`, because it owns the release path rather than merely running a tool: it computes the version, and once a release is cut, publishes the images that release produces. Its jobs are named `version` and `publish`.

**Images.** `build.yml` gains a `workflow_call` trigger with a `release-tag` input, replacing the `release: published` trigger that could never fire. `release.yml` calls it as a job in the same run, gated on the action's `releases_created` output, passing `tag_name`. Because it is a job rather than a separate workflow run, no event needs to be raised. The release path is otherwise unchanged: change detection is bypassed so the tag carries a complete set of images, and `:latest` moves only when `release-tag` is non-empty.

The `inputs` context is empty for a `push`, so `inputs.release-tag` is empty there and an ordinary main build still tags `:sha-<short>` only.

**Validation.** After release-please opens or updates the release pull request, `release.yml` dispatches `validate.yml` at the release branch. Dispatch rather than a reusable-workflow call is deliberate: a `uses:` call runs at the calling run's ref, which is `main`, and would validate the wrong tree. `workflow_dispatch` is one of the two triggers `GITHUB_TOKEN` may fire, so the suite runs unattended. This needs `actions: write` on the job.

This is worth having rather than assuming a release is safe by construction: the release commit edits `build.gradle.kts` and `services/frontend/package.json`, so a bad version bump would otherwise surface only after merge, when the release build fails.

One trade-off worth stating: a dispatched run is not attached to the pull request as a status check, so it appears under Actions rather than in the merge box. The alternative that would produce a real check is a stored token, which is what this change exists to avoid.

## Alternatives considered

A personal access token or GitHub App token fixes all three symptoms at once and is what release-please's own issue tracker recommends, but both mean storing a long-lived credential. `workflow_run` was a dead end: it does not fire when the upstream run came from a `GITHUB_TOKEN` push. Relaxing the approval setting does not help either, since it governs fork pull requests and would not have restored the suppressed `push` and `release` events regardless.

A `repository_dispatch` handshake would decouple the two workflows, at the cost of making the link invisible in the YAML. A manual promotion workflow would remove the coupling entirely but puts a click between a release and its rollout, and would need per-service resolution of which `:sha-` image belongs to a tag.