### PR TITLE
test(system-tests): generate phone numbers libphonenumber accepts

### DIFF
--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -76,6 +76,20 @@ object TestHelper {
      */
     const val DEFAULT_PASSWORD: String = "Password123!"
 
+    /**
+     * Unique Dutch mobile number for created test users. The clock still
+     * supplies the entropy, but the digit right after the `06` prefix is
+     * folded into 1-5: libphonenumber only accepts `06` followed by 1-5 or 8,
+     * and taken from the timestamp raw that digit spends roughly a third of
+     * every 27-hour cycle on numbers the details form rejects — which reads
+     * as a flaky UI test rather than an invalid fixture.
+     */
+    fun uniquePhoneNumber(): String {
+        val suffix = System.currentTimeMillis().toString().takeLast(8)
+        val subscriberPrefix = '1' + (suffix[0] - '0') % 5
+        return "06$subscriberPrefix${suffix.substring(1)}"
+    }
+
     private fun <T> retryOnConnectionFailure(action: () -> T): T {
         var lastException: Exception? = null
         repeat(API_RETRY_ATTEMPTS) { attempt ->
@@ -107,7 +121,7 @@ object TestHelper {
         password: String = DEFAULT_PASSWORD,
         email: String = "$username@systemtest.example.com",
         discord: String = "$username#0001",
-        phoneNumber: String = "06${System.currentTimeMillis().toString().takeLast(8)}",
+        phoneNumber: String = uniquePhoneNumber(),
         firstName: String = "Test",
         lastName: String = "User",
         initials: String = "TU",
@@ -160,7 +174,7 @@ object TestHelper {
         email: String = "$username@systemtest.example.com",
     ): SignupHandle {
         val discord = "$username#0001"
-        val phoneNumber = "06${System.currentTimeMillis().toString().takeLast(8)}"
+        val phoneNumber = uniquePhoneNumber()
         val response = retryOnConnectionFailure {
             givenCsrfApi()
                 .baseUri(apiBaseUrl)
@@ -215,7 +229,7 @@ object TestHelper {
         password: String = DEFAULT_PASSWORD,
         email: String = "$username@systemtest.example.com",
         discord: String = "$username#0001",
-        phoneNumber: String = "06${System.currentTimeMillis().toString().takeLast(8)}",
+        phoneNumber: String = uniquePhoneNumber(),
         firstName: String = "Test",
         lastName: String = "User",
     ): RegisteredUser {
@@ -235,7 +249,7 @@ object TestHelper {
         password: String = DEFAULT_PASSWORD,
         email: String = "$username@systemtest.example.com",
         discord: String = "$username#0001",
-        phoneNumber: String = "06${System.currentTimeMillis().toString().takeLast(8)}",
+        phoneNumber: String = uniquePhoneNumber(),
         firstName: String = "Test",
         lastName: String = "User",
     ): RegisteredUser {


### PR DESCRIPTION
## Why

Seeded system-test users took their phone number from `06` plus the last eight digits of the wall clock. libphonenumber only treats `06` followed by 1-5 or 8 as a Dutch mobile, so whenever those digits happened to start with 0, 6, 7 or 9 every seeded user carried a number the frontend rejects — roughly eleven hours out of each 27-hour cycle, then fine again for the rest.

The details step of the membership signup validates the fields it prefills, so `MembershipSignUpPageSystemTest` "a signed-in applicant becomes a member without a confirmation step" sat on "Enter a valid phone number", never issued the `PUT /users/{id}` it waits for, and timed out. The test passes or fails purely on what time of day CI runs, which makes every branch built during an unlucky window look broken.

## What this achieves

The seeded phone number is valid at every hour, so that test result reflects the code under review instead of the clock.

## How

- `TestHelper.uniquePhoneNumber()` folds the digit after the `06` prefix into 1-5 and keeps the remaining seven digits from the timestamp, so the number stays unique per run while always parsing as a Dutch mobile.
- The four fixture entry points that built the number inline (`register`, `startSignup`, `registerAndActivate`, `registerActivateAndPromote`) call it instead.

<!-- diff-stats:start -->
---
**Diff breakdown** — `█` added `░` removed, scaled to the largest row.

```text
system-tests                                       +18     -4    1
  system tests       █████████████████████░░░░░    +18     -4    1

──────────────────────────────────────────────────────────────────
production                                          +0     -0
tests                                              +18     -4
total (hand-written)                               +18     -4  1 file
```
<!-- diff-stats:end -->