### PR TITLE
fix(release): stop the component check rejecting every release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,6 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "package-name": "website",
       "changelog-path": "docs/changelogs/08-2026-automated-releases.md",
       "extra-files": [
         { "type": "json", "path": "services/frontend/package.json", "jsonpath": "$.version" },


### PR DESCRIPTION
## Why

No release has been tagged, no GitHub release exists, and no new release pull request opens even though releasable commits keep landing on `main`. Every run of the release workflow succeeds while doing nothing, ending with:

```
⚠ There are untagged, merged release PRs outstanding - aborting
```

The outstanding pull request is the merged one for 1.2.0. It cannot be turned into a release because of this, one line earlier:

```
⚠ PR component: undefined does not match configured component: website
```

release-please treats `package-name` as the component, and recovers a merged pull request's component by parsing its title against `pull-request-title-pattern`. The configured pattern states only the version, so the parsed component is always `undefined`, which never equals `website`. The release is therefore unbuildable, it stays labelled `autorelease: pending`, and release-please refuses to open any further release pull request while an untagged merged one exists. The queue is blocked behind a release that can never be built.

This is a deadlock rather than a transient failure: it cannot clear itself, and every subsequent merge makes the eventual release larger.

## What this achieves

The merged release becomes buildable, so it gets its tag and GitHub release, the label moves to `autorelease: tagged`, and the next release pull request opens. Because publishing is gated on `releases_created`, the release images also get built and `:latest` moves — which has not happened yet either.

## How

Drops `package-name` from `release-please-config.json`.

There is a single package at the repository root, and `include-component-in-tag` is already `false`, so tags are plain `v1.2.0` and no component is needed to disambiguate anything. With no component configured, the component parsed from the title — `undefined` — matches, and the title pattern round-trips.

The alternative, adding `${component}` to the title pattern, would make every release read `chore: release website 1.2.0`, naming a component that exists only to satisfy the check.

## Note on the merged 1.2.0 pull request

Its title was written by release-please's default pattern before that pattern was changed, so it read `chore: release main` and could not be parsed at all. It has been retitled to `chore: release 1.2.0` so the version parses. That change alone was not sufficient — it exposed the component mismatch this fixes.

<!-- diff-stats:start -->
---
**Diff breakdown** — `█` added `░` removed, scaled to the largest row.

```text
repo                                                +0     -1    1
  build & config     ░░░░░░░░░░░░░░░░░░░░░░░░░░     +0     -1    1

──────────────────────────────────────────────────────────────────
total (hand-written)                                +0     -1  1 file
```
<!-- diff-stats:end -->