### PR TITLE
chore(frontend): quiet the vite startup warnings

### DIFF
--- a/services/frontend/.pnp.cjs
+++ b/services/frontend/.pnp.cjs
@@ -80,7 +80,6 @@ const RAW_RUNTIME_STATE =
           ["vite-plugin-istanbul", "virtual:47311adda5947663fefbb2862c638deb1f84441a518c80265b7af0abdf16322a3acb7567f73f342eb25d22d4eab4fd6d6ea5df1ffe3e9caffc01101df02b1cd8#npm:9.0.1"],\
           ["vite-plugin-vuetify", "virtual:47311adda5947663fefbb2862c638deb1f84441a518c80265b7af0abdf16322a3acb7567f73f342eb25d22d4eab4fd6d6ea5df1ffe3e9caffc01101df02b1cd8#npm:2.1.3"],\
           ["vite-svg-loader", "virtual:47311adda5947663fefbb2862c638deb1f84441a518c80265b7af0abdf16322a3acb7567f73f342eb25d22d4eab4fd6d6ea5df1ffe3e9caffc01101df02b1cd8#npm:5.1.1"],\
-          ["vite-tsconfig-paths", "virtual:47311adda5947663fefbb2862c638deb1f84441a518c80265b7af0abdf16322a3acb7567f73f342eb25d22d4eab4fd6d6ea5df1ffe3e9caffc01101df02b1cd8#npm:6.1.1"],\
           ["vitest", "virtual:47311adda5947663fefbb2862c638deb1f84441a518c80265b7af0abdf16322a3acb7567f73f342eb25d22d4eab4fd6d6ea5df1ffe3e9caffc01101df02b1cd8#npm:4.1.10"],\
           ["vue", "virtual:47311adda5947663fefbb2862c638deb1f84441a518c80265b7af0abdf16322a3acb7567f73f342eb25d22d4eab4fd6d6ea5df1ffe3e9caffc01101df02b1cd8#npm:3.5.39"],\
           ["vue-axios", "virtual:47311adda5947663fefbb2862c638deb1f84441a518c80265b7af0abdf16322a3acb7567f73f342eb25d22d4eab4fd6d6ea5df1ffe3e9caffc01101df02b1cd8#npm:3.5.2"],\
@@ -3322,7 +3321,6 @@ const RAW_RUNTIME_STATE =
           ["vite-plugin-istanbul", "virtual:47311adda5947663fefbb2862c638deb1f84441a518c80265b7af0abdf16322a3acb7567f73f342eb25d22d4eab4fd6d6ea5df1ffe3e9caffc01101df02b1cd8#npm:9.0.1"],\
           ["vite-plugin-vuetify", "virtual:47311adda5947663fefbb2862c638deb1f84441a518c80265b7af0abdf16322a3acb7567f73f342eb25d22d4eab4fd6d6ea5df1ffe3e9caffc01101df02b1cd8#npm:2.1.3"],\
           ["vite-svg-loader", "virtual:47311adda5947663fefbb2862c638deb1f84441a518c80265b7af0abdf16322a3acb7567f73f342eb25d22d4eab4fd6d6ea5df1ffe3e9caffc01101df02b1cd8#npm:5.1.1"],\
-          ["vite-tsconfig-paths", "virtual:47311adda5947663fefbb2862c638deb1f84441a518c80265b7af0abdf16322a3acb7567f73f342eb25d22d4eab4fd6d6ea5df1ffe3e9caffc01101df02b1cd8#npm:6.1.1"],\
           ["vitest", "virtual:47311adda5947663fefbb2862c638deb1f84441a518c80265b7af0abdf16322a3acb7567f73f342eb25d22d4eab4fd6d6ea5df1ffe3e9caffc01101df02b1cd8#npm:4.1.10"],\
           ["vue", "virtual:47311adda5947663fefbb2862c638deb1f84441a518c80265b7af0abdf16322a3acb7567f73f342eb25d22d4eab4fd6d6ea5df1ffe3e9caffc01101df02b1cd8#npm:3.5.39"],\
           ["vue-axios", "virtual:47311adda5947663fefbb2862c638deb1f84441a518c80265b7af0abdf16322a3acb7567f73f342eb25d22d4eab4fd6d6ea5df1ffe3e9caffc01101df02b1cd8#npm:3.5.2"],\
@@ -3411,7 +3409,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["baseline-browser-mapping", "npm:2.10.0"],\
           ["browserslist", "npm:4.28.1"],\
-          ["caniuse-lite", "npm:1.0.30001770"],\
+          ["caniuse-lite", "npm:1.0.30001809"],\
           ["electron-to-chromium", "npm:1.5.286"],\
           ["node-releases", "npm:2.0.27"],\
           ["update-browserslist-db", "virtual:e455c4c2e8dc3f3e2b2f64927f2b0dff7ca09ff7730ccbb69cae3e9342c0b24fae16e40b2aa46a2b677c172a1365ba425382266fccbf1e96179eec79a4a5c294#npm:1.2.3"]\
@@ -3537,10 +3535,10 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["caniuse-lite", [\
-      ["npm:1.0.30001770", {\
-        "packageLocation": "./.yarn/cache/caniuse-lite-npm-1.0.30001770-4a95887078-02d15a8b72.zip/node_modules/caniuse-lite/",\
+      ["npm:1.0.30001809", {\
+        "packageLocation": "./.yarn/cache/caniuse-lite-npm-1.0.30001809-886d4b68fc-cac2ed4e66.zip/node_modules/caniuse-lite/",\
         "packageDependencies": [\
-          ["caniuse-lite", "npm:1.0.30001770"]\
+          ["caniuse-lite", "npm:1.0.30001809"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -5139,15 +5137,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/globals-npm-17.7.0-b005e29e29-e83f791acf.zip/node_modules/globals/",\
         "packageDependencies": [\
           ["globals", "npm:17.7.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["globrex", [\
-      ["npm:0.1.2", {\
-        "packageLocation": "./.yarn/cache/globrex-npm-0.1.2-ddda94f2d0-a54c029520.zip/node_modules/globrex/",\
-        "packageDependencies": [\
-          ["globrex", "npm:0.1.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -7659,28 +7648,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["tsconfck", [\
-      ["npm:3.1.6", {\
-        "packageLocation": "./.yarn/cache/tsconfck-npm-3.1.6-2dccdb1bd5-269c3c5135.zip/node_modules/tsconfck/",\
-        "packageDependencies": [\
-          ["tsconfck", "npm:3.1.6"]\
-        ],\
-        "linkType": "SOFT"\
-      }],\
-      ["virtual:a6ab0c175ea8df0e869b2f37e57a34056b0a637969584a86bee5cfa65bacf7d6c23405f9bab820a005dd476f6b4458402053dad6681309372a1085e95dc8cc79#npm:3.1.6", {\
-        "packageLocation": "./.yarn/__virtual__/tsconfck-virtual-2d3b297edb/0/cache/tsconfck-npm-3.1.6-2dccdb1bd5-269c3c5135.zip/node_modules/tsconfck/",\
-        "packageDependencies": [\
-          ["@types/typescript", null],\
-          ["tsconfck", "virtual:a6ab0c175ea8df0e869b2f37e57a34056b0a637969584a86bee5cfa65bacf7d6c23405f9bab820a005dd476f6b4458402053dad6681309372a1085e95dc8cc79#npm:3.1.6"],\
-          ["typescript", null]\
-        ],\
-        "packagePeers": [\
-          "@types/typescript",\
-          "typescript"\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["tslib", [\
       ["npm:2.8.1", {\
         "packageLocation": "./.yarn/cache/tslib-npm-2.8.1-66590b21b8-9c4759110a.zip/node_modules/tslib/",\
@@ -8132,31 +8099,6 @@ const RAW_RUNTIME_STATE =
         "packagePeers": [\
           "@types/vue",\
           "vue"\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["vite-tsconfig-paths", [\
-      ["npm:6.1.1", {\
-        "packageLocation": "./.yarn/cache/vite-tsconfig-paths-npm-6.1.1-aeb8d4e5a5-5e61080991.zip/node_modules/vite-tsconfig-paths/",\
-        "packageDependencies": [\
-          ["vite-tsconfig-paths", "npm:6.1.1"]\
-        ],\
-        "linkType": "SOFT"\
-      }],\
-      ["virtual:47311adda5947663fefbb2862c638deb1f84441a518c80265b7af0abdf16322a3acb7567f73f342eb25d22d4eab4fd6d6ea5df1ffe3e9caffc01101df02b1cd8#npm:6.1.1", {\
-        "packageLocation": "./.yarn/__virtual__/vite-tsconfig-paths-virtual-a6ab0c175e/0/cache/vite-tsconfig-paths-npm-6.1.1-aeb8d4e5a5-5e61080991.zip/node_modules/vite-tsconfig-paths/",\
-        "packageDependencies": [\
-          ["@types/vite", null],\
-          ["debug", "virtual:7ab5ba52b9fcd6367507dafc155330170c3c55f17548a046d928befadabfd5327abcd100d7e346691e82b7d81666c3047de6cbc3ee0adedeb0cb467f8c06e66d#npm:4.4.3"],\
-          ["globrex", "npm:0.1.2"],\
-          ["tsconfck", "virtual:a6ab0c175ea8df0e869b2f37e57a34056b0a637969584a86bee5cfa65bacf7d6c23405f9bab820a005dd476f6b4458402053dad6681309372a1085e95dc8cc79#npm:3.1.6"],\
-          ["vite", "virtual:47311adda5947663fefbb2862c638deb1f84441a518c80265b7af0abdf16322a3acb7567f73f342eb25d22d4eab4fd6d6ea5df1ffe3e9caffc01101df02b1cd8#npm:8.1.5"],\
-          ["vite-tsconfig-paths", "virtual:47311adda5947663fefbb2862c638deb1f84441a518c80265b7af0abdf16322a3acb7567f73f342eb25d22d4eab4fd6d6ea5df1ffe3e9caffc01101df02b1cd8#npm:6.1.1"]\
-        ],\
-        "packagePeers": [\
-          "@types/vite",\
-          "vite"\
         ],\
         "linkType": "HARD"\
       }]\

--- a/services/frontend/package.json
+++ b/services/frontend/package.json
@@ -87,7 +87,6 @@
     "vite-plugin-istanbul": "^9.0.1",
     "vite-plugin-vuetify": "^2.1.3",
     "vite-svg-loader": "^5.1.1",
-    "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.10",
     "vue-eslint-parser": "^10.4.1",
     "vue-tsc": "^3.3.7"

--- a/services/frontend/vite.config.mjs
+++ b/services/frontend/vite.config.mjs
@@ -2,13 +2,17 @@ import vue from '@vitejs/plugin-vue'
 import vuetify from 'vite-plugin-vuetify'
 import {defineConfig} from 'vite'
 import {fileURLToPath} from 'node:url'
-import tsconfigPaths from 'vite-tsconfig-paths'
 import svgLoader from 'vite-svg-loader'
 import istanbul from 'vite-plugin-istanbul'
 
 export default defineConfig({
     build: {
         target: "esnext",
+        // forceBuildInstrument keeps istanbul active in every build, so the
+        // system tests can collect coverage from the built image. The plugin
+        // turns sourcemaps on regardless and announces it on every run;
+        // declaring it is what stops the announcement.
+        sourcemap: true,
         // vuetify (~500 kB) and country-data (~615 kB) are legitimately
         // above Vite's 500 kB default; lift the threshold above the floor.
         chunkSizeWarningLimit: 700,
@@ -62,7 +66,6 @@ export default defineConfig({
             checkProd: false,
             forceBuildInstrument: true,
         }),
-        tsconfigPaths(),
         vue(),
         vuetify({
             autoImport: true,

--- a/services/frontend/vitest.config.ts
+++ b/services/frontend/vitest.config.ts
@@ -1,11 +1,9 @@
 import {fileURLToPath, URL} from "node:url"
 import vue from "@vitejs/plugin-vue"
 import {defineConfig} from "vitest/config"
-import tsconfigPaths from "vite-tsconfig-paths"
 
 export default defineConfig({
   plugins: [
-    tsconfigPaths(),
     vue(),
   ],
   resolve: {

--- a/services/frontend/yarn.lock
+++ b/services/frontend/yarn.lock
@@ -2762,7 +2762,6 @@ __metadata:
     vite-plugin-istanbul: "npm:^9.0.1"
     vite-plugin-vuetify: "npm:^2.1.3"
     vite-svg-loader: "npm:^5.1.1"
-    vite-tsconfig-paths: "npm:^6.1.1"
     vitest: "npm:^4.1.10"
     vue: "npm:3.5.39"
     vue-axios: "npm:^3.5.2"
@@ -2956,9 +2955,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001759":
-  version: 1.0.30001770
-  resolution: "caniuse-lite@npm:1.0.30001770"
-  checksum: 10c0/02d15a8b723af65318cb4d888a52bb090076898da7b0de99e8676d537f8d1d2ae4797e81518e1e30cbfe84c33b048c322e8bfafc5b23cfee8defb0d2bf271149
+  version: 1.0.30001809
+  resolution: "caniuse-lite@npm:1.0.30001809"
+  checksum: 10c0/cac2ed4e66cc6c4cbf126b94d2c02012566eb92f93c89949290f99edcd2bdc4ed1290b5c537ccb9b42c773936a479ed468e5d4e9b8938b126a0947090e42e008
   languageName: node
   linkType: hard
 
@@ -3354,7 +3353,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.4.0, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.4.0, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -4396,13 +4395,6 @@ __metadata:
   version: 17.7.0
   resolution: "globals@npm:17.7.0"
   checksum: 10c0/e83f791acf537b85fa1632ac48a45432a1999a61acd9f955b5c2145f66d6b5000a7945029874b6184fa2dfac8d33af03885a5a7ffa457866f1bcf0b40d0c1291
-  languageName: node
-  linkType: hard
-
-"globrex@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "globrex@npm:0.1.2"
-  checksum: 10c0/a54c029520cf58bda1d8884f72bd49b4cd74e977883268d931fd83bcbd1a9eb96d57c7dbd4ad80148fb9247467ebfb9b215630b2ed7563b2a8de02e1ff7f89d1
   languageName: node
   linkType: hard
 
@@ -6756,20 +6748,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfck@npm:^3.0.3":
-  version: 3.1.6
-  resolution: "tsconfck@npm:3.1.6"
-  peerDependencies:
-    typescript: ^5.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  bin:
-    tsconfck: bin/tsconfck.js
-  checksum: 10c0/269c3c513540be44844117bb9b9258fe6f8aeab026d32aeebf458d5299125f330711429dbb556dbf125a0bc25f4a81e6c24ac96de2740badd295c3fb400f66c4
-  languageName: node
-  linkType: hard
-
 "tslib@npm:^2.4.0":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
@@ -7039,19 +7017,6 @@ __metadata:
   peerDependencies:
     vue: ">=3.2.13"
   checksum: 10c0/06bb67e3da9211142232d48616ca65ce7eeaac4c1a1709e5b1322f9a47ec7ce600e26b3c573948c607d8db93afc2dc7a1584a307513da8b0b6255c22d41a3a32
-  languageName: node
-  linkType: hard
-
-"vite-tsconfig-paths@npm:^6.1.1":
-  version: 6.1.1
-  resolution: "vite-tsconfig-paths@npm:6.1.1"
-  dependencies:
-    debug: "npm:^4.1.1"
-    globrex: "npm:^0.1.2"
-    tsconfck: "npm:^3.0.3"
-  peerDependencies:
-    vite: "*"
-  checksum: 10c0/5e61080991418fefa08c5b98995cdcada4931ae01ac97ef9e2ee941051f61b76890a6e7ba48bed3b2a229ec06fef33a06621bba4ce457b3f4233ad31dc0c1d1b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Why

Every dev-server start and every build printed three advisory warnings that say
nothing about this codebase:

- `vite:istanbul> Sourcemaps was automatically enabled for code coverage to be accurate.`
- `The plugin "vite-tsconfig-paths" is detected. Vite now supports tsconfig paths resolution natively…`
- `Browserslist: browsers data (caniuse-lite) is 6 months old.`

Noise that appears on every run trains readers to skim past the output, which is
where a real warning has to be noticed.

## What this achieves

The dev server and both build modes start clean, so anything that does get
printed is worth reading. One dependency and its two transitive dependencies
leave the tree, and browser-target data is current.

## How

**Sourcemaps.** `vite-plugin-istanbul` turns sourcemaps on by itself and
announces it unless the config declares them. `forceBuildInstrument` keeps the
plugin active in every build, not only coverage runs, so that the system tests
can collect coverage from the built image — maps were already being produced in
every mode. `build.sourcemap` now states that rather than leaving the plugin to
infer it, which is what stops the announcement. Nothing about what gets built
changes.

**tsconfig paths.** `vite-tsconfig-paths` resolved exactly one mapping, `@/*` to
`./src/*`, which both `vite.config.mjs` and `vitest.config.ts` already declared
as an explicit `resolve.alias`. The plugin was redundant, so it and its
`tsconfck` / `globrex` dependencies are gone.

Worth recording for whoever reads the warning next: the native
`resolve.tsconfigPaths` option the message recommends is **not** a drop-in
replacement here. It requires a `baseUrl`, which none of the tsconfigs in
`services/frontend` set, and with it every `@/…` import fails to resolve — 107
test files load zero tests. The explicit alias is what does the work.

**Browser data.** `caniuse-lite` moves from `1.0.30001770` to `1.0.30001809`.

Left alone deliberately: the fourth warning, `Using Yarn PnP with Vite is
discouraged`. Changing `nodeLinker` touches the Docker images, the CI caches and
every install path, which is far more than a noise cleanup.

Verified locally with 456 unit tests, 112 end-to-end tests, typecheck, lint, and
a build in both plain and coverage modes with no warnings printed. The e2e
coverage report still remaps through the instrumented bundle, measuring 142 files.

<!-- diff-stats:start -->
---
**Diff breakdown** — `█` added `░` removed, scaled to the largest row.

```text
frontend                                            +5     -5    3
  build & config     █████████████░░░░░░░░░░░░░     +5     -5    3
  generated          ██░░░░░░░░░░░░░░░░░░░░░░░░     +8   -101    2  ~

──────────────────────────────────────────────────────────────────
total (hand-written)                                +5     -5  3 files
~ generated (excluded)                              +8   -101  2 files
```
<!-- diff-stats:end -->