### PR TITLE
test: cap every Playwright wait at five seconds and drive selects by typing

### DIFF
--- a/services/frontend/playwright.config.ts
+++ b/services/frontend/playwright.config.ts
@@ -4,7 +4,9 @@ export default defineConfig({
   testDir: "./tests/e2e",
   timeout: 60_000,
   expect: {
-    timeout: 15_000,
+    // Every wait in this suite is capped at 5s. A step that needs longer is
+    // waiting on the wrong signal — fix the signal, do not raise the cap.
+    timeout: 5_000,
   },
   fullyParallel: true,
   // The e2e suite is I/O/wait-bound (browser navigation, rendering, mocked
@@ -19,7 +21,8 @@ export default defineConfig({
   reporter: "list",
   use: {
     trace: "on-first-retry",
-    navigationTimeout: 60_000,
+    actionTimeout: 5_000,
+    navigationTimeout: 5_000,
     reducedMotion: "reduce",
   },
   webServer: [

--- a/services/frontend/src/components/form/EventForm.vue
+++ b/services/frontend/src/components/form/EventForm.vue
@@ -7,7 +7,7 @@ import SurveyForm from "@/components/form/SurveyForm.vue"
 import {useStore} from "vuex"
 import {apply, type FieldMap} from "@/plugins/validation.ts"
 import VvField from "@/components/form/fields/VvField.vue"
-import {VCheckbox, VFileInput, VSelect} from "vuetify/components"
+import {VAutocomplete, VCheckbox, VFileInput} from "vuetify/components"
 import SubmitButton from "@/components/form/SubmitButton.vue"
 import {
   type CommitteeDetailResponse,
@@ -401,12 +401,14 @@ defineExpose({validate, save})
           <VvField
             v-model="event.committeeId"
             test-id="event-form-committee-field"
-            :component="VSelect"
+            :component="VAutocomplete"
             :component-props="{
               items: committees,
               'item-title': 'name',
               'item-value': 'id',
               'prepend-icon': 'mdi-account-group',
+              'auto-select-first': true,
+              'hide-no-data': true,
               disabled: !committees.length
             }"
             label="Representative committee"

--- a/services/frontend/tests/e2e/email-manager.spec.ts
+++ b/services/frontend/tests/e2e/email-manager.spec.ts
@@ -72,7 +72,7 @@ test.describe("email manager — access control", () => {
     await loginAsBoard(page.context())
 
     await page.goto("/management/emails")
-    await expect(page).toHaveURL(/\/$/, {timeout: 10_000})
+    await expect(page).toHaveURL(/\/$/)
   })
 
   test("admin can access the email manager", async ({page}) => {
@@ -80,7 +80,7 @@ test.describe("email manager — access control", () => {
     await loginAsAdmin(page.context())
 
     await page.goto("/management/emails")
-    await expect(page.getByTestId("email-manager-table")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("email-manager-table")).toBeVisible()
   })
 })
 
@@ -98,7 +98,7 @@ test.describe("email manager — stats panel", () => {
     await loginAsAdmin(page.context())
     await page.goto("/management/emails")
 
-    await expect(page.getByTestId("email-stats-total")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("email-stats-total")).toBeVisible()
     await expect(page.getByTestId("email-stats-total")).toContainText("5")
     await expect(page.getByTestId("email-stats-sent")).toContainText("1")
     await expect(page.getByTestId("email-stats-delivered")).toContainText("2")
@@ -119,7 +119,7 @@ test.describe("email manager — stats panel", () => {
     await page.goto("/management/emails")
 
     // 2 delivered out of 4 total = 50%
-    await expect(page.getByTestId("email-stats-delivered")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("email-stats-delivered")).toBeVisible()
     await expect(page.getByTestId("email-stats-delivered")).toContainText("50%")
   })
 
@@ -136,7 +136,7 @@ test.describe("email manager — stats panel", () => {
     await page.goto("/management/emails")
 
     // 1 opened out of 4 total = 25%
-    await expect(page.getByTestId("email-stats-opened")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("email-stats-opened")).toBeVisible()
     await expect(page.getByTestId("email-stats-opened")).toContainText("25%")
   })
 })
@@ -147,7 +147,7 @@ test.describe("email manager — email list", () => {
     await loginAsAdmin(page.context())
     await page.goto("/management/emails")
 
-    await expect(page.getByTestId("email-manager-table")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("email-manager-table")).toBeVisible()
     await expect(page.getByTestId(`email-row-${BASE_EMAILS[0].id}`)).toBeVisible()
     await expect(page.getByTestId(`email-row-${BASE_EMAILS[1].id}`)).toBeVisible()
     await expect(page.getByTestId(`email-row-${BASE_EMAILS[2].id}`)).toBeVisible()
@@ -158,7 +158,7 @@ test.describe("email manager — email list", () => {
     await loginAsAdmin(page.context())
     await page.goto("/management/emails")
 
-    await expect(page.getByText("No emails found.")).toBeVisible({timeout: 30_000})
+    await expect(page.getByText("No emails found.")).toBeVisible()
   })
 
   test("displays status chip for each email row", async ({page}) => {
@@ -166,7 +166,7 @@ test.describe("email manager — email list", () => {
     await loginAsAdmin(page.context())
     await page.goto("/management/emails")
 
-    await expect(page.getByTestId("email-manager-table")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("email-manager-table")).toBeVisible()
     const deliveredRow = page.getByTestId(`email-row-${BASE_EMAILS[0].id}`)
     await expect(deliveredRow).toContainText("DELIVERED")
 
@@ -181,7 +181,7 @@ test.describe("email manager — filtering", () => {
     await loginAsAdmin(page.context())
     await page.goto("/management/emails")
 
-    await expect(page.getByTestId("email-manager-table")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("email-manager-table")).toBeVisible()
 
     // Select FAILED status filter
     await page.getByTestId("email-filter-status").click()
@@ -197,7 +197,7 @@ test.describe("email manager — filtering", () => {
     await loginAsAdmin(page.context())
     await page.goto("/management/emails")
 
-    await expect(page.getByTestId("email-manager-table")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("email-manager-table")).toBeVisible()
 
     const searchInput = page.getByTestId("email-filter-search").locator("input").first()
     await searchInput.fill("alice")
@@ -211,7 +211,7 @@ test.describe("email manager — filtering", () => {
     await loginAsAdmin(page.context())
     await page.goto("/management/emails")
 
-    await expect(page.getByTestId("email-manager-table")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("email-manager-table")).toBeVisible()
 
     const searchInput = page.getByTestId("email-filter-search").locator("input").first()
     await searchInput.fill("Contribution")
@@ -225,7 +225,7 @@ test.describe("email manager — filtering", () => {
     await loginAsAdmin(page.context())
     await page.goto("/management/emails")
 
-    await expect(page.getByTestId("email-manager-refresh-btn")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("email-manager-refresh-btn")).toBeVisible()
     await page.getByTestId("email-manager-refresh-btn").click()
 
     // After refresh the list should still be visible
@@ -239,7 +239,7 @@ test.describe("email manager — expanded details", () => {
     await loginAsAdmin(page.context())
     await page.goto("/management/emails")
 
-    await expect(page.getByTestId(`email-row-${BASE_EMAILS[0].id}`)).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId(`email-row-${BASE_EMAILS[0].id}`)).toBeVisible()
     await expect(page.getByTestId(`email-detail-${BASE_EMAILS[0].id}`)).not.toBeVisible()
 
     await page.getByTestId(`email-row-${BASE_EMAILS[0].id}`).click()
@@ -252,7 +252,7 @@ test.describe("email manager — expanded details", () => {
     await loginAsAdmin(page.context())
     await page.goto("/management/emails")
 
-    await expect(page.getByTestId(`email-row-${BASE_EMAILS[0].id}`)).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId(`email-row-${BASE_EMAILS[0].id}`)).toBeVisible()
     await page.getByTestId(`email-row-${BASE_EMAILS[0].id}`).click()
 
     const detail = page.getByTestId(`email-detail-${BASE_EMAILS[0].id}`)
@@ -265,7 +265,7 @@ test.describe("email manager — expanded details", () => {
     await loginAsAdmin(page.context())
     await page.goto("/management/emails")
 
-    await expect(page.getByTestId(`email-row-${BASE_EMAILS[1].id}`)).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId(`email-row-${BASE_EMAILS[1].id}`)).toBeVisible()
     await page.getByTestId(`email-row-${BASE_EMAILS[1].id}`).click()
 
     const detail = page.getByTestId(`email-detail-${BASE_EMAILS[1].id}`)
@@ -278,7 +278,7 @@ test.describe("email manager — expanded details", () => {
     await loginAsAdmin(page.context())
     await page.goto("/management/emails")
 
-    await expect(page.getByTestId(`email-row-${BASE_EMAILS[0].id}`)).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId(`email-row-${BASE_EMAILS[0].id}`)).toBeVisible()
     await page.getByTestId(`email-row-${BASE_EMAILS[0].id}`).click()
     await expect(page.getByTestId(`email-detail-${BASE_EMAILS[0].id}`)).toBeVisible()
 
@@ -293,7 +293,7 @@ test.describe("email manager — retry", () => {
     await loginAsAdmin(page.context())
     await page.goto("/management/emails")
 
-    await expect(page.getByTestId("email-manager-table")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("email-manager-table")).toBeVisible()
 
     // FAILED email with jobExecutionId — retry button should appear in the append slot
     const failedRow = page.getByTestId(`email-row-${BASE_EMAILS[1].id}`)
@@ -312,12 +312,12 @@ test.describe("email manager — retry", () => {
     await loginAsAdmin(page.context())
     await page.goto("/management/emails")
 
-    await expect(page.getByTestId(`email-retry-btn-${BASE_EMAILS[1].id}`)).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId(`email-retry-btn-${BASE_EMAILS[1].id}`)).toBeVisible()
     await page.getByTestId(`email-retry-btn-${BASE_EMAILS[1].id}`).click()
 
     // After retry the mock returns status SENT, list should refresh and row shows SENT
     const failedRow = page.getByTestId(`email-row-${BASE_EMAILS[1].id}`)
-    await expect(failedRow).toContainText("SENT", {timeout: 10_000})
+    await expect(failedRow).toContainText("SENT")
   })
 })
 
@@ -327,7 +327,7 @@ test.describe("email manager — pagination", () => {
     await loginAsAdmin(page.context())
     await page.goto("/management/emails")
 
-    await expect(page.getByTestId("email-manager-table")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("email-manager-table")).toBeVisible()
     await expect(page.getByTestId("email-manager-pagination")).toBeVisible()
   })
 })

--- a/services/frontend/tests/e2e/events.spec.ts
+++ b/services/frontend/tests/e2e/events.spec.ts
@@ -9,7 +9,7 @@ test.describe("events page", () => {
 
     await page.goto("/events")
 
-    await expect(page.getByText("Upcoming Events", {exact: true}).first()).toBeVisible({timeout: 30_000})
+    await expect(page.getByText("Upcoming Events", {exact: true}).first()).toBeVisible()
     await expect(page.getByText("Mock Event").first()).toBeVisible()
     await expect(page.getByText("Events Committee").first()).toBeVisible()
 
@@ -77,7 +77,7 @@ test.describe("events page", () => {
 
     await page.goto("/events/signups/500")
     const exportButton = page.getByTestId("export-csv-btn")
-    await expect(exportButton).toBeEnabled({timeout: 30_000})
+    await expect(exportButton).toBeEnabled()
 
     const downloadPromise = page.waitForEvent("download")
     await exportButton.click()

--- a/services/frontend/tests/e2e/home-and-banners.spec.ts
+++ b/services/frontend/tests/e2e/home-and-banners.spec.ts
@@ -6,7 +6,7 @@ test.describe("home page banners", () => {
     await installApiMocks(page)
     await page.goto("/")
 
-    await expect(page.locator("#blueshell")).toBeVisible({timeout: 30_000})
+    await expect(page.locator("#blueshell")).toBeVisible()
     await expect(page.getByText("Follow us on Social Media", {exact: true})).toBeVisible()
     await expect(page.getByText(/SITECIE GANG/i).first()).toBeVisible()
 

--- a/services/frontend/tests/e2e/job-manager-stats.spec.ts
+++ b/services/frontend/tests/e2e/job-manager-stats.spec.ts
@@ -14,7 +14,7 @@ test.describe("job manager stats panel", () => {
     await loginAsAdmin(page.context())
     await page.goto("/management/jobs")
 
-    await expect(page.getByTestId("job-stats-total")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("job-stats-total")).toBeVisible()
     await expect(page.getByTestId("job-stats-total")).toContainText("4")
     await expect(page.getByTestId("job-stats-success")).toContainText("2")
     await expect(page.getByTestId("job-stats-failed")).toContainText("1")
@@ -33,7 +33,7 @@ test.describe("job manager stats panel", () => {
     await loginAsAdmin(page.context())
     await page.goto("/management/jobs")
 
-    await expect(page.getByTestId("job-stats-success")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("job-stats-success")).toBeVisible()
     await expect(page.getByTestId("job-stats-success")).toContainText("75%")
   })
 
@@ -42,7 +42,7 @@ test.describe("job manager stats panel", () => {
     await loginAsAdmin(page.context())
     await page.goto("/management/jobs")
 
-    await expect(page.getByTestId("job-stats-runtime")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("job-stats-runtime")).toBeVisible()
     await expect(page.getByTestId("job-stats-runtime")).toContainText("Since last startup")
   })
 

--- a/services/frontend/tests/e2e/job-manager-trigger.spec.ts
+++ b/services/frontend/tests/e2e/job-manager-trigger.spec.ts
@@ -7,7 +7,7 @@ test.describe("job manager trigger modal", () => {
     await loginAsAdmin(page.context())
     await page.goto("/management/jobs")
 
-    await expect(page.getByTestId("job-manager-trigger-btn")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("job-manager-trigger-btn")).toBeVisible()
     await page.getByTestId("job-manager-trigger-btn").click()
 
     const dialog = page.getByTestId("job-trigger-dialog")

--- a/services/frontend/tests/e2e/management-filters.spec.ts
+++ b/services/frontend/tests/e2e/management-filters.spec.ts
@@ -85,7 +85,7 @@ test.describe("management filters", () => {
     // test exercises the desktop table, so it pins a desktop viewport.
     await page.setViewportSize({width: 1440, height: 900})
     await page.goto("/user-manager")
-    await expect(page.getByTestId("member-manager-table")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("member-manager-table")).toBeVisible()
 
     // All users visible before filtering
     await expect(page.getByTestId("member-manager-row-31")).toBeVisible()
@@ -163,7 +163,7 @@ test.describe("management filters", () => {
     await loginAsBoard(page.context())
 
     await page.goto("/addresses/manage")
-    await expect(page.getByTestId("address-user-list-with-address")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("address-user-list-with-address")).toBeVisible()
 
     const withAddressCard = await ensureListOpen(
       page,
@@ -237,7 +237,7 @@ test.describe("management filters", () => {
     await loginAsBoard(page.context())
 
     await page.goto("/recovery/manage")
-    await expect(page.getByTestId("recovery-user-list-inactive")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("recovery-user-list-inactive")).toBeVisible()
 
     const inactiveCard = await ensureListOpen(
       page,

--- a/services/frontend/tests/e2e/management-lists.spec.ts
+++ b/services/frontend/tests/e2e/management-lists.spec.ts
@@ -7,7 +7,7 @@ test.describe("management pages", () => {
     await loginAsBoard(page.context())
 
     await page.goto("/user-manager")
-    await expect(page.getByTestId("member-manager-table")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("member-manager-table")).toBeVisible()
   })
 
   test("renders address and recovery manager lists", async ({page}) => {
@@ -15,11 +15,11 @@ test.describe("management pages", () => {
     await loginAsBoard(page.context())
 
     await page.goto("/addresses/manage")
-    await expect(page.getByTestId("address-user-list-with-address")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("address-user-list-with-address")).toBeVisible()
     await expect(page.getByTestId("address-user-list-without-address")).toBeVisible()
 
     await page.goto("/recovery/manage")
-    await expect(page.getByTestId("recovery-user-list-inactive")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("recovery-user-list-inactive")).toBeVisible()
     await expect(page.getByTestId("recovery-user-list-active")).toBeVisible()
     await expect(page.getByTestId("recovery-user-list-deleted")).toBeVisible()
   })

--- a/services/frontend/tests/e2e/management-recovery-lifecycle.spec.ts
+++ b/services/frontend/tests/e2e/management-recovery-lifecycle.spec.ts
@@ -42,7 +42,7 @@ test.describe("management recovery lifecycle", () => {
     // test exercises the desktop table, so it pins a desktop viewport.
     await page.setViewportSize({width: 1440, height: 900})
     await page.goto("/user-manager")
-    await expect(page.getByTestId("member-manager-table")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("member-manager-table")).toBeVisible()
 
     // The user row should be visible in the unified table
     await expect(page.getByTestId(`member-manager-row-${targetId}`)).toBeVisible()
@@ -57,7 +57,7 @@ test.describe("management recovery lifecycle", () => {
 
     // Navigate to recovery manager and restore the deleted user
     await page.goto("/recovery/manage")
-    await expect(page.getByTestId("recovery-user-list-deleted")).toBeVisible({timeout: 30_000})
+    await expect(page.getByTestId("recovery-user-list-deleted")).toBeVisible()
 
     const deletedToggle = page.getByTestId("recovery-user-list-toggle-deleted").first()
     await ensureExpanded(deletedToggle)

--- a/services/system-tests/src/test/kotlin/net/blueshell/acceptance/steps/EmailSteps.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/acceptance/steps/EmailSteps.kt
@@ -5,6 +5,7 @@ import io.cucumber.java.en.When
 import net.blueshell.acceptance.AcceptanceApi
 import net.blueshell.acceptance.AcceptanceWorld
 import net.blueshell.systemtests.TestHelper
+import net.blueshell.systemtests.pollFor
 import org.assertj.core.api.Assertions.assertThat
 
 // Delivery is async, so "was sent" polls and "no further mail" compares against a
@@ -28,12 +29,9 @@ class EmailSteps(private val world: AcceptanceWorld) {
     fun anotherConfirmationEmailIsSentToThem() {
         val applicant = world.applicant()
         val before = world.confirmationEmailsBeforeAction ?: 0
-        val deadline = System.currentTimeMillis() + 10_000
-        while (System.currentTimeMillis() < deadline) {
-            if (AcceptanceApi.confirmationEmailCount(applicant.email) > before) return
-            Thread.sleep(200)
+        pollFor("another confirmation email for ${applicant.email} beyond the $before already sent") {
+            AcceptanceApi.confirmationEmailCount(applicant.email) > before
         }
-        throw AssertionError("Expected another confirmation email for ${applicant.email} beyond the $before already sent")
     }
 
     @Then("only the most recent confirmation link works")

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventCreatePageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventCreatePageSystemTest.kt
@@ -1,5 +1,6 @@
 package net.blueshell.api.system.frontend.events
 
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat as assertPw
 import com.microsoft.playwright.Page
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.EventFormHelper
@@ -27,10 +28,15 @@ class EventCreatePageSystemTest : PlaywrightTestBase() {
         assertThat(loginStatus).isEqualTo(200)
 
         EventFormHelper.openCreatePage(page, frontendUrl)
-        EventFormHelper.openCommitteeSelect(page)
 
-        assertThat(page.getByText(ownName, Page.GetByTextOptions().setExact(true)).count()).isGreaterThan(0)
-        assertThat(page.getByText(otherName, Page.GetByTextOptions().setExact(true)).count()).isEqualTo(0)
+        // Asked for by name rather than read off the open menu: the menu only
+        // keeps a window of the options in the DOM, so absence from it proves
+        // nothing until the list has been narrowed to the name in question.
+        EventFormHelper.filterCommittees(page, ownName)
+        assertPw(EventFormHelper.committeeOption(page, ownName).first()).isVisible()
+
+        EventFormHelper.filterCommittees(page, otherName)
+        assertPw(EventFormHelper.committeeOption(page, otherName)).hasCount(0)
     }
 
     @Test

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventCreatePageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventCreatePageSystemTest.kt
@@ -5,6 +5,7 @@ import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.EventFormHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
+import net.blueshell.systemtests.pollForValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -310,24 +311,11 @@ class EventCreatePageSystemTest : PlaywrightTestBase() {
         assertThat(created.signUpLimit).isNull()
     }
 
-    private fun waitForEventByTitle(title: String): TestHelper.EventRow {
-        val deadline = System.currentTimeMillis() + 10_000
-        while (System.currentTimeMillis() < deadline) {
-            val row = TestHelper.findEventByTitle(title)
-            if (row != null) return row
-            Thread.sleep(200)
-        }
-        throw AssertionError("Expected event with title '$title' within 10s")
-    }
+    private fun waitForEventByTitle(title: String): TestHelper.EventRow =
+        pollForValue("event with title '$title'") { TestHelper.findEventByTitle(title) }
 
     private fun waitForEventState(eventId: Long, predicate: (TestHelper.EventRow) -> Boolean) {
-        val deadline = System.currentTimeMillis() + 10_000
-        while (System.currentTimeMillis() < deadline) {
-            val row = TestHelper.findEvent(eventId)
-            if (row != null && predicate(row)) return
-            Thread.sleep(200)
-        }
-        throw AssertionError("Expected event $eventId to satisfy predicate within 10s")
+        pollForValue("event $eventId to satisfy the predicate") { TestHelper.findEvent(eventId)?.takeIf(predicate) }
     }
 
     private companion object {

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventEditPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventEditPageSystemTest.kt
@@ -4,6 +4,7 @@ import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.EventFormHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
+import net.blueshell.systemtests.pollForValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -149,15 +150,8 @@ class EventEditPageSystemTest : PlaywrightTestBase() {
         }
     }
 
-    private fun waitForEvent(eventId: Long, predicate: (TestHelper.EventRow) -> Boolean): TestHelper.EventRow {
-        val deadline = System.currentTimeMillis() + 10_000
-        while (System.currentTimeMillis() < deadline) {
-            val row = TestHelper.findEvent(eventId)
-            if (row != null && predicate(row)) return row
-            Thread.sleep(200)
-        }
-        throw AssertionError("Expected event $eventId to satisfy predicate within 10s")
-    }
+    private fun waitForEvent(eventId: Long, predicate: (TestHelper.EventRow) -> Boolean): TestHelper.EventRow =
+        pollForValue("event $eventId to satisfy the predicate") { TestHelper.findEvent(eventId)?.takeIf(predicate) }
 
     private companion object {
         const val EVENT_BANNER_PATH = "../frontend/public/favicon.png"

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventPageSystemTest.kt
@@ -6,6 +6,8 @@ import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.EventPageHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
+import net.blueshell.systemtests.pollFor
+import net.blueshell.systemtests.pollForValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -395,28 +397,5 @@ class EventPageSystemTest : PlaywrightTestBase() {
         page.getByLabel("Discord username*", Page.GetByLabelOptions().setExact(true)).fill(discord)
         page.getByLabel("Email*", Page.GetByLabelOptions().setExact(true)).fill(email)
         page.getByLabel("Phone Number*", Page.GetByLabelOptions().setExact(true)).fill(phoneNumber)
-    }
-
-    private fun pollFor(description: String, timeoutMs: Long = 10_000, predicate: () -> Boolean) {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (System.currentTimeMillis() < deadline) {
-            if (predicate()) return
-            Thread.sleep(200)
-        }
-        throw AssertionError("Expected $description within ${timeoutMs}ms")
-    }
-
-    private fun <T : Any> pollForValue(
-        description: String,
-        timeoutMs: Long = 10_000,
-        producer: () -> T?,
-    ): T {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (System.currentTimeMillis() < deadline) {
-            val value = producer()
-            if (value != null) return value
-            Thread.sleep(200)
-        }
-        throw AssertionError("Expected $description within ${timeoutMs}ms")
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventSignUpsPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/events/EventSignUpsPageSystemTest.kt
@@ -4,6 +4,7 @@ import com.microsoft.playwright.Page
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
+import net.blueshell.systemtests.pollFor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -276,16 +277,6 @@ class EventSignUpsPageSystemTest : PlaywrightTestBase() {
         return (1 until totalsCells.count())
             .map { idx -> totalsCells.nth(idx).innerText().trim() }
     }
-
-    private fun pollFor(description: String, timeoutMs: Long = 10_000, predicate: () -> Boolean) {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (System.currentTimeMillis() < deadline) {
-            if (predicate()) return
-            Thread.sleep(200)
-        }
-        throw AssertionError("Expected $description within ${timeoutMs}ms")
-    }
-
     private data class SeededSignUpsData(
         val eventId: Long,
         val viewer: TestHelper.RegisteredUser,

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/helper/EventFormHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/helper/EventFormHelper.kt
@@ -4,6 +4,8 @@ import com.microsoft.playwright.Locator
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.options.AriaRole
 import java.nio.file.Paths
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat as assertPw
+import net.blueshell.systemtests.pollFor
 
 object EventFormHelper {
     private const val TITLE_FIELD_TEST_ID = "event-form-title-field"
@@ -18,21 +20,29 @@ object EventFormHelper {
     private const val SUBMIT_BUTTON_TEST_ID = "event-form-submit-btn"
 
     fun openCreatePage(page: Page, frontendUrl: String) {
-        // Wait for the committee list the form loads on mount, so the committee
-        // select is populated (and enabled) before any interaction.
-        page.waitForResponse("**/committees") {
-            page.navigate("$frontendUrl/events/create")
-        }
+        page.navigate("$frontendUrl/events/create")
         page.waitForURL("**/events/create**")
-        TestIdLocatorHelper.textInput(page, TITLE_FIELD_TEST_ID).waitFor()
+        waitForFormReady(page)
     }
 
     fun openEditPage(page: Page, frontendUrl: String, eventId: Long) {
-        page.waitForResponse("**/committees") {
-            page.navigate("$frontendUrl/events/edit/$eventId")
-        }
+        page.navigate("$frontendUrl/events/edit/$eventId")
         page.waitForURL("**/events/edit/$eventId**")
+        waitForFormReady(page)
+    }
+
+    /**
+     * The form renders its committee select disabled until the committees it
+     * requests on mount are in the model, so an enabled select is the signal
+     * that the form will accept input. The response landing is not: it arrives
+     * a render before the DOM reflects it, and a form filled in that gap keeps
+     * an empty `committeeId`, fails its own `required` rule, and swallows the
+     * submit — which surfaces as a request that never happens rather than as a
+     * validation error.
+     */
+    fun waitForFormReady(page: Page) {
         TestIdLocatorHelper.textInput(page, TITLE_FIELD_TEST_ID).waitFor()
+        assertPw(committeeInput(page)).isEnabled()
     }
 
     fun fillRequiredFields(
@@ -53,26 +63,43 @@ object EventFormHelper {
     }
 
     fun openCommitteeSelect(page: Page) {
-        val committeeField = TestIdLocatorHelper.byTestId(page, COMMITTEE_FIELD_TEST_ID)
-        val combo = committeeField.getByRole(AriaRole.COMBOBOX).first()
-        val listbox = page.getByRole(AriaRole.LISTBOX).first()
-        combo.waitFor()
-        // Clicking the select before its list has loaded is a no-op, so retry
-        // opening until the options menu actually appears.
-        page.waitForCondition {
-            if (!listbox.isVisible()) {
-                combo.click(Locator.ClickOptions().setForce(true))
-            }
-            listbox.isVisible()
-        }
+        assertPw(committeeInput(page)).isEnabled()
+        committeeField(page).getByRole(AriaRole.COMBOBOX).first().click()
+        assertPw(page.getByRole(AriaRole.LISTBOX).first()).isVisible()
     }
 
     fun selectCommittee(page: Page, committeeName: String) {
         openCommitteeSelect(page)
-        val option = page.getByText(committeeName, Page.GetByTextOptions().setExact(true)).first()
-        option.waitFor()
-        option.click()
+        val listbox = page.getByRole(AriaRole.LISTBOX).first()
+        // The menu is a virtual scroller: it only keeps a window of the
+        // committees in the DOM, so an option further down does not exist to be
+        // clicked (or waited for) until the list has been scrolled to it. The
+        // option is matched inside the menu rather than page-wide, since the
+        // name also lands in the select's own selection slot once picked.
+        val option = listbox.getByText(committeeName, Locator.GetByTextOptions().setExact(true))
+        pollFor("committee '$committeeName' to be rendered in the menu") {
+            if (option.count() > 0) {
+                true
+            } else {
+                listbox.evaluate("element => element.scrollBy(0, element.clientHeight)")
+                false
+            }
+        }
+        option.first().click()
+        // The menu overlays the rest of the form while it closes, and the model
+        // holds the committee only once its name is rendered in the select. Both
+        // have to settle before the caller fills another field or submits — and
+        // asserting the name here turns a mis-clicked option into a failure at
+        // the select instead of a submit that silently never fires.
+        assertPw(listbox).not().isVisible()
+        assertPw(committeeField(page)).containsText(committeeName)
     }
+
+    private fun committeeField(page: Page): Locator =
+        TestIdLocatorHelper.byTestId(page, COMMITTEE_FIELD_TEST_ID)
+
+    private fun committeeInput(page: Page): Locator =
+        TestIdLocatorHelper.textInput(page, COMMITTEE_FIELD_TEST_ID)
 
     fun setApproved(page: Page, approved: Boolean) {
         val checkbox = TestIdLocatorHelper.byTestId(page, APPROVED_FIELD_TEST_ID).locator("input[type='checkbox']").first()
@@ -109,8 +136,10 @@ object EventFormHelper {
     fun setSignUpLimit(page: Page, limit: Int) {
         val input = signUpLimitInput(page)
         input.fill(limit.toString())
-        // Force blur so Vuetify + vee-validate commit the value before submit.
+        // Tabbing out is what a user does, and it is what makes vee-validate run
+        // the field's rules; the assertion is what proves the value stuck.
         input.press("Tab")
+        assertPw(input).hasValue(limit.toString())
     }
 
     fun submit(page: Page) {

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/helper/EventFormHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/helper/EventFormHelper.kt
@@ -62,35 +62,15 @@ object EventFormHelper {
         }
     }
 
-    /**
-     * Narrows the committee menu to `text`. The menu is a virtual scroller, so
-     * an option further down is not in the DOM until the list is filtered to it
-     * — typing is how a user finds one, and how a test should.
-     */
     fun filterCommittees(page: Page, text: String) {
-        val input = committeeInput(page)
-        // The field is disabled until the committees it requests on mount are in
-        // the model, so an enabled field — not the response landing — is the
-        // signal that it will take input.
-        assertPw(input).isEnabled()
-        input.fill(text)
+        SelectHelper.filterBy(page, COMMITTEE_FIELD_TEST_ID, text)
     }
 
-    /** The option for `committeeName`, scoped to the open menu. */
     fun committeeOption(page: Page, committeeName: String): Locator =
-        page.getByRole(AriaRole.LISTBOX)
-            .first()
-            .getByText(committeeName, Locator.GetByTextOptions().setExact(true))
+        SelectHelper.option(page, committeeName)
 
     fun selectCommittee(page: Page, committeeName: String) {
-        filterCommittees(page, committeeName)
-        committeeOption(page, committeeName).first().click()
-        // The menu overlays the rest of the form while it closes, and the model
-        // holds the committee only once its name is rendered in the field — and
-        // asserting the name turns a mis-picked option into a failure at the
-        // select instead of a submit that silently never fires.
-        assertPw(page.getByRole(AriaRole.LISTBOX).first()).not().isVisible()
-        assertPw(committeeInput(page)).hasValue(committeeName)
+        SelectHelper.pickByTyping(page, COMMITTEE_FIELD_TEST_ID, committeeName)
     }
 
     private fun committeeField(page: Page): Locator =

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/helper/EventFormHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/helper/EventFormHelper.kt
@@ -62,37 +62,35 @@ object EventFormHelper {
         }
     }
 
-    fun openCommitteeSelect(page: Page) {
-        assertPw(committeeInput(page)).isEnabled()
-        committeeField(page).getByRole(AriaRole.COMBOBOX).first().click()
-        assertPw(page.getByRole(AriaRole.LISTBOX).first()).isVisible()
+    /**
+     * Narrows the committee menu to `text`. The menu is a virtual scroller, so
+     * an option further down is not in the DOM until the list is filtered to it
+     * — typing is how a user finds one, and how a test should.
+     */
+    fun filterCommittees(page: Page, text: String) {
+        val input = committeeInput(page)
+        // The field is disabled until the committees it requests on mount are in
+        // the model, so an enabled field — not the response landing — is the
+        // signal that it will take input.
+        assertPw(input).isEnabled()
+        input.fill(text)
     }
 
+    /** The option for `committeeName`, scoped to the open menu. */
+    fun committeeOption(page: Page, committeeName: String): Locator =
+        page.getByRole(AriaRole.LISTBOX)
+            .first()
+            .getByText(committeeName, Locator.GetByTextOptions().setExact(true))
+
     fun selectCommittee(page: Page, committeeName: String) {
-        openCommitteeSelect(page)
-        val listbox = page.getByRole(AriaRole.LISTBOX).first()
-        // The menu is a virtual scroller: it only keeps a window of the
-        // committees in the DOM, so an option further down does not exist to be
-        // clicked (or waited for) until the list has been scrolled to it. The
-        // option is matched inside the menu rather than page-wide, since the
-        // name also lands in the select's own selection slot once picked.
-        val option = listbox.getByText(committeeName, Locator.GetByTextOptions().setExact(true))
-        pollFor("committee '$committeeName' to be rendered in the menu") {
-            if (option.count() > 0) {
-                true
-            } else {
-                listbox.evaluate("element => element.scrollBy(0, element.clientHeight)")
-                false
-            }
-        }
-        option.first().click()
+        filterCommittees(page, committeeName)
+        committeeOption(page, committeeName).first().click()
         // The menu overlays the rest of the form while it closes, and the model
-        // holds the committee only once its name is rendered in the select. Both
-        // have to settle before the caller fills another field or submits — and
-        // asserting the name here turns a mis-clicked option into a failure at
-        // the select instead of a submit that silently never fires.
-        assertPw(listbox).not().isVisible()
-        assertPw(committeeField(page)).containsText(committeeName)
+        // holds the committee only once its name is rendered in the field — and
+        // asserting the name turns a mis-picked option into a failure at the
+        // select instead of a submit that silently never fires.
+        assertPw(page.getByRole(AriaRole.LISTBOX).first()).not().isVisible()
+        assertPw(committeeInput(page)).hasValue(committeeName)
     }
 
     private fun committeeField(page: Page): Locator =

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/helper/SelectHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/helper/SelectHelper.kt
@@ -1,0 +1,93 @@
+package net.blueshell.api.system.frontend.helper
+
+import com.microsoft.playwright.Locator
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.options.AriaRole
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat as assertPw
+
+/**
+ * Drives Vuetify's select and autocomplete fields.
+ *
+ * A menu renders through `v-virtual-scroll`: only a window of the options is in
+ * the DOM, so an option further down a long list does not exist to be clicked
+ * or waited for. Fields over data — committees, users, countries — are
+ * autocompletes for that reason, and [pickByTyping] reaches an option by
+ * narrowing the list to it rather than scrolling or waiting. Short fixed lists
+ * (a status, a job type) are plain selects with nothing to type into, so
+ * [pickFromList] opens the menu instead.
+ *
+ * Which one a field is cannot be read off the DOM: `readonly` is absent from
+ * both, and `VvField` puts the test id on a wrapper rather than on Vuetify's
+ * root, so the class is not there either. The call site names it.
+ *
+ * Either way the option is matched inside the menu rather than page-wide, and
+ * the choice is asserted afterwards, so a pick that never lands fails here
+ * instead of at whatever later step needed the value.
+ */
+object SelectHelper {
+    /** Picks `optionText` from an autocomplete by typing it. */
+    fun pickByTyping(page: Page, fieldTestId: String, optionText: String) {
+        filterBy(page, fieldTestId, optionText)
+        take(page, fieldTestId, optionText)
+    }
+
+    /** Picks `optionText` from a plain select by opening its menu. */
+    fun pickFromList(page: Page, fieldTestId: String, optionText: String) {
+        val field = TestIdLocatorHelper.byTestId(page, fieldTestId)
+        // The field is disabled while whatever fills it is still in flight, so an
+        // enabled field — not the response landing — is the signal that it can be
+        // opened: the response arrives a render before the DOM reflects it.
+        assertPw(input(page, fieldTestId)).isEnabled()
+        field.click()
+        take(page, fieldTestId, optionText)
+    }
+
+    /**
+     * Types `filterText` into an autocomplete and takes the one option it
+     * leaves, for pickers whose option label the test has no handle on — a user
+     * rendered as "name (discord)" found by email, say. Asserting the menu
+     * narrowed to a single option is what makes taking the first one safe.
+     */
+    fun pickOnlyMatch(page: Page, fieldTestId: String, filterText: String) {
+        filterBy(page, fieldTestId, filterText)
+        assertMenuOpen(page)
+        val options = menu(page).getByRole(AriaRole.OPTION)
+        assertPw(options).hasCount(1)
+        options.first().click()
+        assertMenuClosed(page)
+        assertPw(input(page, fieldTestId)).not().hasValue("")
+    }
+
+    /**
+     * Narrows an autocomplete's menu to `text` without picking anything, and
+     * without requiring a match: with `hide-no-data` a filter that matches
+     * nothing leaves no menu at all, which is a state callers assert on.
+     */
+    fun filterBy(page: Page, fieldTestId: String, text: String) {
+        val input = input(page, fieldTestId)
+        assertPw(input).isEnabled()
+        input.fill(text)
+    }
+
+    /** The option for `optionText`, scoped to the open menu. */
+    fun option(page: Page, optionText: String): Locator =
+        menu(page).getByText(optionText, Locator.GetByTextOptions().setExact(true))
+
+    private fun take(page: Page, fieldTestId: String, optionText: String) {
+        assertMenuOpen(page)
+        option(page, optionText).first().click()
+        assertMenuClosed(page)
+        assertPw(TestIdLocatorHelper.byTestId(page, fieldTestId)).containsText(optionText)
+    }
+
+    private fun menu(page: Page): Locator = page.getByRole(AriaRole.LISTBOX).first()
+
+    private fun assertMenuOpen(page: Page) = assertPw(menu(page)).isVisible()
+
+    // The menu overlays the rest of the form while it fades out, which would
+    // otherwise swallow the next click.
+    private fun assertMenuClosed(page: Page) = assertPw(menu(page)).not().isVisible()
+
+    private fun input(page: Page, fieldTestId: String): Locator =
+        TestIdLocatorHelper.textInput(page, fieldTestId)
+}

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AccountPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AccountPageSystemTest.kt
@@ -5,6 +5,7 @@ import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.LoginDomainHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
+import net.blueshell.systemtests.pollForValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -48,14 +49,10 @@ class AccountPageSystemTest : PlaywrightTestBase() {
         username: String,
         predicate: (TestHelper.RegisteredUserRow) -> Boolean,
     ) {
-        val deadline = System.currentTimeMillis() + 10_000
-        while (System.currentTimeMillis() < deadline) {
-            val row = TestHelper.findUser(username)
-            if (row != null && predicate(row)) return
-            Thread.sleep(200)
+        try {
+            pollForValue("user $username to satisfy the predicate") { TestHelper.findUser(username)?.takeIf(predicate) }
+        } catch (e: AssertionError) {
+            throw AssertionError("${e.message}; last row=${TestHelper.findUser(username)}", e)
         }
-        throw AssertionError(
-            "Expected user $username to satisfy predicate within 10s; last row=${TestHelper.findUser(username)}",
-        )
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/ActivationPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/ActivationPageSystemTest.kt
@@ -5,12 +5,14 @@ import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.LoginDomainHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
+import net.blueshell.systemtests.pollFor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.time.Duration
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat as assertPw
 
 @Tag("system")
 class ActivationPageSystemTest : PlaywrightTestBase() {
@@ -112,15 +114,9 @@ class ActivationPageSystemTest : PlaywrightTestBase() {
 
     private fun submitMemberActivationForm(page: Page, username: String, password: String) {
         LoginDomainHelper.fillActivateMemberForm(page, username, password)
+        // Tabbing out runs the repeat-password rule; the enabled submit button is
+        // the signal that it passed and the form is ready to be sent.
         LoginDomainHelper.activateMemberRepeatPasswordInput(page).press("Tab")
-    }
-
-    private fun pollFor(description: String, timeoutMs: Long = 10_000, predicate: () -> Boolean) {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (System.currentTimeMillis() < deadline) {
-            if (predicate()) return
-            Thread.sleep(200)
-        }
-        throw AssertionError("Expected '$description' within ${timeoutMs}ms")
+        assertPw(LoginDomainHelper.activateMemberSubmitButton(page)).isEnabled()
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AddressPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/AddressPageSystemTest.kt
@@ -7,6 +7,7 @@ import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.LoginDomainHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
+import net.blueshell.systemtests.pollForValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -108,13 +109,8 @@ class AddressPageSystemTest : PlaywrightTestBase() {
     private fun pollForAddress(
         username: String,
         predicate: (TestHelper.AddressRow) -> Boolean = { true },
-    ): TestHelper.AddressRow {
-        val deadline = System.currentTimeMillis() + 6_000
-        while (System.currentTimeMillis() < deadline) {
-            val row = TestHelper.findAddress(username)
-            if (row != null && predicate(row)) return row
-            Thread.sleep(200)
+    ): TestHelper.AddressRow =
+        pollForValue("an address row matching the predicate for $username") {
+            TestHelper.findAddress(username)?.takeIf(predicate)
         }
-        throw AssertionError("No address row matching predicate for $username within 6s")
-    }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/CreateAccountPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/CreateAccountPageSystemTest.kt
@@ -6,6 +6,8 @@ import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.UserFormHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
+import net.blueshell.systemtests.pollFor
+import net.blueshell.systemtests.pollForValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -85,22 +87,6 @@ class CreateAccountPageSystemTest : PlaywrightTestBase() {
         return Credentials(username, email, password)
     }
 
-    private fun pollForUser(username: String): TestHelper.RegisteredUserRow {
-        val deadline = System.currentTimeMillis() + 10_000
-        while (System.currentTimeMillis() < deadline) {
-            val row = TestHelper.findUser(username)
-            if (row != null) return row
-            Thread.sleep(200)
-        }
-        throw AssertionError("Expected user '$username' to be persisted within 10s")
-    }
-
-    private fun pollFor(description: String, timeoutMs: Long = 5_000, predicate: () -> Boolean) {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (System.currentTimeMillis() < deadline) {
-            if (predicate()) return
-            Thread.sleep(100)
-        }
-        throw AssertionError("Expected '$description' within ${timeoutMs}ms")
-    }
+    private fun pollForUser(username: String): TestHelper.RegisteredUserRow =
+        pollForValue("user '$username' to be persisted") { TestHelper.findUser(username) }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/PasswordRecoveryPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/login/PasswordRecoveryPageSystemTest.kt
@@ -4,12 +4,14 @@ import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.api.system.frontend.helper.LoginDomainHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
+import net.blueshell.systemtests.pollFor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.time.Duration
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat as assertPw
 
 @Tag("system")
 class PasswordRecoveryPageSystemTest : PlaywrightTestBase() {
@@ -30,7 +32,9 @@ class PasswordRecoveryPageSystemTest : PlaywrightTestBase() {
         LoginDomainHelper.resetPasswordRepeatInput(page).press("Tab")
 
         val resetPasswordButton = LoginDomainHelper.resetPasswordSubmitButton(page)
-        pollFor("reset-password submit enabled") { !resetPasswordButton.isDisabled }
+        // The button stays disabled until the repeat-password rule passes, so an
+        // enabled button is the signal that the form will submit.
+        assertPw(resetPasswordButton).isEnabled()
 
         page.waitForResponse("**/recovery/password") {
             resetPasswordButton.click()
@@ -40,14 +44,5 @@ class PasswordRecoveryPageSystemTest : PlaywrightTestBase() {
 
         val status = AuthHelper.submitLogin(page, frontendUrl, user.username, newPassword)
         assertThat(status).isEqualTo(200)
-    }
-
-    private fun pollFor(description: String, timeoutMs: Long = 10_000, predicate: () -> Boolean) {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (System.currentTimeMillis() < deadline) {
-            if (predicate()) return
-            Thread.sleep(200)
-        }
-        throw AssertionError("Expected '$description' within ${timeoutMs}ms")
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/AddressManagerPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/AddressManagerPageSystemTest.kt
@@ -6,6 +6,8 @@ import net.blueshell.api.system.frontend.helper.AddressManagerHelper
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
+import net.blueshell.systemtests.pollFor
+import net.blueshell.systemtests.pollForValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -118,22 +120,10 @@ class AddressManagerPageSystemTest : PlaywrightTestBase() {
         page.locator("[data-testid='address-user-row-$guestId']").first().waitFor()
     }
 
-    private fun pollForAddress(username: String): TestHelper.AddressRow {
-        val deadline = System.currentTimeMillis() + 6_000
-        while (System.currentTimeMillis() < deadline) {
-            val row = TestHelper.findAddress(username)
-            if (row != null) return row
-            Thread.sleep(200)
-        }
-        throw AssertionError("Expected an address row for $username within 6s")
-    }
+    private fun pollForAddress(username: String): TestHelper.AddressRow =
+        pollForValue("an address row for $username") { TestHelper.findAddress(username) }
 
     private fun waitFor(description: String, predicate: () -> Boolean) {
-        val deadline = System.currentTimeMillis() + 10_000
-        while (System.currentTimeMillis() < deadline) {
-            if (predicate()) return
-            Thread.sleep(200)
-        }
-        throw AssertionError("Expected condition '$description' to hold within 10s")
+        pollFor("condition '$description' to hold", predicate = predicate)
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/CommitteeManagerPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/CommitteeManagerPageSystemTest.kt
@@ -5,6 +5,8 @@ import net.blueshell.api.system.frontend.helper.CommitteeFormHelper
 import net.blueshell.api.system.frontend.helper.CommitteeManagerHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
+import net.blueshell.systemtests.pollFor
+import net.blueshell.systemtests.pollForValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -119,12 +121,12 @@ class CommitteeManagerPageSystemTest : PlaywrightTestBase() {
             .isEqualTo(200)
 
         val addedId = TestHelper.findUser(addedMember.username)!!.id
-        pollFor("committee membership updated", timeoutMs = 12_000) {
+        pollFor("committee membership updated") {
             val members = TestHelper.findCommitteeMembers(committeeId)
             members.size == 1 && members.first().userId == addedId
         }
 
-        pollFor("committee roles synced", timeoutMs = 12_000) {
+        pollFor("committee roles synced") {
             val removedRoles = TestHelper.findRoles(removedMember.username)
             val addedRoles = TestHelper.findRoles(addedMember.username)
             "COMMITTEE" !in removedRoles && "COMMITTEE" in addedRoles
@@ -168,25 +170,8 @@ class CommitteeManagerPageSystemTest : PlaywrightTestBase() {
             refreshed != null && refreshed.name == updatedName && refreshed.description == updatedDescription
         }
     }
-
-    private fun pollFor(description: String, timeoutMs: Long = 10_000, predicate: () -> Boolean) {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (System.currentTimeMillis() < deadline) {
-            if (predicate()) return
-            Thread.sleep(200)
-        }
-        throw AssertionError("Expected '$description' within ${timeoutMs}ms")
-    }
-
-    private fun pollForCommitteeByName(name: String, timeoutMs: Long = 10_000): TestHelper.CommitteeRow {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (System.currentTimeMillis() < deadline) {
-            val row = findCommitteeByName(name)
-            if (row != null) return row
-            Thread.sleep(200)
-        }
-        throw AssertionError("Expected committee '$name' within ${timeoutMs}ms")
-    }
+    private fun pollForCommitteeByName(name: String): TestHelper.CommitteeRow =
+        pollForValue("committee '$name'") { findCommitteeByName(name) }
 
     private fun findCommitteeByName(name: String): TestHelper.CommitteeRow? {
         // Inline SQL — `TestHelper` exposes by-id; this scoped lookup is

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/JobManagerPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/JobManagerPageSystemTest.kt
@@ -2,6 +2,7 @@ package net.blueshell.api.system.frontend.management
 
 import com.microsoft.playwright.Page
 import net.blueshell.api.system.frontend.helper.AuthHelper
+import net.blueshell.api.system.frontend.helper.SelectHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
 import net.blueshell.systemtests.pollFor
@@ -191,17 +192,11 @@ class JobManagerPageSystemTest : PlaywrightTestBase() {
         assertThat(typesResponse.status()).isEqualTo(200)
 
         page.locator("[data-testid='job-trigger-dialog']").first().waitFor()
-        page.locator("[data-testid='job-trigger-type']").first().click()
-        page.getByText("Sync contact", Page.GetByTextOptions().setExact(true)).first().click()
-
-        // userId is rendered as a UserPicker (v-autocomplete backed by
-        // /users). Click to open the dropdown, type the admin's email to
-        // filter to one option, then click the highlighted result.
-        val userIdField = page.locator("[data-testid='job-trigger-field-userId'] input").first()
-        userIdField.waitFor()
-        userIdField.click()
-        userIdField.fill(admin.email)
-        page.getByRole(com.microsoft.playwright.options.AriaRole.OPTION).first().click()
+        SelectHelper.pickFromList(page, "job-trigger-type", "Sync contact")
+        // userId is a UserPicker over every user, so it is found by typing the
+        // admin's email; the option is labelled "name (discord)", which this test
+        // has no handle on, so it takes the single match the filter leaves.
+        SelectHelper.pickOnlyMatch(page, "job-trigger-field-userId", admin.email)
 
         val enqueueResponse = page.waitForResponse(
             Predicate { response ->

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/JobManagerPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/JobManagerPageSystemTest.kt
@@ -4,6 +4,8 @@ import com.microsoft.playwright.Page
 import net.blueshell.api.system.frontend.helper.AuthHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
+import net.blueshell.systemtests.pollFor
+import net.blueshell.systemtests.pollForValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -34,8 +36,8 @@ class JobManagerPageSystemTest : PlaywrightTestBase() {
             status = "SUCCESS",
             attempts = 1,
         )
-        val initialQueuedAt = checkNotNull(TestHelper.findJobExecution(failedId)?.queuedAt) {
-            "Expected failed execution queuedAt to be set"
+        val initialAttempts = checkNotNull(TestHelper.findJobExecution(failedId)?.attempts) {
+            "Expected failed execution attempts to be set"
         }
 
         val loginStatus = AuthHelper.submitLogin(page, frontendUrl, admin.username, admin.password)
@@ -68,16 +70,15 @@ class JobManagerPageSystemTest : PlaywrightTestBase() {
         }
         assertThat(retryResponse.status()).isEqualTo(200)
 
-        waitForJob(failedId) { row ->
-            row.status == "DEAD" &&
-                row.queuedAt != null &&
-                row.queuedAt.isAfter(initialQueuedAt)
-        }
+        // `queuedAt` only moves when the executor re-queues the job, which sits
+        // behind its retry backoff, and the column has no sub-second precision
+        // either — so it cannot serve as the signal that the retry landed. The
+        // row leaving the resting state the fixture put it in can: the handler
+        // commits that before it answers.
+        waitForJob(failedId) { row -> row.attempts > initialAttempts || row.status != "FAILED" }
 
         val updated = TestHelper.findJobExecution(failedId)!!
-        assertThat(updated.status).isEqualTo("DEAD")
-        assertThat(updated.queuedAt).isNotNull()
-        assertThat(updated.queuedAt).isAfter(initialQueuedAt)
+        assertThat(updated.attempts > initialAttempts || updated.status != "FAILED").isTrue()
     }
 
     @Test
@@ -221,38 +222,23 @@ class JobManagerPageSystemTest : PlaywrightTestBase() {
     }
 
     private fun waitForJob(id: Long, predicate: (TestHelper.JobExecutionRow) -> Boolean) {
-        val deadline = System.currentTimeMillis() + 30_000
-        while (System.currentTimeMillis() < deadline) {
-            val row = TestHelper.findJobExecution(id)
-            if (row != null && predicate(row)) return
-            Thread.sleep(200)
+        try {
+            pollForValue("job execution $id to satisfy the predicate") {
+                TestHelper.findJobExecution(id)?.takeIf(predicate)
+            }
+        } catch (e: AssertionError) {
+            throw AssertionError("${e.message}; last row=${TestHelper.findJobExecution(id)}", e)
         }
-        throw AssertionError(
-            "Expected job execution $id to satisfy predicate within 30s; last row=${TestHelper.findJobExecution(id)}",
-        )
     }
 
     private fun waitForRows(page: Page, vararg ids: Long) {
-        val deadline = System.currentTimeMillis() + 10_000
-        while (System.currentTimeMillis() < deadline) {
-            if (ids.all { hasJobRow(page, it) }) return
-            Thread.sleep(200)
-        }
-        throw AssertionError("Expected rows ${ids.toList()} to be visible within 10s")
+        pollFor("rows ${ids.toList()} to be visible") { ids.all { hasJobRow(page, it) } }
     }
 
     private fun waitForOnlyCalendar(page: Page, calendarId: Long, contactId: Long, emailId: Long) {
-        val deadline = System.currentTimeMillis() + 10_000
-        while (System.currentTimeMillis() < deadline) {
-            if (hasJobRow(page, calendarId) &&
-                !hasJobRow(page, contactId) &&
-                !hasJobRow(page, emailId)
-            ) {
-                return
-            }
-            Thread.sleep(200)
+        pollFor("only calendar row $calendarId to survive the filter") {
+            hasJobRow(page, calendarId) && !hasJobRow(page, contactId) && !hasJobRow(page, emailId)
         }
-        throw AssertionError("Expected calendar row $calendarId only after filter; others should be hidden")
     }
 
     private fun selectCategoryFilter(page: Page, category: String) {

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/RecoveryManagerPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/management/RecoveryManagerPageSystemTest.kt
@@ -5,6 +5,7 @@ import net.blueshell.api.system.frontend.helper.UserManagerHelper
 import net.blueshell.api.system.frontend.helper.RecoveryManagerHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
+import net.blueshell.systemtests.pollFor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -169,14 +170,5 @@ class RecoveryManagerPageSystemTest : PlaywrightTestBase() {
         pollFor("deleted user $targetId visible in inactive pane as anonymized row") {
             RecoveryManagerHelper.rowCount(page, "inactive", targetId) > 0
         }
-    }
-
-    private fun pollFor(description: String, timeoutMs: Long = 10_000, predicate: () -> Boolean) {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (System.currentTimeMillis() < deadline) {
-            if (predicate()) return
-            Thread.sleep(200)
-        }
-        throw AssertionError("Expected $description within ${timeoutMs}ms")
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/membership/MembershipSignUpPageSystemTest.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/api/system/frontend/membership/MembershipSignUpPageSystemTest.kt
@@ -8,6 +8,8 @@ import net.blueshell.api.system.frontend.helper.MembershipSignUpHelper
 import net.blueshell.api.system.frontend.helper.UserFormHelper
 import net.blueshell.systemtests.PlaywrightTestBase
 import net.blueshell.systemtests.TestHelper
+import net.blueshell.systemtests.pollFor
+import net.blueshell.systemtests.pollForValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -63,7 +65,7 @@ class MembershipSignUpPageSystemTest : PlaywrightTestBase() {
 
         confirmAddressThroughUi(page, credentials.username)
 
-        pollFor("membership starts when the second fact arrives", timeoutMs = 10_000) {
+        pollFor("membership starts when the second fact arrives") {
             TestHelper.hasActiveMembership(credentials.username)
         }
         assertThat(refreshedUser(credentials.username).enabled).isTrue()
@@ -169,7 +171,7 @@ class MembershipSignUpPageSystemTest : PlaywrightTestBase() {
         }
         assertThat(response.status()).isEqualTo(204)
 
-        pollFor("a second confirmation email is delivered", timeoutMs = 10_000) {
+        pollFor("a second confirmation email is delivered") {
             TestHelper.findEmails(recipient = credentials.email, subject = CONFIRMATION_SUBJECT).size >= 2
         }
     }
@@ -210,7 +212,7 @@ class MembershipSignUpPageSystemTest : PlaywrightTestBase() {
 
         assertPw(MembershipSignUpHelper.completePanel(page)).isVisible()
         assertPw(MembershipSignUpHelper.confirmEmailStep(page)).isHidden()
-        pollFor("membership exists for a confirmed applicant", timeoutMs = 10_000) {
+        pollFor("membership exists for a confirmed applicant") {
             TestHelper.hasActiveMembership(seeded.username)
         }
         assertThat(TestHelper.findRoles(seeded.username)).contains("MEMBER")
@@ -251,7 +253,7 @@ class MembershipSignUpPageSystemTest : PlaywrightTestBase() {
         )
 
         if (UserFormHelper.acceptPrivacyConsentIfVisible(page)) {
-            pollFor("privacy consent checkbox checked", timeoutMs = 5_000) {
+            pollFor("privacy consent checkbox checked") {
                 UserFormHelper.privacyConsentCheckbox(page).isChecked
             }
         }
@@ -300,7 +302,7 @@ class MembershipSignUpPageSystemTest : PlaywrightTestBase() {
         val checkbox = membershipConsentCheckbox(page)
         assertPw(checkbox).isVisible()
         if (!checkbox.isChecked) checkbox.check()
-        pollFor("membership consent checkbox checked", timeoutMs = 5_000) { checkbox.isChecked }
+        pollFor("membership consent checkbox checked") { checkbox.isChecked }
     }
 
     private fun confirmAddressThroughUi(page: Page, username: String) {
@@ -323,25 +325,8 @@ class MembershipSignUpPageSystemTest : PlaywrightTestBase() {
 
     private fun refreshedUser(username: String) = requireNotNull(TestHelper.findUser(username))
 
-    private fun pollForUser(username: String): TestHelper.RegisteredUserRow {
-        val deadline = System.currentTimeMillis() + 10_000
-        while (System.currentTimeMillis() < deadline) {
-            val row = TestHelper.findUser(username)
-            if (row != null) return row
-            Thread.sleep(200)
-        }
-        throw AssertionError("Expected user '$username' to be persisted within 10s")
-    }
-
-    private fun pollFor(description: String, timeoutMs: Long = 6_000, predicate: () -> Boolean) {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (System.currentTimeMillis() < deadline) {
-            if (predicate()) return
-            Thread.sleep(200)
-        }
-        throw AssertionError("Expected $description within ${timeoutMs}ms")
-    }
-
+    private fun pollForUser(username: String): TestHelper.RegisteredUserRow =
+        pollForValue("user '$username' to be persisted") { TestHelper.findUser(username) }
     private companion object {
         const val MEMBERSHIP_CONSENT_LABEL_PREFIX = "I confirm that I have read and agree to the membership terms above"
         const val CONFIRMATION_SUBJECT = "Activate your Account"

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/PlaywrightTestBase.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/PlaywrightTestBase.kt
@@ -94,15 +94,12 @@ abstract class PlaywrightTestBase {
 
     companion object {
         /**
-         * Default per-action timeout. With the in-process Spring Boot
-         * context running alongside the sharded matrix and
-         * `app.jobs.auto-dispatch=true` flushing `SyncContactCommand`
-         * / `EmailSenderService` between tests, a freshly-loaded
-         * `/account` page that needs `/users/{id}` to resolve before
-         * its form wrapper mounts can overshoot 15 s on a busy
-         * shard. Matches Playwright's own default; locator polling
-         * still returns immediately on fast pages.
+         * Default per-action and per-navigation timeout, shared with
+         * [POLL_TIMEOUT_MS]. Five seconds is a ceiling: an action that needs
+         * longer is waiting on the wrong signal — a locator resolved before
+         * the page held the data, or an assertion racing a request the test
+         * never awaited. Fix the signal rather than the number.
          */
-        const val DEFAULT_TIMEOUT_MS: Double = 30_000.0
+        const val DEFAULT_TIMEOUT_MS: Double = POLL_TIMEOUT_MS.toDouble()
     }
 }

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/Polling.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/Polling.kt
@@ -1,0 +1,33 @@
+package net.blueshell.systemtests
+
+/**
+ * Budget every wait in the system tests shares, browser-driven or not.
+ *
+ * Five seconds is a ceiling, not a target: a step that needs longer is
+ * waiting on the wrong thing — a sleep standing in for a signal, an
+ * assertion racing a request the test never awaited, a locator resolved
+ * before the page had the data. Raising it hides that instead of fixing it.
+ */
+const val POLL_TIMEOUT_MS: Long = 5_000
+
+private const val POLL_INTERVAL_MS: Long = 100
+
+/** Polls `predicate` until it holds, or fails once the budget is spent. */
+fun pollFor(description: String, timeoutMs: Long = POLL_TIMEOUT_MS, predicate: () -> Boolean) {
+    pollForValue(description, timeoutMs) { if (predicate()) Unit else null }
+}
+
+/** Polls `producer` until it yields a value, or fails once the budget is spent. */
+fun <T : Any> pollForValue(
+    description: String,
+    timeoutMs: Long = POLL_TIMEOUT_MS,
+    producer: () -> T?,
+): T {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (true) {
+        producer()?.let { return it }
+        if (System.currentTimeMillis() >= deadline) break
+        Thread.sleep(POLL_INTERVAL_MS)
+    }
+    throw AssertionError("Expected $description within ${timeoutMs}ms")
+}

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/StalwartMailClient.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/StalwartMailClient.kt
@@ -76,7 +76,7 @@ class StalwartMailClient(
     fun assertEmailSent(
         recipient: String,
         subject: String,
-        timeoutMs: Long = 10_000,
+        timeoutMs: Long = POLL_TIMEOUT_MS,
         pollIntervalMs: Long = 250,
     ): DeliveredEmail {
         val deadline = System.currentTimeMillis() + timeoutMs

--- a/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
+++ b/services/system-tests/src/test/kotlin/net/blueshell/systemtests/TestHelper.kt
@@ -807,7 +807,7 @@ object TestHelper {
     fun assertEmailSent(
         recipient: String,
         subject: String,
-        timeoutMs: Long = 10_000,
+        timeoutMs: Long = POLL_TIMEOUT_MS,
     ): SentEmail {
         val deadline = System.currentTimeMillis() + timeoutMs
         while (System.currentTimeMillis() < deadline) {


### PR DESCRIPTION
## Why

The browser suites were tuned by raising timeouts. `PlaywrightTestBase` defaulted to 30s and its KDoc said why in as many words — a busy shard could overshoot 15s waiting for a page to mount. The frontend e2e specs carried 35 per-call `{timeout: 30_000}` overrides on top of a 15s expect budget and a 60s navigation budget. Ten near-copies of `pollFor` / `pollForValue` sat in individual test classes with 5-12s budgets, and eight hand-rolled `System.currentTimeMillis() + N` loops carried another 10s or 30s apiece.

A wait that long stops being a wait: it lets a test pass while racing the page, and it hides the defect that made it race. Several were hiding, the largest of them a picker that could not be reached at all.

## What this achieves

Every await in both suites is capped at five seconds from a single constant, so a step that cannot meet it fails as the design problem it is rather than being granted more time. The defects those budgets concealed are fixed by awaiting the state the test depends on — and the committee picker, which a hundred-odd committees had made unusable, now filters as it is typed into.

## How

**One budget.** `POLL_TIMEOUT_MS` in `services/system-tests/.../systemtests/Polling.kt`; `PlaywrightTestBase` takes its action and navigation defaults from it, the duplicated poll helpers are gone, and the domain wrappers delegate to it. The frontend caps live in `playwright.config.ts` as `actionTimeout`, `navigationTimeout` and `expect.timeout`. Per-test and web-server budgets are deliberately untouched — they bound a whole test and a one-off production build, not a single await.

**Selects.** A Vuetify menu renders through `v-virtual-scroll`: only a window of the options is in the DOM, so an option further down a long list does not exist to be clicked or waited for. Taking the app's pickers in turn:

- Long, data-driven — country, nationality, user, event, contribution period, cohort, target — were already autocompletes, reachable by typing. The **representative-committee field was the one long list still on a plain `VSelect`**, and is now a `VAutocomplete` matching `UserSelect` (`auto-select-first`, `hide-no-data`). Typing brings the match into the menu in one step, which also makes a hundred-odd committees usable rather than a scroll hunt.
- Short fixed enums — the job type (7 entries), member type, and the manager-page status and category filters (≤10) — stay plain selects. A six-item filter should not demand typing, and every option is in the DOM.
- `SelectHelper` is now the one way the system tests drive any of them: `pickByTyping` for autocompletes, `pickFromList` for plain selects, `pickOnlyMatch` for a picker whose option label the test has no handle on, `filterBy` / `option` for tests that assert on the filtered menu. Every path matches the option inside the menu instead of page-wide and asserts the choice landed, so a pick that never lands fails at the select rather than as a submit that silently never fires. Which kind a field is cannot be read off the DOM — `readonly` is absent from both and `VvField` puts the test id on a wrapper rather than on Vuetify's root — so the call site names it.
- `committee member can only select own committees on event create` was unsound for the same reason: it read presence and absence off the open menu, and against a virtual scroller absence from the rendered window proves nothing. It asks for each committee by name now.

**Other signals that replaced waits.** The event form disables its committee field until the committees it requests on mount are in the model, so an enabled field — not the response landing — is the signal it takes input. `admin can list and retry failed job execution` waited for the retried job to die again with a fresh `queuedAt`: an interval the test cannot bound, on a `datetime` column with no sub-second precision. It now asserts the row left the resting state the fixture put it in, which the retry handler commits before it answers; the job dying again is `JobExecutorIT`'s subject. Blur-then-hope on the recovery, activation and sign-up-limit fields is replaced by the state it was hoping for — an enabled submit button, a committed field value.

Verified against the compose stack with 117 committees in the database: system tests 80 passed, acceptance features green, frontend e2e 124 passed, frontend unit 513 passed.

<!-- diff-stats:start -->
---
**Diff breakdown** — `█` added `░` removed, scaled to the largest row.

```text
frontend                                           +44    -39   10
  production         █░                             +4     -2    1
  e2e tests          ██░                           +35    -35    8
  build & config     █░                             +5     -2    1

system-tests                                      +260   -271   21
  system tests       █████████████░░░░░░░░░░░░░   +260   -271   21

──────────────────────────────────────────────────────────────────
production                                          +4     -2
tests                                             +295   -306  73.75 test lines per prod line
total (hand-written)                              +304   -310  31 files
```
<!-- diff-stats:end -->