### PR TITLE
feat(documents): make the document buttons copyable links

### DIFF
--- a/services/frontend/src/components/base/DocumentTable.vue
+++ b/services/frontend/src/components/base/DocumentTable.vue
@@ -4,153 +4,44 @@
     color="grey-darken-4"
     rounded="lg"
   >
-    <!-- Statutes -->
-    <v-row class="text-center py-4">
-      <v-col
-        class="text-h6"
-        cols="4"
-      >
-        Statutes
-      </v-col>
-      <v-col cols="4">
-        <v-btn
-          class="w-100"
-          color="primary"
-          @click="downloadFile('@/assets/documents/20171212 - ESA Blueshell Statuten.pdf', 'ESA Blueshell - Statuten.pdf')"
-        >
-          Dutch
-        </v-btn>
-      </v-col>
-      <v-col cols="4">
-        <v-btn
-          class="w-100"
-          color="primary"
-          @click="downloadFile('@/assets/documents/20171212 - ESA Blueshell Statutes.pdf', 'ESA Blueshell - Statutes.pdf')"
-        >
-          English
-        </v-btn>
-      </v-col>
-    </v-row>
+    <template
+      v-for="(document, index) in documents"
+      :key="document.title"
+    >
+      <v-divider
+        v-if="index > 0"
+        class="my-2"
+      />
 
-    <v-divider class="my-2" />
-
-    <!-- Domestic Regulations -->
-    <v-row class="text-center py-4">
-      <v-col
-        class="text-h6"
-        cols="4"
-      >
-        Domestic Regulations
-      </v-col>
-      <v-col cols="4">
-        <v-btn
-          class="w-100"
-          color="primary"
-          @click="downloadFile('@/assets/documents/20180109 - ESA Blueshell Huishoudelijk Reglement.pdf', 'ESA Blueshell - Huishoudelijk Reglement.pdf')"
+      <v-row class="text-center py-4">
+        <v-col
+          class="text-h6"
+          cols="4"
         >
-          Dutch
-        </v-btn>
-      </v-col>
-      <v-col cols="4">
-        <v-btn
-          class="w-100"
-          color="primary"
-          @click="downloadFile('@/assets/documents/20180109 - ESA Blueshell Domestic Regulations.pdf', 'ESA Blueshell - Domestic Regulations.pdf')"
-        >
-          English
-        </v-btn>
-      </v-col>
-    </v-row>
-
-    <v-divider class="my-2" />
-
-    <!-- Privacy Policy -->
-    <v-row class="text-center py-4">
-      <v-col
-        class="text-h6"
-        cols="4"
-      >
-        Privacy Policy
-      </v-col>
-      <v-col cols="4">
-        <v-btn
-          class="w-100"
-          color="primary"
-          @click="downloadFile('@/assets/documents/20260223 - ESA Blueshell Privacybeleid.pdf', 'ESA Blueshell - Privacybeleid.pdf')"
-        >
-          Dutch
-        </v-btn>
-      </v-col>
-      <v-col cols="4">
-        <v-btn
-          class="w-100"
-          color="primary"
-          @click="downloadFile('@/assets/documents/20260223 - ESA Blueshell Privacy Policy.pdf', 'ESA Blueshell - Privacy Policy.pdf')"
-        >
-          English
-        </v-btn>
-      </v-col>
-    </v-row>
-
-    <v-divider class="my-2" />
-
-    <!-- Code of Conduct -->
-    <v-row class="text-center py-4">
-      <v-col
-        class="text-h6"
-        cols="4"
-      >
-        Code of Conduct
-      </v-col>
-      <v-col cols="4">
-        <v-btn
-          class="w-100"
-          color="primary"
-          @click="downloadFile('@/assets/documents/20210324 - ESA Blueshell Gedragscode.pdf', 'ESA Blueshell - Gedragscode.pdf')"
-        >
-          Dutch
-        </v-btn>
-      </v-col>
-      <v-col cols="4">
-        <v-btn
-          class="w-100"
-          color="primary"
-          @click="downloadFile('@/assets/documents/20210324 - ESA Blueshell Code of Conduct.pdf', 'ESA Blueshell - Code of Conduct.pdf')"
-        >
-          English
-        </v-btn>
-      </v-col>
-    </v-row>
-
-    <v-divider class="my-2" />
-
-    <!-- Cookie Policy -->
-    <v-row class="text-center py-4">
-      <v-col
-        class="text-h6"
-        cols="4"
-      >
-        Cookie Policy
-      </v-col>
-      <v-col cols="4">
-        <v-btn
-          class="w-100"
-          color="primary"
-          @click="downloadFile(ACTIVE_COOKIE_POLICY_PATHS.dutch, ACTIVE_COOKIE_POLICY_DOWNLOAD_NAMES.dutch)"
-        >
-          Dutch
-        </v-btn>
-      </v-col>
-      <v-col cols="4">
-        <v-btn
-          class="w-100"
-          color="primary"
-          @click="downloadFile(ACTIVE_COOKIE_POLICY_PATHS.english, ACTIVE_COOKIE_POLICY_DOWNLOAD_NAMES.english)"
-        >
-          English
-        </v-btn>
-      </v-col>
-    </v-row>
+          {{ document.title }}
+        </v-col>
+        <v-col cols="4">
+          <v-btn
+            :download="document.dutch.fileName"
+            :href="documentUrl(document.dutch.path)"
+            class="w-100"
+            color="primary"
+          >
+            Dutch
+          </v-btn>
+        </v-col>
+        <v-col cols="4">
+          <v-btn
+            :download="document.english.fileName"
+            :href="documentUrl(document.english.path)"
+            class="w-100"
+            color="primary"
+          >
+            English
+          </v-btn>
+        </v-col>
+      </v-row>
+    </template>
   </v-sheet>
 </template>
 
@@ -161,13 +52,65 @@ import {
   ACTIVE_COOKIE_POLICY_PATHS,
 } from "@/config/policies"
 
-function downloadFile(path: string, fileName: string) {
-  const url = path.startsWith("http") ? path : $require(path)
-  const link = document.createElement("a")
-  link.href = url
-  link.download = fileName
-  document.body.appendChild(link)
-  link.click()
-  document.body.removeChild(link)
+const documents = [
+  {
+    title: "Statutes",
+    dutch: {
+      path: "@/assets/documents/20171212 - ESA Blueshell Statuten.pdf",
+      fileName: "ESA Blueshell - Statuten.pdf",
+    },
+    english: {
+      path: "@/assets/documents/20171212 - ESA Blueshell Statutes.pdf",
+      fileName: "ESA Blueshell - Statutes.pdf",
+    },
+  },
+  {
+    title: "Domestic Regulations",
+    dutch: {
+      path: "@/assets/documents/20180109 - ESA Blueshell Huishoudelijk Reglement.pdf",
+      fileName: "ESA Blueshell - Huishoudelijk Reglement.pdf",
+    },
+    english: {
+      path: "@/assets/documents/20180109 - ESA Blueshell Domestic Regulations.pdf",
+      fileName: "ESA Blueshell - Domestic Regulations.pdf",
+    },
+  },
+  {
+    title: "Privacy Policy",
+    dutch: {
+      path: "@/assets/documents/20260223 - ESA Blueshell Privacybeleid.pdf",
+      fileName: "ESA Blueshell - Privacybeleid.pdf",
+    },
+    english: {
+      path: "@/assets/documents/20260223 - ESA Blueshell Privacy Policy.pdf",
+      fileName: "ESA Blueshell - Privacy Policy.pdf",
+    },
+  },
+  {
+    title: "Code of Conduct",
+    dutch: {
+      path: "@/assets/documents/20210324 - ESA Blueshell Gedragscode.pdf",
+      fileName: "ESA Blueshell - Gedragscode.pdf",
+    },
+    english: {
+      path: "@/assets/documents/20210324 - ESA Blueshell Code of Conduct.pdf",
+      fileName: "ESA Blueshell - Code of Conduct.pdf",
+    },
+  },
+  {
+    title: "Cookie Policy",
+    dutch: {
+      path: ACTIVE_COOKIE_POLICY_PATHS.dutch,
+      fileName: ACTIVE_COOKIE_POLICY_DOWNLOAD_NAMES.dutch,
+    },
+    english: {
+      path: ACTIVE_COOKIE_POLICY_PATHS.english,
+      fileName: ACTIVE_COOKIE_POLICY_DOWNLOAD_NAMES.english,
+    },
+  },
+]
+
+function documentUrl(path: string): string {
+  return path.startsWith("http") ? path : $require(path)
 }
 </script>

--- a/services/frontend/tests/unit/components/base/DocumentTable.test.ts
+++ b/services/frontend/tests/unit/components/base/DocumentTable.test.ts
@@ -1,7 +1,10 @@
-import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+import {beforeEach, describe, expect, it, vi} from "vitest"
 import {shallowMount} from "@vue/test-utils"
 import DocumentTable from "@/components/base/DocumentTable.vue"
-import {ACTIVE_COOKIE_POLICY_PATHS} from "@/config/policies"
+import {
+  ACTIVE_COOKIE_POLICY_DOWNLOAD_NAMES,
+  ACTIVE_COOKIE_POLICY_PATHS,
+} from "@/config/policies"
 
 const {mockRequire} = vi.hoisted(() => ({
   mockRequire: vi.fn((path: string) => `https://assets.example.test/${encodeURIComponent(path)}`),
@@ -11,112 +14,87 @@ vi.mock("@/plugins/require.ts", () => ({
   $require: mockRequire,
 }))
 
-function findButton(wrapper: ReturnType<typeof shallowMount>, label: string) {
-  const button = wrapper.findAll("button").find((node) => node.text().trim() === label)
-  if (!button) {
-    throw new Error(`Expected button with label '${label}'`)
-  }
-  return button
+function assetUrl(path: string) {
+  return `https://assets.example.test/${encodeURIComponent(path)}`
+}
+
+function mountTable() {
+  return shallowMount(DocumentTable, {
+    global: {
+      stubs: {
+        VSheet: {template: "<div><slot /></div>"},
+        VRow: {template: "<div><slot /></div>"},
+        VCol: {template: "<div><slot /></div>"},
+        VDivider: {template: "<hr />"},
+        VBtn: {template: "<a><slot /></a>"},
+      },
+    },
+  })
+}
+
+function documentLinks(wrapper: ReturnType<typeof mountTable>) {
+  return wrapper.findAll("a").map((node) => ({
+    label: node.text().trim(),
+    href: node.attributes("href"),
+    download: node.attributes("download"),
+  }))
 }
 
 describe("DocumentTable", () => {
-  const createdLinks: HTMLAnchorElement[] = []
-
   beforeEach(() => {
     vi.clearAllMocks()
-    createdLinks.length = 0
-
-    const createElement = document.createElement.bind(document)
-    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
-      const element = createElement(tagName)
-      if (tagName.toLowerCase() === "a") {
-        createdLinks.push(element as HTMLAnchorElement)
-        vi.spyOn(element as HTMLAnchorElement, "click").mockImplementation(() => {})
-      }
-      return element
-    })
   })
 
-  afterEach(() => {
-    vi.restoreAllMocks()
+  it("renders a Dutch and English link for every document", () => {
+    const wrapper = mountTable()
+
+    for (const title of [
+      "Statutes",
+      "Domestic Regulations",
+      "Privacy Policy",
+      "Code of Conduct",
+      "Cookie Policy",
+    ]) {
+      expect(wrapper.text()).toContain(title)
+    }
+
+    const links = documentLinks(wrapper)
+    expect(links).toHaveLength(10)
+    expect(links.map((link) => link.label)).toEqual(Array(5).fill(["Dutch", "English"]).flat())
   })
 
-  it("renders statutes language actions", () => {
-    const wrapper = shallowMount(DocumentTable, {
-      global: {
-        stubs: {
-          VSheet: {template: "<div><slot /></div>"},
-          VRow: {template: "<div><slot /></div>"},
-          VCol: {template: "<div><slot /></div>"},
-          VDivider: {template: "<hr />"},
-          VBtn: {
-            template: "<button @click=\"$emit('click')\"><slot /></button>",
-            emits: ["click"],
-          },
-        },
-      },
-    })
+  it("links the statutes to their bundled assets with a download filename", () => {
+    const dutchPath = "@/assets/documents/20171212 - ESA Blueshell Statuten.pdf"
+    const englishPath = "@/assets/documents/20171212 - ESA Blueshell Statutes.pdf"
 
-    expect(wrapper.text()).toContain("Statutes")
-    expect(findButton(wrapper, "Dutch").exists()).toBe(true)
-    expect(findButton(wrapper, "English").exists()).toBe(true)
+    const links = documentLinks(mountTable())
+
+    expect(links[0]).toEqual({
+      label: "Dutch",
+      href: assetUrl(dutchPath),
+      download: "ESA Blueshell - Statuten.pdf",
+    })
+    expect(links[1]).toEqual({
+      label: "English",
+      href: assetUrl(englishPath),
+      download: "ESA Blueshell - Statutes.pdf",
+    })
+    expect(mockRequire).toHaveBeenCalledWith(dutchPath)
+    expect(mockRequire).toHaveBeenCalledWith(englishPath)
   })
 
-  it("downloads dutch and english statutes with expected filenames", async () => {
-    const appendSpy = vi.spyOn(document.body, "appendChild")
-    const removeSpy = vi.spyOn(document.body, "removeChild")
-    const wrapper = shallowMount(DocumentTable, {
-      global: {
-        stubs: {
-          VSheet: {template: "<div><slot /></div>"},
-          VRow: {template: "<div><slot /></div>"},
-          VCol: {template: "<div><slot /></div>"},
-          VDivider: {template: "<hr />"},
-          VBtn: {
-            template: "<button @click=\"$emit('click')\"><slot /></button>",
-            emits: ["click"],
-          },
-        },
-      },
+  it("links the cookie policy from the active policy metadata", () => {
+    const links = documentLinks(mountTable())
+
+    expect(links.at(-2)).toEqual({
+      label: "Dutch",
+      href: assetUrl(ACTIVE_COOKIE_POLICY_PATHS.dutch),
+      download: ACTIVE_COOKIE_POLICY_DOWNLOAD_NAMES.dutch,
     })
-
-    await findButton(wrapper, "Dutch").trigger("click")
-    await findButton(wrapper, "English").trigger("click")
-
-    expect(createdLinks).toHaveLength(2)
-    expect(createdLinks[0].download).toBe("ESA Blueshell - Statuten.pdf")
-    expect(createdLinks[1].download).toBe("ESA Blueshell - Statutes.pdf")
-    expect(mockRequire).toHaveBeenCalledWith("@/assets/documents/20171212 - ESA Blueshell Statuten.pdf")
-    expect(mockRequire).toHaveBeenCalledWith("@/assets/documents/20171212 - ESA Blueshell Statutes.pdf")
-    expect(createdLinks[0].click).toHaveBeenCalledTimes(1)
-    expect(createdLinks[1].click).toHaveBeenCalledTimes(1)
-    expect(appendSpy).toHaveBeenCalledTimes(2)
-    expect(removeSpy).toHaveBeenCalledTimes(2)
-  })
-
-  it("downloads cookie policy files from active policy metadata", async () => {
-    const wrapper = shallowMount(DocumentTable, {
-      global: {
-        stubs: {
-          VSheet: {template: "<div><slot /></div>"},
-          VRow: {template: "<div><slot /></div>"},
-          VCol: {template: "<div><slot /></div>"},
-          VDivider: {template: "<hr />"},
-          VBtn: {
-            template: "<button @click=\"$emit('click')\"><slot /></button>",
-            emits: ["click"],
-          },
-        },
-      },
+    expect(links.at(-1)).toEqual({
+      label: "English",
+      href: assetUrl(ACTIVE_COOKIE_POLICY_PATHS.english),
+      download: ACTIVE_COOKIE_POLICY_DOWNLOAD_NAMES.english,
     })
-
-    const buttons = wrapper.findAll("button")
-    await buttons.at(-2)?.trigger("click")
-    await buttons.at(-1)?.trigger("click")
-
-    expect(mockRequire).toHaveBeenCalledWith(ACTIVE_COOKIE_POLICY_PATHS.dutch)
-    expect(mockRequire).toHaveBeenCalledWith(ACTIVE_COOKIE_POLICY_PATHS.english)
-    expect(createdLinks.at(-2)?.download).toBe("ESA Blueshell - Cookiebeleid.pdf")
-    expect(createdLinks.at(-1)?.download).toBe("ESA Blueshell - Cookie Policy.pdf")
   })
 })


### PR DESCRIPTION
## Why

The buttons in the document table resolved their asset URL inside a click handler and then clicked a synthetic, detached anchor. Nothing on the page ever carried the URL, so the documents could not be shared: right-click offered no "copy link address", middle-click and cmd-click did nothing, and there was no way to bookmark the statutes or link a member straight to the privacy policy. The absence of a shareable link is why stale, hand-typed URLs keep circulating for these files.

## What this achieves

Every document button is a link. Copying its address yields a working URL to the bundled PDF, cmd-click opens it in a new tab, and left-click still downloads the file under the same friendly filename as before.

## How

- `services/frontend/src/components/base/DocumentTable.vue`: each button binds `:href` to the resolved asset URL and carries a `download` attribute. Vuetify's `v-btn` renders an `<a>` as soon as `href` is present, so the rendered element is a real link rather than a button with a handler. The synthetic-anchor `downloadFile` helper is gone; `documentUrl` now only resolves a path through `$require`, matching how `UserForm.vue` already links the privacy policy.
- The five rows (statutes, domestic regulations, privacy policy, code of conduct, cookie policy) moved into a `documents` array rendered with `v-for`, replacing five hand-written blocks of identical markup. The cookie policy row still takes its path and filename from `ACTIVE_COOKIE_POLICY_PATHS` / `ACTIVE_COOKIE_POLICY_DOWNLOAD_NAMES` in `src/config/policies.ts`, so the active-policy indirection is preserved.
- `services/frontend/tests/unit/components/base/DocumentTable.test.ts`: assertions moved from spying on `document.createElement("a")` and click dispatch to reading the rendered `href` and `download` attributes.

<!-- diff-stats:start -->
---
**Diff breakdown** — `█` added `░` removed, scaled to the largest row.

```text
frontend                                          +167   -246    2
  production         ██████████░░░░░░░░░░░░░░░░    +96   -153    1
  unit tests         ███████░░░░░░░░░░             +71    -93    1

──────────────────────────────────────────────────────────────────
production                                         +96   -153
tests                                              +71    -93  0.74 test lines per prod line
total (hand-written)                              +167   -246  2 files
```
<!-- diff-stats:end -->