### PR TITLE
feat(platform): alert on outages and announce rollouts via Discord

### DIFF
--- a/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
+++ b/platform/cluster/flux/apps/data/vault/bootstrap-auth.sh
@@ -153,6 +153,10 @@ path "secret/data/platform/ghcr" {
 path "secret/data/platform/mariadb" {
   capabilities = ["read"]
 }
+
+path "secret/data/platform/alerting" {
+  capabilities = ["read"]
+}
 EOF
 
 vault policy write api /tmp/api.hcl
@@ -176,7 +180,7 @@ vault write auth/kubernetes/role/stalwart \
 
 vault write auth/kubernetes/role/vso \
   bound_service_account_names="vault-secrets-operator" \
-  bound_service_account_namespaces="vso-system,cert-manager,external-dns,default,mail-system,data-system" \
+  bound_service_account_namespaces="vso-system,cert-manager,external-dns,default,mail-system,data-system,utility-system" \
   policies="vso" \
   ttl="1h"
 

--- a/platform/cluster/flux/apps/stateless/api/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/api/deployment.yaml
@@ -18,6 +18,11 @@ metadata:
     keel.sh/match-tag: 'true'
     keel.sh/trigger: poll
     keel.sh/pollSchedule: '@every 2m'
+    # Appended to Keel's rollout notification as "Release notes: <url>".
+    # The tag on this Deployment is the moving :latest, so the notification
+    # can only name the old and new digest — this link is what turns that
+    # into something a reader can act on.
+    keel.sh/releaseNotes: https://github.com/ESA-Blueshell/website/releases
 spec:
   replicas: 1
   # Zero-downtime rollout: bring a second pod up first (maxSurge=1) and only

--- a/platform/cluster/flux/apps/stateless/frontend/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/frontend/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     keel.sh/match-tag: 'true'
     keel.sh/trigger: poll
     keel.sh/pollSchedule: '@every 2m'
+    # Appended to Keel's rollout notification as "Release notes: <url>".
+    keel.sh/releaseNotes: https://github.com/ESA-Blueshell/website/releases
 spec:
   replicas: 1
   # Single replica, but replaced with zero downtime: surge a second pod and

--- a/platform/cluster/flux/apps/utility-system/alerting-vss.yaml
+++ b/platform/cluster/flux/apps/utility-system/alerting-vss.yaml
@@ -1,0 +1,57 @@
+# Gatus (uptime alerts) and Keel (image rollout notifications) post to the
+# same Discord incoming webhook. The URL is a credential — anyone holding
+# it can post as the bot — so it lives in Vault at
+# `secret/platform/alerting:discord.webhook_url` and VSO renders it into
+# one Secret shared by both consumers in this namespace.
+#
+# The Secret exposes exactly one key, `DISCORD_WEBHOOK_URL`, because
+# Keel's chart mounts the whole Secret with `envFrom.secretRef` and reads
+# the env var under that name. Gatus takes the same key as an explicit
+# env var and interpolates `${DISCORD_WEBHOOK_URL}` out of its config.
+#
+# The CR sits in apps-utility-system rather than apps-vso-secrets: the
+# `utility-system` Namespace and both consumers are created by this same
+# Kustomization, so a single reconcile brings namespace, Secret and
+# consumers up in order. The VaultStaticSecret CRD is installed by the
+# VSO HelmRelease in apps-core, which this Kustomization dependsOn with
+# `wait: true`, so the CRD is always established before this applies.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  # VSO authenticates each VaultStaticSecret with the ServiceAccount named
+  # by the VaultAuth (vso-system/default → `vault-secrets-operator`) in the
+  # CR's own namespace. Without it VSO reports "ServiceAccount
+  # vault-secrets-operator not found" and never reaches Vault.
+  name: vault-secrets-operator
+  namespace: utility-system
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: alerting-discord
+  namespace: utility-system
+spec:
+  vaultAuthRef: vso-system/default
+  type: kv-v2
+  mount: secret
+  path: platform/alerting
+  destination:
+    name: alerting-discord
+    create: true
+    transformation:
+      # Keel consumes this Secret wholesale via `envFrom`, so every key in
+      # it becomes an env var. `discord.webhook_url` is not a legal env var
+      # name and `_raw` would hand Keel the entire JSON payload, so both are
+      # dropped and only the template below survives.
+      excludes:
+        - '.*'
+      excludeRaw: true
+      templates:
+        DISCORD_WEBHOOK_URL:
+          text: '{{- get .Secrets "discord.webhook_url" -}}'
+  refreshAfter: 1h
+  rolloutRestartTargets:
+    # Gatus reads the webhook URL once, at config load, so a rotated URL
+    # only takes effect after a restart.
+    - kind: Deployment
+      name: gatus

--- a/platform/cluster/flux/apps/utility-system/gatus/deployment.yaml
+++ b/platform/cluster/flux/apps/utility-system/gatus/deployment.yaml
@@ -35,6 +35,18 @@ spec:
           env:
             - name: GATUS_CONFIG_PATH
               value: /config
+            # Interpolated into `alerting.discord.webhook-url` when Gatus
+            # reads its config. Marked optional on purpose: a monitoring
+            # service that refuses to start because its alert channel is
+            # unseeded is worse than one that serves the status page and
+            # logs the misconfigured provider. VSO fills the Secret in
+            # from `secret/platform/alerting` and restarts this Deployment.
+            - name: DISCORD_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: alerting-discord
+                  key: DISCORD_WEBHOOK_URL
+                  optional: true
           ports:
             - containerPort: 8080
               name: http

--- a/platform/cluster/flux/apps/utility-system/gatus/gatus-config-configmap.yaml
+++ b/platform/cluster/flux/apps/utility-system/gatus/gatus-config-configmap.yaml
@@ -12,3 +12,26 @@ data:
       title: Blueshell Esports status
       description: Uptime for the esa-blueshell.nl stack.
       header: Blueshell Esports
+    alerting:
+      discord:
+        # Gatus expands ${VAR} from its own environment when it reads the
+        # config file. DISCORD_WEBHOOK_URL comes from the alerting-discord
+        # Secret (Vault `secret/platform/alerting:discord.webhook_url`) and
+        # is marked optional on the Deployment, so an unseeded Vault leaves
+        # the URL empty: Gatus logs that the provider is misconfigured,
+        # ignores every discord alert, and keeps serving the status page.
+        webhook-url: "${DISCORD_WEBHOOK_URL}"
+        title: "Blueshell Esports status"
+        # Endpoints opt in with `alerts: - type: discord`; the defaults
+        # below fill in the thresholds so each endpoint carries only the
+        # one line. Gatus merges a provider's default-alert into alerts an
+        # endpoint already declares — it never adds an alert on its own.
+        default-alert:
+          enabled: true
+          # Endpoints are probed every 60s (mail ports every 120s), so an
+          # alert fires after ~3 consecutive failures and resolves after 2
+          # successes. Tolerates a single flaky probe without going quiet
+          # about a real outage for long.
+          failure-threshold: 3
+          success-threshold: 2
+          send-on-resolved: true

--- a/platform/cluster/flux/apps/utility-system/gatus/gatus-endpoints-configmap.yaml
+++ b/platform/cluster/flux/apps/utility-system/gatus/gatus-endpoints-configmap.yaml
@@ -32,6 +32,8 @@ data:
       - "[STATUS] == 200"
       - "[RESPONSE_TIME] < 2000"
       - "[CERTIFICATE_EXPIRATION] > 168h"
+      alerts:
+      - type: discord
     - name: "Blueshell API"
       group: "public"
       # Same-origin /api/health routes via the apex PathPrefix(/api)
@@ -43,6 +45,8 @@ data:
       - "[STATUS] == 200"
       - "[RESPONSE_TIME] < 2000"
       - "[CERTIFICATE_EXPIRATION] > 168h"
+      alerts:
+      - type: discord
 
     # ---------- Internal application checks ----------
     # OIDC discovery is consumed by Vault + Headlamp across the
@@ -57,6 +61,8 @@ data:
       - "[STATUS] == 200"
       - "[BODY].issuer == https://esa-blueshell.nl/api"
       - "[RESPONSE_TIME] < 500"
+      alerts:
+      - type: discord
 
     # ---------- Admin services (forward-auth) ----------
     # All four sit behind the `forward-auth` Middleware at the edge —
@@ -69,6 +75,8 @@ data:
       conditions:
       - "[STATUS] == 200"
       - "[RESPONSE_TIME] < 500"
+      alerts:
+      - type: discord
     - name: "Stalwart Admin"
       group: "admin"
       # Stalwart v0.16 serves the webadmin at /admin/ and 404s the root.
@@ -80,6 +88,8 @@ data:
       conditions:
       - "[STATUS] == 200"
       - "[RESPONSE_TIME] < 500"
+      alerts:
+      - type: discord
     - name: "Vault Admin"
       group: "admin"
       url: "http://vault.data-system.svc.cluster.local:8200/v1/sys/health?standbyok=true"
@@ -87,6 +97,8 @@ data:
       conditions:
       - "[STATUS] == 200"
       - "[RESPONSE_TIME] < 500"
+      alerts:
+      - type: discord
     - name: "Traefik Dashboard"
       group: "admin"
       # /ping is the chart's healthcheck endpoint on the `traefik`
@@ -102,6 +114,8 @@ data:
       conditions:
       - "[STATUS] == 200"
       - "[RESPONSE_TIME] < 500"
+      alerts:
+      - type: discord
 
     # ---------- Data plane ----------
     - name: "MariaDB"
@@ -110,6 +124,8 @@ data:
       interval: "60s"
       conditions:
       - "[CONNECTED] == true"
+      alerts:
+      - type: discord
     - name: "Valkey"
       group: "data"
       # Backs HTTP sessions + the api's user-lookup cache. A TCP connect
@@ -120,6 +136,8 @@ data:
       interval: "60s"
       conditions:
       - "[CONNECTED] == true"
+      alerts:
+      - type: discord
     # ---------- Mail ports ----------
     # TCP connect from inside the cluster proves stalwart is listening
     # on each port; a real end-to-end SMTP/IMAP handshake from outside
@@ -130,6 +148,8 @@ data:
       interval: "120s"
       conditions:
       - "[CONNECTED] == true"
+      alerts:
+      - type: discord
     - name: "Stalwart STARTTLS"
       group: "mail"
       # RFC 6409 submission port — clients upgrade with STARTTLS after
@@ -138,6 +158,8 @@ data:
       interval: "120s"
       conditions:
       - "[CONNECTED] == true"
+      alerts:
+      - type: discord
     - name: "Stalwart SMTPS"
       group: "mail"
       # Implicit-TLS submission.
@@ -145,6 +167,8 @@ data:
       interval: "120s"
       conditions:
       - "[CONNECTED] == true"
+      alerts:
+      - type: discord
     - name: "Stalwart IMAP"
       group: "mail"
       # IMAP-over-TLS (993). Plain IMAP on 143 is not exposed.
@@ -152,3 +176,5 @@ data:
       interval: "120s"
       conditions:
       - "[CONNECTED] == true"
+      alerts:
+      - type: discord

--- a/platform/cluster/flux/apps/utility-system/keel/release.yaml
+++ b/platform/cluster/flux/apps/utility-system/keel/release.yaml
@@ -12,12 +12,29 @@ spec:
         kind: HelmRepository
         name: keel
         namespace: utility-system
+  # The chart renders `envFrom.secretRef` without `optional`, so a missing
+  # alerting-discord Secret would hold the pod in
+  # CreateContainerConfigError and silently stop image auto-updates. Keel
+  # treats an absent DISCORD_WEBHOOK_URL as "discord sender disabled", so
+  # marking the reference optional degrades to no notifications instead of
+  # no deployments.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: keel
+            patch: |
+              - op: add
+                path: /spec/template/spec/containers/0/envFrom/0/secretRef/optional
+                value: true
   values:
     # Keel polls registries for new image tags and triggers rolling
     # restarts on Deployments that opt in via `keel.sh/*` annotations.
-    # We only want the polling path: no webhook server, no Slack /
-    # Hipchat / Mattermost integrations, no Helm provider, no approvals
-    # UI. Keel itself is in-cluster and has no public ingress.
+    # We only want the polling path plus outbound Discord notifications:
+    # no webhook server, no Slack / Hipchat / Mattermost integrations, no
+    # Helm provider, no approvals UI. Keel itself is in-cluster and has
+    # no public ingress.
     replicaCount: 1
     service:
       enabled: false
@@ -52,6 +69,21 @@ spec:
       enabled: false
     mattermost:
       enabled: false
+    # Discord notifications come from the Vault-backed Secret rather than
+    # this block: the chart only reads `discord.webhookUrl` when it renders
+    # its own Secret, which would put the webhook URL in git in plaintext.
+    # With `secret.create: false` the chart skips that Secret and points
+    # `envFrom` at ours instead, so Keel picks DISCORD_WEBHOOK_URL up from
+    # the VSO-synced alerting-discord Secret.
+    discord:
+      enabled: false
+    secret:
+      create: false
+      name: alerting-discord
+    # Keel emits the "preparing to update" event at debug and the
+    # completed rollout at success, so `info` yields exactly one message
+    # per rollout plus failures — no chatter while it polls.
+    notificationLevel: info
     debug: false
     resources:
       requests:

--- a/platform/cluster/flux/apps/utility-system/kustomization.yaml
+++ b/platform/cluster/flux/apps/utility-system/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - namespace.yaml
+  - alerting-vss.yaml
   - headlamp
   - keel
   - gatus

--- a/platform/docs/vault-bootstrap.md
+++ b/platform/docs/vault-bootstrap.md
@@ -78,6 +78,9 @@ of them blocks at least one downstream Secret.
   to `read:packages` on `ESA-Blueshell` (private api/frontend images).
 - **Stalwart admin user/password** + base64-encoded RSA-2048 DKIM
   private key + bounce mailbox `bounce@esa-blueshell.nl` credentials.
+- **Discord incoming webhook URL** for the channel that receives Gatus
+  uptime alerts and Keel rollout notifications. Optional at day 0 —
+  both consumers start without it.
 - **One-shot generated values** (only if missing from the legacy env):
   - `JWT_SECRET` — `openssl rand -base64 64`.
   - `vault-oidc-client-secret` — `openssl rand -hex 32`.
@@ -254,6 +257,36 @@ access to `ESA-Blueshell`, permission `Packages: read-only`). Rotate by
 re-running the same `kv put` with a new token — VSO re-renders the
 dockerconfigjson within one refresh cycle (1 h) and pods pick up the
 new auth on their next pull.
+
+### Alerting webhook (Gatus + Keel)
+
+Gatus posts uptime alerts and Keel posts image-rollout notifications to
+the same Discord incoming webhook. VSO materialises
+`utility-system/alerting-discord` with a single key,
+`DISCORD_WEBHOOK_URL`, from this path.
+
+```bash
+vault kv put secret/platform/alerting \
+  discord.webhook_url=https://discord.com/api/webhooks/<id>/<token>
+```
+
+Create the webhook in Discord under *Server Settings → Integrations →
+Webhooks*; the channel it targets is where every alert and rollout
+message lands. Anyone holding the URL can post to that channel, so it
+is a credential and never belongs in git.
+
+Both consumers tolerate the path being absent: the Gatus Deployment
+marks its `secretKeyRef` optional and logs the discord provider as
+misconfigured while continuing to serve the status page, and the Keel
+HelmRelease patches its chart-rendered `envFrom` to `optional: true` so
+image auto-updates keep running with notifications off. Seeding the
+path and letting VSO sync (≤1 h, or force a reconcile) turns both on;
+the Gatus Deployment is restarted automatically because the
+VaultStaticSecret lists it under `rolloutRestartTargets`.
+
+Rotate by re-running the same `kv put`. Keel reads the env var per
+notification and needs no restart; Gatus reads it once at config load,
+which the rollout-restart target handles.
 
 ## 5. Confirm VSO sync
 


### PR DESCRIPTION
## Why

Gatus watched thirteen endpoints and told nobody. A failing probe turned a tile red on a status page that has to be opened to be read, so an outage was only ever noticed by whoever happened to look. Keel rolled new images with equally little ceremony: nothing recorded which digest replaced which, so a surprise change in behaviour could not be tied back to a deployment after the fact.

## What this achieves

Both post to one Discord incoming webhook. Every endpoint alerts after three consecutive failures and again when it recovers, so an outage arrives in a channel instead of waiting to be discovered. Each completed image rollout announces the resource, the digest it moved from and to, and a link to the release notes — a deployment is now something with a timestamp and a paper trail.

Neither tool starts depending on the webhook. An unseeded Vault path costs notifications, not uptime monitoring and not deployments.

## How

The webhook URL is a credential — anyone holding it can post to the channel — so it lives in Vault at `secret/platform/alerting:discord.webhook_url` and reaches both consumers as `utility-system/alerting-discord`, a Secret carrying the single key `DISCORD_WEBHOOK_URL`.

- `apps/utility-system/alerting-vss.yaml` — the VaultStaticSecret plus the `vault-secrets-operator` ServiceAccount VSO looks up in the CR's own namespace. `excludes: ['.*']` and `excludeRaw: true` keep everything but the templated key out of the Secret: Keel mounts it wholesale with `envFrom`, so the raw `discord.webhook_url` field (not a legal env var name) and the `_raw` JSON blob must not survive. Gatus is a `rolloutRestartTargets` entry because it reads the URL once, at config load. The CR sits in apps-utility-system rather than apps-vso-secrets so the namespace, the Secret and both consumers come up in one reconcile; the CRD is guaranteed present because this Kustomization dependsOn apps-core with `wait: true`.
- `gatus-config-configmap.yaml` — a `discord` provider whose `webhook-url` interpolates `${DISCORD_WEBHOOK_URL}` from the container env, with a `default-alert` carrying the thresholds. `gatus-endpoints-configmap.yaml` gives each of the thirteen endpoints the single line that opts it in; Gatus merges a provider default into alerts an endpoint already declares and never adds one on its own, so the per-endpoint line is required.
- `keel/release.yaml` — `secret.create: false` with `secret.name: alerting-discord` points the chart's `envFrom` at the Vault-backed Secret. The chart's own `discord.webhookUrl` value is deliberately unused: it only feeds a chart-rendered Secret, which would put the webhook URL in git in plaintext. `notificationLevel: info` drops the debug "preparing to update" event and keeps success and failure, so one rollout produces one message.
- The chart renders that `envFrom` without `optional`, so a missing Secret would hold the pod in CreateContainerConfigError and silently stop image auto-updates. A `postRenderers` kustomize patch marks the reference optional. The Gatus `secretKeyRef` is optional for the same reason — a monitoring service that refuses to boot because its alert channel is unseeded is worse than one that serves the status page and logs the misconfigured provider.
- `keel.sh/releaseNotes` on the api and frontend Deployments. Both track the moving `:latest` tag, so Keel's message can only name the old and new digest; the annotation appends `Release notes: <url>` to turn that into something actionable.
- `bootstrap-auth.sh` — `utility-system` joins the `vso` role's bound service account namespaces and `secret/data/platform/alerting` joins the `vso` policy. Editing the script rotates the configMapGenerator hash, which flips the Job spec and triggers the existing `kustomize.toolkit.fluxcd.io/force: enabled` replace, so the role and policy actually update rather than holding stale state.

## Seeding the webhook

The Vault path is the one manual step, and nothing breaks while it is absent:

```bash
vault kv put secret/platform/alerting \
  discord.webhook_url=https://discord.com/api/webhooks/<id>/<token>
```

Create the webhook under *Server Settings → Integrations → Webhooks* in Discord; the channel it targets receives both alerts and rollout messages. `platform/docs/vault-bootstrap.md` documents the path, the rotation story and the degradation behaviour.

Note that apps-utility-system does not depend on apps-data, so on a fresh cluster the VaultStaticSecret can be applied before the bootstrap Job has added `utility-system` to the `vso` role. VSO retries on its own backoff and both Kustomizations reconcile every two minutes, so this converges without intervention.

## Verification

Configuration was exercised rather than reasoned about. Running `twinproduction/gatus:v5.35.0` against the rendered ConfigMaps reports `configuredProviders=[discord]` and `Validated 13 endpoints`; pointing the webhook at a local sink and shortening the probe intervals produced the alert POST at exactly the third consecutive failure, carrying the configured title and the failed condition results. Starting the same image with no `DISCORD_WEBHOOK_URL` logs `Ignoring provider=discord due to error=webhook-url not set` and serves the status page, which is the degradation path the optional `secretKeyRef` relies on. Rendering keel 0.21.1 with these values yields `envFrom.secretRef.name: alerting-discord` and no chart-created Secret, and applying the post-render patch to that output produces `optional: true` at the intended path.

<!-- diff-stats:start -->
---
**Diff breakdown** — `█` added `░` removed, scaled to the largest row.

```text
platform                                          +199     -4   10
  infrastructure     █████████████████████████░   +199     -4   10

──────────────────────────────────────────────────────────────────
total (hand-written)                              +199     -4  10 files
```
<!-- diff-stats:end -->