### PR TITLE
ci: prepare the test schema with the client the database image already ships

### DIFF
--- a/.github/workflows/openapi-external-specs.yml
+++ b/.github/workflows/openapi-external-specs.yml
@@ -70,23 +70,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Wait for database service
-        run: |
-          sudo apt-get update && sudo apt-get install -y default-mysql-client
-          for i in {1..30}; do
-            if mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -uroot -p"$MYSQL_ROOT_PASSWORD" -e "SELECT 1;" >/dev/null 2>&1; then
-              echo "Database is ready!"
-              exit 0
-            fi
-            echo "Waiting for database... ($i/30)"
-            sleep 2
-          done
-          echo "Database did not become ready in time."
-          exit 1
-
       - name: Prepare test database schema
         run: |
-          mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -uroot -p"$MYSQL_ROOT_PASSWORD" < services/api/0_init.sql
+          # The runner blocks steps until the service reports healthy, and the
+          # image ships its own client, so there is nothing to poll and nothing
+          # to install. Reaching a package mirror here bought a network
+          # dependency whose only effect was to hang the job.
+          db=$(docker ps --filter "ancestor=mariadb:10.11.10" --format '{{.ID}}' | head -1)
+          if [ -z "$db" ]; then
+            echo "No mariadb service container is running." >&2
+            exit 1
+          fi
+          docker exec -i "$db" mariadb -uroot -p"$MYSQL_ROOT_PASSWORD" < services/api/0_init.sql
 
       - name: Set up Java Development Kit
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -184,25 +184,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Wait for database service
-        run: |
-          sudo apt-get update && sudo apt-get install -y default-mysql-client
-          for i in {1..30}; do
-            if mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -uroot -p"$MYSQL_ROOT_PASSWORD" -e "SELECT 1;" >/dev/null 2>&1; then
-              echo "Database is ready!"
-              exit 0
-            fi
-            echo "Waiting for database... ($i/30)"
-            sleep 2
-          done
-          echo "Database did not become ready in time."
-          exit 1
-
       - name: Prepare test database schema
         run: |
-          mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -uroot -p"$MYSQL_ROOT_PASSWORD" < services/api/0_init.sql
-          mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -uroot -p"$MYSQL_ROOT_PASSWORD" -e "SHOW DATABASES;"
-          mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -uroot -p"$MYSQL_ROOT_PASSWORD" -e "USE $MYSQL_DATABASE; SHOW TABLES;"
+          # The runner blocks steps until the service reports healthy, and the
+          # image ships its own client, so there is nothing to poll and nothing
+          # to install. Reaching a package mirror here bought a network
+          # dependency whose only effect was to hang the job.
+          db=$(docker ps --filter "ancestor=mariadb:10.11.10" --format '{{.ID}}' | head -1)
+          if [ -z "$db" ]; then
+            echo "No mariadb service container is running." >&2
+            exit 1
+          fi
+          docker exec -i "$db" mariadb -uroot -p"$MYSQL_ROOT_PASSWORD" < services/api/0_init.sql
+          docker exec "$db" mariadb -uroot -p"$MYSQL_ROOT_PASSWORD" -e "SHOW DATABASES;"
+          docker exec "$db" mariadb -uroot -p"$MYSQL_ROOT_PASSWORD" -e "USE \`$MYSQL_DATABASE\`; SHOW TABLES;"
 
       - name: Set up Java + Gradle
         uses: ./.github/actions/setup-java-gradle


### PR DESCRIPTION
## Why

Two jobs installed `default-mysql-client` from a package mirror before touching the
database, to poll a service container and then load `0_init.sql`. On 2026-08-19 the
mirror stalled: two consecutive runs of `API unit and integration tests` sat inside
`apt-get update` for 29 minutes and were cancelled by the 30-minute job cap without
executing a single test. No test report or coverage artefact was produced, so the
failure looked like a test failure while nothing had run.

The install existed to support a wait loop that was never needed. A service
declared with a `--health-cmd` blocks step execution until it reports healthy —
the runner prints `db service is healthy.` while initialising containers, and
fails the job outright if it never does — so the database is already up before the
first step starts.

## What this achieves

Neither job reaches a package mirror any more, so a slow or unavailable mirror can
no longer consume a job's entire time budget. Both lose a redundant step, and the
schema is prepared with a client that ships inside the image the job already pulled.

## How

- Dropped the `Wait for database service` step from `.github/workflows/validate.yml`
  and `.github/workflows/openapi-external-specs.yml`, along with the
  `default-mysql-client` install.
- `Prepare test database schema` now resolves the running service container and
  runs `mariadb` inside it via `docker exec`, piping `services/api/0_init.sql` on
  stdin. It fails with a clear message if no such container is found.
- `USE` is backtick-quoted because the schema name (`blueshell-test`) contains a
  hyphen.

Steps that reach the database over TCP from the runner are untouched: the
`3306:3306` mapping and the `MYSQL_HOST` / `MYSQL_PORT` variables are unchanged, so
Gradle connects exactly as before.

<!-- diff-stats:start -->
---
**Diff breakdown** — `█` added `░` removed, scaled to the largest row.

```text
ci                                                 +22    -32    2
  build & config     ███████████░░░░░░░░░░░░░░░    +22    -32    2

──────────────────────────────────────────────────────────────────
total (hand-written)                               +22    -32  2 files
```
<!-- diff-stats:end -->