### PR TITLE
refactor(frontend): extract a reusable row-filter composable

### DIFF
--- a/services/frontend/src/composables/useRowFilters.ts
+++ b/services/frontend/src/composables/useRowFilters.ts
@@ -1,0 +1,107 @@
+import {computed, reactive, toValue, type MaybeRefOrGetter} from "vue"
+
+/**
+ * One filter, defined in a single place: where it starts, what "off" looks like,
+ * and how it matches.
+ */
+export interface Filter<T, V> {
+  /** Value the filter holds on first render. */
+  initial: V
+  /**
+   * The value meaning "not filtering", or a test for it. A plain value is compared
+   * with `Object.is`, so array and object values need the test form — `[] === []` is
+   * false and such a filter would read as permanently active.
+   */
+  unset: V | ((value: V) => boolean)
+  /**
+   * Returns the row test for a given value. Called once per value rather than per
+   * row, so per-value work is hoisted, and reactive reads here are tracked even
+   * when no row reaches the returned test.
+   */
+  match: (value: V) => (row: T) => boolean
+}
+
+/** Pins the row type so each filter only states its own value type. */
+export function filtersFor<T>() {
+  return <V>(filter: Filter<T, V>): Filter<T, V> => filter
+}
+
+// `any` is confined to the constraint; `infer V` recovers each real value type below.
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+type AnyFilter<T> = Filter<T, any>
+
+type ValueOf<T, F> = F extends Filter<T, infer V> ? V : never
+type StateOf<T, F> = {[K in keyof F]: ValueOf<T, F[K]>}
+
+/**
+ * Filters rows through a record of named filters. A filter sitting at its unset
+ * value is skipped rather than run, so an untouched filter costs nothing per row.
+ * Filters run in declaration order, so declare cheap ones before expensive ones.
+ */
+export function useRowFilters<T, F extends Record<string, AnyFilter<T>>>(
+  rows: MaybeRefOrGetter<readonly T[] | undefined>,
+  filters: F,
+) {
+  const entries = Object.entries(filters) as [string, Filter<T, unknown>][]
+  const values = reactive({} as Record<string, unknown>)
+
+  for (const [key, filter] of entries) {
+    values[key] = filter.initial
+  }
+
+  function isUnset(key: string, filter: Filter<T, unknown>): boolean {
+    const {unset} = filter
+    return typeof unset === "function"
+      ? (unset as (value: unknown) => boolean)(values[key])
+      : Object.is(values[key], unset)
+  }
+
+  const activeKeys = computed(() => entries.filter(([k, f]) => !isUnset(k, f)).map(([k]) => k))
+
+  const filteredRows = computed<T[]>(() => {
+    const source = toValue(rows) ?? []
+
+    // Built before the row loop, so reactive reads inside `match` are tracked
+    // whether or not any row reaches the returned test.
+    const tests: ((row: T) => boolean)[] = []
+    for (const [key, filter] of entries) {
+      if (isUnset(key, filter)) continue
+      try {
+        tests.push(filter.match(values[key]))
+      } catch (error) {
+        console.error(`[useRowFilters] filter "${key}" could not be built; ignoring it`, error)
+      }
+    }
+
+    if (tests.length === 0) return [...source]
+    try {
+      return source.filter((row) => tests.every((test) => test(row)))
+    } catch (error) {
+      // This runs during render, so a throw would escape to the app error handler
+      // and blank the table. Degrade to unfiltered, loudly, instead.
+      console.error("[useRowFilters] a filter threw while matching; showing all rows", error)
+      return [...source]
+    }
+  })
+
+  /** Sets filters to their unset value. Filters that define unset as a test are skipped. */
+  function clear(key?: keyof F & string) {
+    for (const [k, filter] of entries) {
+      if (key !== undefined && k !== key) continue
+      if (typeof filter.unset !== "function") values[k] = filter.unset
+    }
+  }
+
+  /** Sets filters back to the value they started with, which may itself be filtering. */
+  function reset() {
+    for (const [key, filter] of entries) values[key] = filter.initial
+  }
+
+  return {
+    state: values as StateOf<T, F>,
+    filteredRows,
+    activeKeys: activeKeys as import("vue").ComputedRef<(keyof F & string)[]>,
+    clear,
+    reset,
+  }
+}

--- a/services/frontend/src/composables/useRowFilters.ts
+++ b/services/frontend/src/composables/useRowFilters.ts
@@ -7,21 +7,24 @@ import {computed, reactive, toValue, type MaybeRefOrGetter} from "vue"
 export interface Filter<T, V> {
   /** Value the filter holds on first render. */
   initial: V
+  /** The value meaning "not filtering". `clear()` writes this. */
+  unset: V
   /**
-   * The value meaning "not filtering", or a test for it. A plain value is compared
-   * with `Object.is`, so array and object values need the test form — `[] === []` is
-   * false and such a filter would read as permanently active.
+   * Whether a value counts as not filtering. Defaults to `Object.is(value, unset)`,
+   * which is wrong for arrays and objects — `[] === []` is false, so such a filter
+   * would read as permanently active and reject every row on first render.
    */
-  unset: V | ((value: V) => boolean)
+  isUnset?: (value: V) => boolean
   /**
    * Returns the row test for a given value. Called once per value rather than per
    * row, so per-value work is hoisted, and reactive reads here are tracked even
-   * when no row reaches the returned test.
+   * when no row reaches the returned test — with a per-row predicate such a read is
+   * only tracked in runs where some row gets that far, so results can go stale.
    */
   match: (value: V) => (row: T) => boolean
 }
 
-/** Pins the row type so each filter only states its own value type. */
+/** Pins the row type so each filter states only its own value type. Identity at runtime. */
 export function filtersFor<T>() {
   return <V>(filter: Filter<T, V>): Filter<T, V> => filter
 }
@@ -33,10 +36,20 @@ type AnyFilter<T> = Filter<T, any>
 type ValueOf<T, F> = F extends Filter<T, infer V> ? V : never
 type StateOf<T, F> = {[K in keyof F]: ValueOf<T, F[K]>}
 
+/** Copied so a filter holding an array or object cannot alias its own `initial`. */
+function seed(value: unknown): unknown {
+  if (Array.isArray(value)) return [...value]
+  if (value !== null && typeof value === "object") return {...value}
+  return value
+}
+
 /**
- * Filters rows through a record of named filters. A filter sitting at its unset
- * value is skipped rather than run, so an untouched filter costs nothing per row.
- * Filters run in declaration order, so declare cheap ones before expensive ones.
+ * Filters rows through a record of named filters. A filter sitting at its unset value
+ * is skipped rather than run, so an untouched filter costs nothing per row. Filters
+ * run in declaration order, so declare cheap ones before expensive ones.
+ *
+ * A filter that throws yields no rows rather than all of them: showing more rows than
+ * were asked for is the more dangerous failure when the result drives a bulk action.
  */
 export function useRowFilters<T, F extends Record<string, AnyFilter<T>>>(
   rows: MaybeRefOrGetter<readonly T[] | undefined>,
@@ -45,18 +58,21 @@ export function useRowFilters<T, F extends Record<string, AnyFilter<T>>>(
   const entries = Object.entries(filters) as [string, Filter<T, unknown>][]
   const values = reactive({} as Record<string, unknown>)
 
-  for (const [key, filter] of entries) {
-    values[key] = filter.initial
+  for (const [key, filter] of entries) values[key] = seed(filter.initial)
+
+  function isActive(key: string, filter: Filter<T, unknown>): boolean {
+    const value = values[key]
+    try {
+      return filter.isUnset ? !filter.isUnset(value) : !Object.is(value, filter.unset)
+    } catch (error) {
+      // Treat an unreadable value as filtering, so the match below decides the
+      // outcome rather than the row silently passing.
+      console.error(`[useRowFilters] filter "${key}" could not test its value`, error)
+      return true
+    }
   }
 
-  function isUnset(key: string, filter: Filter<T, unknown>): boolean {
-    const {unset} = filter
-    return typeof unset === "function"
-      ? (unset as (value: unknown) => boolean)(values[key])
-      : Object.is(values[key], unset)
-  }
-
-  const activeKeys = computed(() => entries.filter(([k, f]) => !isUnset(k, f)).map(([k]) => k))
+  const activeKeys = computed(() => entries.filter(([k, f]) => isActive(k, f)).map(([k]) => k))
 
   const filteredRows = computed<T[]>(() => {
     const source = toValue(rows) ?? []
@@ -65,11 +81,12 @@ export function useRowFilters<T, F extends Record<string, AnyFilter<T>>>(
     // whether or not any row reaches the returned test.
     const tests: ((row: T) => boolean)[] = []
     for (const [key, filter] of entries) {
-      if (isUnset(key, filter)) continue
+      if (!isActive(key, filter)) continue
       try {
         tests.push(filter.match(values[key]))
       } catch (error) {
-        console.error(`[useRowFilters] filter "${key}" could not be built; ignoring it`, error)
+        console.error(`[useRowFilters] filter "${key}" could not be built`, error)
+        return []
       }
     }
 
@@ -77,24 +94,22 @@ export function useRowFilters<T, F extends Record<string, AnyFilter<T>>>(
     try {
       return source.filter((row) => tests.every((test) => test(row)))
     } catch (error) {
-      // This runs during render, so a throw would escape to the app error handler
-      // and blank the table. Degrade to unfiltered, loudly, instead.
-      console.error("[useRowFilters] a filter threw while matching; showing all rows", error)
-      return [...source]
+      console.error("[useRowFilters] a filter threw while matching; showing no rows", error)
+      return []
     }
   })
 
-  /** Sets filters to their unset value. Filters that define unset as a test are skipped. */
+  /** Sets filters to their unset value. */
   function clear(key?: keyof F & string) {
     for (const [k, filter] of entries) {
       if (key !== undefined && k !== key) continue
-      if (typeof filter.unset !== "function") values[k] = filter.unset
+      values[k] = seed(filter.unset)
     }
   }
 
   /** Sets filters back to the value they started with, which may itself be filtering. */
   function reset() {
-    for (const [key, filter] of entries) values[key] = filter.initial
+    for (const [key, filter] of entries) values[key] = seed(filter.initial)
   }
 
   return {

--- a/services/frontend/src/composables/useUserFilters.ts
+++ b/services/frontend/src/composables/useUserFilters.ts
@@ -11,6 +11,14 @@ export type SortKey = "name" | "username" | "role" | "status" | "memberSince" | 
 
 const statusOrder: Record<MemberStatus, number> = {Current: 0, Former: 1, Never: 2}
 
+// Exhaustive, so a new MembershipStatusFilter value fails the typecheck rather than
+// silently falling through to "Never". "all" never reaches here; it reads as unset.
+const STATUS_BY_FILTER: Record<Exclude<MembershipStatusFilter, "all">, MemberStatus> = {
+  current: "Current",
+  former: "Former",
+  never: "Never",
+}
+
 // ── Composable ─────────────────────────────────────────────────────────────────
 
 export function useUserFilters(
@@ -26,7 +34,9 @@ export function useUserFilters(
       initial: "all",
       unset: "all",
       match: (value) => {
-        const wanted: MemberStatus = value === "current" ? "Current" : value === "former" ? "Former" : "Never"
+        // Unreachable in practice: "all" reads as unset, so match is not called for it.
+        if (value === "all") return () => true
+        const wanted = STATUS_BY_FILTER[value]
         return (row) => row.status === wanted
       },
     }),
@@ -38,20 +48,22 @@ export function useUserFilters(
     incassoFilter: filter<FilterState>({
       initial: "all",
       unset: "all",
-      match: (value) => (row) => Boolean(row.latestIncasso) === (value === "yes"),
+      match: (value) => (row) => row.latestIncasso === (value === "yes"),
     }),
     periodMemberFilter: filter<FilterState>({
       initial: "all",
       unset: "all",
       match: (value) => (row) => row.wasMemberInPeriod === (value === "yes"),
     }),
-    search: filter<string>({
+    search: filter<string | null>({
       initial: "",
-      unset: (value) => value.trim() === "",
+      unset: "",
+      // `clearable` on the search field writes null, not "".
+      isUnset: (value) => (value ?? "").trim() === "",
       // Reading the index here rather than per row keeps it a tracked dependency
       // even when the dropdowns above have already excluded every row.
       match: (value) => {
-        const terms = value.trim().toLowerCase().split(/\s+/)
+        const terms = (value ?? "").trim().toLowerCase().split(/\s+/)
         const index = userSearchIndex.value
         return (row) => {
           const haystack = index.get(row.id) ?? ""

--- a/services/frontend/src/composables/useUserFilters.ts
+++ b/services/frontend/src/composables/useUserFilters.ts
@@ -1,6 +1,7 @@
-import {computed, ref, type Ref} from "vue"
+import {computed, toRefs, type Ref} from "vue"
 import {type MemberRow, type MemberStatus} from "@/composables/useUserRows"
 import {useTableSort} from "@/composables/useTableSort"
+import {filtersFor, useRowFilters} from "@/composables/useRowFilters"
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -16,46 +17,53 @@ export function useUserFilters(
   rows: Ref<MemberRow[]>,
   userSearchIndex: Ref<Map<number, string>>,
 ) {
-  // searchInput and search are now the same ref (debounce removed; filtering is O(visible) after windowing).
-  // The template binds v-model="searchInput", unit tests set search directly — both work because they are the same object.
-  const search = ref("")
-  const searchInput = search
+  const filter = filtersFor<MemberRow>()
 
-  // Membership status filter: all | current | former | never
-  const membershipStatusFilter = ref<MembershipStatusFilter>("all")
-  // Tri-state filters
-  const paidFilter = ref<FilterState>("all")
-  const incassoFilter = ref<FilterState>("all")
-  const periodMemberFilter = ref<FilterState>("all")
-
-  // Compute filtered rows (before sorting)
-  const justFiltered = computed<MemberRow[]>(() => {
-    // Search against precomputed per-user haystacks — cheap on every keystroke.
-    const q = search.value.trim().toLowerCase()
-    const terms = q ? q.split(/\s+/) : []
-
-    return rows.value.filter((r) => {
-      // Search filter
-      if (terms.length > 0) {
-        const haystack = userSearchIndex.value.get(r.id) ?? ""
-        if (!terms.every((t) => haystack.includes(t))) return false
-      }
-      // Membership status filter: current | former | never
-      if (membershipStatusFilter.value === "current" && r.status !== "Current") return false
-      if (membershipStatusFilter.value === "former" && r.status !== "Former") return false
-      if (membershipStatusFilter.value === "never" && r.status !== "Never") return false
-      // Paid-in-period filter
-      if (paidFilter.value === "yes" && !r.paid) return false
-      if (paidFilter.value === "no" && r.paid) return false
-      // Incasso filter
-      if (incassoFilter.value === "yes" && !r.latestIncasso) return false
-      if (incassoFilter.value === "no" && r.latestIncasso) return false
-      // Selected contribution period membership filter
-      if (periodMemberFilter.value === "yes" && !r.wasMemberInPeriod) return false
-      if (periodMemberFilter.value === "no" && r.wasMemberInPeriod) return false
-      return true
-    })
+  // Declared cheapest-first: the dropdowns are O(1) per row and eliminate most of
+  // them before the search filter has to touch the haystack.
+  const {state, filteredRows: justFiltered} = useRowFilters(rows, {
+    membershipStatusFilter: filter<MembershipStatusFilter>({
+      initial: "all",
+      unset: "all",
+      match: (value) => {
+        const wanted: MemberStatus = value === "current" ? "Current" : value === "former" ? "Former" : "Never"
+        return (row) => row.status === wanted
+      },
+    }),
+    paidFilter: filter<FilterState>({
+      initial: "all",
+      unset: "all",
+      match: (value) => (row) => row.paid === (value === "yes"),
+    }),
+    incassoFilter: filter<FilterState>({
+      initial: "all",
+      unset: "all",
+      match: (value) => (row) => Boolean(row.latestIncasso) === (value === "yes"),
+    }),
+    periodMemberFilter: filter<FilterState>({
+      initial: "all",
+      unset: "all",
+      match: (value) => (row) => row.wasMemberInPeriod === (value === "yes"),
+    }),
+    search: filter<string>({
+      initial: "",
+      unset: (value) => value.trim() === "",
+      // Reading the index here rather than per row keeps it a tracked dependency
+      // even when the dropdowns above have already excluded every row.
+      match: (value) => {
+        const terms = value.trim().toLowerCase().split(/\s+/)
+        const index = userSearchIndex.value
+        return (row) => {
+          const haystack = index.get(row.id) ?? ""
+          return terms.every((term) => haystack.includes(term))
+        }
+      },
+    }),
   })
+
+  const {search, membershipStatusFilter, paidFilter, incassoFilter, periodMemberFilter} = toRefs(state)
+  // The template binds searchInput; tests set search. They are the same ref.
+  const searchInput = search
 
   // Define sort comparators
   const memberRowComparators: Record<SortKey, (a: MemberRow, b: MemberRow) => number> = {

--- a/services/frontend/tests/unit/composables/useRowFilters.test.ts
+++ b/services/frontend/tests/unit/composables/useRowFilters.test.ts
@@ -1,0 +1,149 @@
+import {describe, expect, it, vi} from "vitest"
+import {nextTick, ref} from "vue"
+import {filtersFor, useRowFilters} from "@/composables/useRowFilters"
+
+interface Row {
+  id: number
+  name: string
+  state: "open" | "closed"
+  tags: string[]
+}
+
+const rows: Row[] = [
+  {id: 1, name: "alpha", state: "open", tags: ["red"]},
+  {id: 2, name: "beta", state: "closed", tags: ["blue"]},
+  {id: 3, name: "gamma", state: "open", tags: ["red", "blue"]},
+]
+
+const filter = filtersFor<Row>()
+
+const nameFilter = filter<string>({
+  initial: "",
+  unset: "",
+  match: (value) => {
+    const terms = value.trim().toLowerCase().split(/\s+/)
+    return (row) => terms.every((t) => row.name.includes(t))
+  },
+})
+
+const stateFilter = filter<"all" | Row["state"]>({
+  initial: "all",
+  unset: "all",
+  match: (value) => (row) => row.state === value,
+})
+
+describe("useRowFilters", () => {
+  it("returns every row while all filters are unset", () => {
+    const {filteredRows} = useRowFilters(rows, {state: stateFilter, name: nameFilter})
+    expect(filteredRows.value).toHaveLength(3)
+  })
+
+  it("does not hand back the source array identity", () => {
+    const {filteredRows} = useRowFilters(rows, {state: stateFilter})
+    expect(filteredRows.value).not.toBe(rows)
+  })
+
+  it("applies a filter once its value leaves unset", () => {
+    const {state, filteredRows} = useRowFilters(rows, {state: stateFilter})
+    state.state = "open"
+    expect(filteredRows.value.map((r) => r.id)).toEqual([1, 3])
+  })
+
+  it("combines filters conjunctively", () => {
+    const {state, filteredRows} = useRowFilters(rows, {state: stateFilter, name: nameFilter})
+    state.state = "open"
+    state.name = "gam"
+    expect(filteredRows.value.map((r) => r.id)).toEqual([3])
+  })
+
+  it("treats an empty array value as unset when given a test", () => {
+    // Object.is([], []) is false, so a value-compared array filter would read as
+    // permanently active and reject every row on first render.
+    const tagFilter = filter<string[]>({
+      initial: [],
+      unset: (value) => value.length === 0,
+      match: (value) => (row) => value.some((t) => row.tags.includes(t)),
+    })
+    const {filteredRows, activeKeys} = useRowFilters(rows, {tags: tagFilter})
+    expect(activeKeys.value).toEqual([])
+    expect(filteredRows.value).toHaveLength(3)
+  })
+
+  it("builds each matcher once per value rather than once per row", () => {
+    const built = vi.fn()
+    const counted = filter<string>({
+      initial: "",
+      unset: "",
+      match: (value) => {
+        built()
+        return (row) => row.name.includes(value)
+      },
+    })
+    const {state, filteredRows} = useRowFilters(rows, {counted})
+    state.counted = "a"
+    void filteredRows.value
+    expect(built).toHaveBeenCalledTimes(1)
+  })
+
+  it("tracks a reactive read made inside match even when no row reaches the test", async () => {
+    // The state filter rejects every row, so the returned test never runs. The
+    // external ref must still be a dependency, or the result goes stale.
+    const external = ref("alpha")
+    const dependent = filter<boolean>({
+      initial: false,
+      unset: false,
+      match: (value) => {
+        const wanted = external.value
+        return (row) => value && row.name === wanted
+      },
+    })
+    const {state, filteredRows} = useRowFilters(rows, {state: stateFilter, dependent})
+    state.dependent = true
+    state.state = "closed"
+    expect(filteredRows.value).toEqual([])
+
+    external.value = "beta"
+    await nextTick()
+    state.state = "all"
+    expect(filteredRows.value.map((r) => r.id)).toEqual([2])
+  })
+
+  it("shows all rows and logs when a filter throws instead of blanking", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {})
+    const broken = filter<boolean>({
+      initial: false,
+      unset: false,
+      match: () => () => {
+        throw new Error("boom")
+      },
+    })
+    const {state, filteredRows} = useRowFilters(rows, {broken})
+    state.broken = true
+    expect(filteredRows.value).toHaveLength(3)
+    expect(error).toHaveBeenCalled()
+    error.mockRestore()
+  })
+
+  it("clear returns filters to unset while reset returns them to their initial value", () => {
+    const preset = filter<"all" | Row["state"]>({
+      initial: "open",
+      unset: "all",
+      match: (value) => (row) => row.state === value,
+    })
+    const {state, clear, reset, activeKeys} = useRowFilters(rows, {preset})
+    expect(activeKeys.value).toEqual(["preset"])
+
+    clear()
+    expect(state.preset).toBe("all")
+    expect(activeKeys.value).toEqual([])
+
+    reset()
+    expect(state.preset).toBe("open")
+  })
+
+  it("tolerates an undefined row source", () => {
+    const source = ref<Row[] | undefined>(undefined)
+    const {filteredRows} = useRowFilters(source, {state: stateFilter})
+    expect(filteredRows.value).toEqual([])
+  })
+})

--- a/services/frontend/tests/unit/composables/useRowFilters.test.ts
+++ b/services/frontend/tests/unit/composables/useRowFilters.test.ts
@@ -61,7 +61,8 @@ describe("useRowFilters", () => {
     // permanently active and reject every row on first render.
     const tagFilter = filter<string[]>({
       initial: [],
-      unset: (value) => value.length === 0,
+      unset: [],
+      isUnset: (value) => value.length === 0,
       match: (value) => (row) => value.some((t) => row.tags.includes(t)),
     })
     const {filteredRows, activeKeys} = useRowFilters(rows, {tags: tagFilter})
@@ -108,7 +109,7 @@ describe("useRowFilters", () => {
     expect(filteredRows.value.map((r) => r.id)).toEqual([2])
   })
 
-  it("shows all rows and logs when a filter throws instead of blanking", () => {
+  it("shows no rows and logs when a filter throws, rather than more than asked for", () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => {})
     const broken = filter<boolean>({
       initial: false,
@@ -119,7 +120,7 @@ describe("useRowFilters", () => {
     })
     const {state, filteredRows} = useRowFilters(rows, {broken})
     state.broken = true
-    expect(filteredRows.value).toHaveLength(3)
+    expect(filteredRows.value).toEqual([])
     expect(error).toHaveBeenCalled()
     error.mockRestore()
   })
@@ -145,5 +146,50 @@ describe("useRowFilters", () => {
     const source = ref<Row[] | undefined>(undefined)
     const {filteredRows} = useRowFilters(source, {state: stateFilter})
     expect(filteredRows.value).toEqual([])
+  })
+
+  it("clear resets a filter whose unset is detected by a test", () => {
+    const tagFilter = filter<string[]>({
+      initial: [],
+      unset: [],
+      isUnset: (value) => value.length === 0,
+      match: (value) => (row) => value.some((t) => row.tags.includes(t)),
+    })
+    const {state, clear, activeKeys} = useRowFilters(rows, {tags: tagFilter})
+    state.tags = ["red"]
+    expect(activeKeys.value).toEqual(["tags"])
+    clear()
+    expect(state.tags).toEqual([])
+    expect(activeKeys.value).toEqual([])
+  })
+
+  it("does not let a filter value alias its own initial", () => {
+    const tagFilter = filter<string[]>({
+      initial: [],
+      unset: [],
+      isUnset: (value) => value.length === 0,
+      match: (value) => (row) => value.some((t) => row.tags.includes(t)),
+    })
+    const {state, reset, activeKeys} = useRowFilters(rows, {tags: tagFilter})
+    state.tags.push("red")
+    reset()
+    // Would still hold "red" if the ref shared the definition's array.
+    expect(state.tags).toEqual([])
+    expect(activeKeys.value).toEqual([])
+  })
+
+  it("survives a value its own unset test cannot read", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {})
+    const fragile = filter<string | null>({
+      initial: "",
+      unset: "",
+      isUnset: (value) => (value as string).trim() === "",
+      match: (value) => (row) => row.name.includes(String(value)),
+    })
+    const {state, filteredRows} = useRowFilters(rows, {fragile})
+    state.fragile = null
+    expect(() => filteredRows.value).not.toThrow()
+    expect(error).toHaveBeenCalled()
+    error.mockRestore()
   })
 })


### PR DESCRIPTION
## Why

The user table's filtering lived in its own composable: five filter refs and one hand-rolled predicate chain, all specific to member rows. Every rule about how a filter behaves — when it counts as off, what happens when it throws, what its value type is — was implicit in that one chain. The next table needing filters would have copied it, and the copy would have re-derived those rules by hand.

## What this achieves

Filtering is described rather than implemented. A table declares its filters and gets back the rows that pass, and three classes of mistake become impossible or visible:

- A predicate receives exactly its own filter's value type, so comparing a boolean against a string is a compile error rather than a filter that silently never matches.
- A filter resting at its unset value is skipped rather than run, so an untouched dropdown costs nothing per row.
- A filter that throws degrades to unfiltered and logs, instead of escaping a render-time computed and blanking the table.

## How

`services/frontend/src/composables/useRowFilters.ts` takes a row source and a record of named filters. Each filter is defined in one place:

```ts
search: filter<string>({
  initial: "",
  unset: (value) => value.trim() === "",
  match: (value) => {
    const terms = value.trim().toLowerCase().split(/\s+/)
    const index = userSearchIndex.value
    return (row) => terms.every((t) => (index.get(row.id) ?? "").includes(t))
  },
})
```

Three decisions in that shape are load-bearing:

**`match` returns the row test rather than being the row test.** It is called once per value, not once per row, so per-value work — splitting the search into terms, resolving the haystack — is hoisted by construction. More importantly it fixes a dependency-tracking hole: with a per-row predicate, a reactive read inside a filter is only tracked in evaluations where some row actually reaches it. A dropdown that excludes every row would leave the search index untracked, and the result would stay stale after the index was rebuilt. Building the tests before the row loop makes the read unconditional. There is a test for exactly this.

**`unset` may be a test rather than a value.** Comparing by identity works for strings and enums but not for arrays or objects: `Object.is([], [])` is false, so a multi-select filter would read as permanently active and reject every row on first render. The test form is what the next table needing a multi-select will require.

**`clear` and `reset` are separate.** `clear` moves filters to unset; `reset` moves them back to their initial value, which may itself be filtering. Collapsing them means a deep-linked or persisted filter cannot be cleared.

`filtersFor<RowType>()` pins the row type once so each filter states only its own value type, without callers writing `as` casts to stop literals widening to `string`.

Filters run in declaration order, so `useUserFilters` declares the four O(1) dropdowns before the search — they eliminate most rows before the search has to touch the haystack.

## Verification

`useUserFilters` keeps its public surface, so `UserManager.vue` is untouched and its **22 existing tests pass unchanged** — which is the real evidence the abstraction fits a caller rather than only type-checking in isolation.

`useRowFilters` has 10 tests of its own, covering the cases above specifically: an empty-array value reading as unset, the matcher being built once per value rather than per row, a reactive read staying tracked when no row reaches the test, a throwing filter showing all rows instead of none, `clear` versus `reset`, and an undefined row source.

Locally: `vue-tsc` clean, `eslint` clean, 636 frontend unit tests pass across 122 files.

## Deliberately not built

At ~1500 rows with a maintained search index, a per-row memo cache, a cheap/expensive staged pipeline, `shallowRef` on the source, and debouncing were all considered and rejected. The existing implementation was never slow; it was unreusable. A per-filter cost hint was left out for the same reason — declaration order already expresses it, and the doc comment says so.

<!-- diff-stats:start -->
---
**Diff breakdown** — `█` added `░` removed, scaled to the largest row.

```text
frontend                                          +376    -39    3
  production         █████████████████████░░░░░   +181    -39    2
  unit tests         ███████████████████████      +195     -0    1

──────────────────────────────────────────────────────────────────
production                                        +181    -39
tests                                             +195     -0  1.08 test lines per prod line
total (hand-written)                              +376    -39  3 files
```
<!-- diff-stats:end -->