### PR TITLE
refactor(platform): cut the commentary on the Discord alerting manifests

### DIFF
--- a/platform/cluster/flux/apps/stateless/api/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/api/deployment.yaml
@@ -18,10 +18,8 @@ metadata:
     keel.sh/match-tag: 'true'
     keel.sh/trigger: poll
     keel.sh/pollSchedule: '@every 2m'
-    # Appended to Keel's rollout notification as "Release notes: <url>".
-    # The tag on this Deployment is the moving :latest, so the notification
-    # can only name the old and new digest — this link is what turns that
-    # into something a reader can act on.
+    # Keel's rollout message can only name digests on :latest, so it
+    # appends this link.
     keel.sh/releaseNotes: https://github.com/ESA-Blueshell/website/releases
 spec:
   replicas: 1

--- a/platform/cluster/flux/apps/stateless/frontend/deployment.yaml
+++ b/platform/cluster/flux/apps/stateless/frontend/deployment.yaml
@@ -8,7 +8,6 @@ metadata:
     keel.sh/match-tag: 'true'
     keel.sh/trigger: poll
     keel.sh/pollSchedule: '@every 2m'
-    # Appended to Keel's rollout notification as "Release notes: <url>".
     keel.sh/releaseNotes: https://github.com/ESA-Blueshell/website/releases
 spec:
   replicas: 1

--- a/platform/cluster/flux/apps/utility-system/alerting-vss.yaml
+++ b/platform/cluster/flux/apps/utility-system/alerting-vss.yaml
@@ -1,27 +1,9 @@
-# Gatus (uptime alerts) and Keel (image rollout notifications) post to the
-# same Discord incoming webhook. The URL is a credential — anyone holding
-# it can post as the bot — so it lives in Vault at
-# `secret/platform/alerting:discord.webhook_url` and VSO renders it into
-# one Secret shared by both consumers in this namespace.
-#
-# The Secret exposes exactly one key, `DISCORD_WEBHOOK_URL`, because
-# Keel's chart mounts the whole Secret with `envFrom.secretRef` and reads
-# the env var under that name. Gatus takes the same key as an explicit
-# env var and interpolates `${DISCORD_WEBHOOK_URL}` out of its config.
-#
-# The CR sits in apps-utility-system rather than apps-vso-secrets: the
-# `utility-system` Namespace and both consumers are created by this same
-# Kustomization, so a single reconcile brings namespace, Secret and
-# consumers up in order. The VaultStaticSecret CRD is installed by the
-# VSO HelmRelease in apps-core, which this Kustomization dependsOn with
-# `wait: true`, so the CRD is always established before this applies.
+# One Discord webhook, shared by Gatus alerts and Keel rollout messages.
+# Keel's chart envFroms this Secret, so the key must be its env var name.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  # VSO authenticates each VaultStaticSecret with the ServiceAccount named
-  # by the VaultAuth (vso-system/default → `vault-secrets-operator`) in the
-  # CR's own namespace. Without it VSO reports "ServiceAccount
-  # vault-secrets-operator not found" and never reaches Vault.
+  # VSO looks this SA up in the CR's own namespace.
   name: vault-secrets-operator
   namespace: utility-system
 ---
@@ -39,10 +21,8 @@ spec:
     name: alerting-discord
     create: true
     transformation:
-      # Keel consumes this Secret wholesale via `envFrom`, so every key in
-      # it becomes an env var. `discord.webhook_url` is not a legal env var
-      # name and `_raw` would hand Keel the entire JSON payload, so both are
-      # dropped and only the template below survives.
+      # Every surviving key becomes an env var in Keel, so keep only the
+      # template — not the raw field or _raw.
       excludes:
         - '.*'
       excludeRaw: true
@@ -51,7 +31,6 @@ spec:
           text: '{{- get .Secrets "discord.webhook_url" -}}'
   refreshAfter: 1h
   rolloutRestartTargets:
-    # Gatus reads the webhook URL once, at config load, so a rotated URL
-    # only takes effect after a restart.
+    # Gatus reads the URL once, at config load.
     - kind: Deployment
       name: gatus

--- a/platform/cluster/flux/apps/utility-system/gatus/deployment.yaml
+++ b/platform/cluster/flux/apps/utility-system/gatus/deployment.yaml
@@ -35,12 +35,8 @@ spec:
           env:
             - name: GATUS_CONFIG_PATH
               value: /config
-            # Interpolated into `alerting.discord.webhook-url` when Gatus
-            # reads its config. Marked optional on purpose: a monitoring
-            # service that refuses to start because its alert channel is
-            # unseeded is worse than one that serves the status page and
-            # logs the misconfigured provider. VSO fills the Secret in
-            # from `secret/platform/alerting` and restarts this Deployment.
+            # Optional: an unseeded alert channel must not stop the status
+            # page from serving.
             - name: DISCORD_WEBHOOK_URL
               valueFrom:
                 secretKeyRef:

--- a/platform/cluster/flux/apps/utility-system/gatus/gatus-config-configmap.yaml
+++ b/platform/cluster/flux/apps/utility-system/gatus/gatus-config-configmap.yaml
@@ -14,24 +14,12 @@ data:
       header: Blueshell Esports
     alerting:
       discord:
-        # Gatus expands ${VAR} from its own environment when it reads the
-        # config file. DISCORD_WEBHOOK_URL comes from the alerting-discord
-        # Secret (Vault `secret/platform/alerting:discord.webhook_url`) and
-        # is marked optional on the Deployment, so an unseeded Vault leaves
-        # the URL empty: Gatus logs that the provider is misconfigured,
-        # ignores every discord alert, and keeps serving the status page.
         webhook-url: "${DISCORD_WEBHOOK_URL}"
         title: "Blueshell Esports status"
-        # Endpoints opt in with `alerts: - type: discord`; the defaults
-        # below fill in the thresholds so each endpoint carries only the
-        # one line. Gatus merges a provider's default-alert into alerts an
-        # endpoint already declares — it never adds an alert on its own.
+        # Only applies to endpoints that declare `alerts: - type: discord`;
+        # Gatus never adds an alert on its own.
         default-alert:
           enabled: true
-          # Endpoints are probed every 60s (mail ports every 120s), so an
-          # alert fires after ~3 consecutive failures and resolves after 2
-          # successes. Tolerates a single flaky probe without going quiet
-          # about a real outage for long.
           failure-threshold: 3
           success-threshold: 2
           send-on-resolved: true

--- a/platform/cluster/flux/apps/utility-system/keel/release.yaml
+++ b/platform/cluster/flux/apps/utility-system/keel/release.yaml
@@ -12,12 +12,8 @@ spec:
         kind: HelmRepository
         name: keel
         namespace: utility-system
-  # The chart renders `envFrom.secretRef` without `optional`, so a missing
-  # alerting-discord Secret would hold the pod in
-  # CreateContainerConfigError and silently stop image auto-updates. Keel
-  # treats an absent DISCORD_WEBHOOK_URL as "discord sender disabled", so
-  # marking the reference optional degrades to no notifications instead of
-  # no deployments.
+  # The chart omits `optional` on its envFrom, so a missing Secret would
+  # hold the pod in CreateContainerConfigError and stop image updates.
   postRenderers:
     - kustomize:
         patches:
@@ -31,10 +27,9 @@ spec:
   values:
     # Keel polls registries for new image tags and triggers rolling
     # restarts on Deployments that opt in via `keel.sh/*` annotations.
-    # We only want the polling path plus outbound Discord notifications:
-    # no webhook server, no Slack / Hipchat / Mattermost integrations, no
-    # Helm provider, no approvals UI. Keel itself is in-cluster and has
-    # no public ingress.
+    # We only want polling and Discord notifications: no webhook server,
+    # no Slack / Hipchat / Mattermost, no Helm provider, no approvals UI.
+    # Keel itself is in-cluster and has no public ingress.
     replicaCount: 1
     service:
       enabled: false
@@ -69,20 +64,13 @@ spec:
       enabled: false
     mattermost:
       enabled: false
-    # Discord notifications come from the Vault-backed Secret rather than
-    # this block: the chart only reads `discord.webhookUrl` when it renders
-    # its own Secret, which would put the webhook URL in git in plaintext.
-    # With `secret.create: false` the chart skips that Secret and points
-    # `envFrom` at ours instead, so Keel picks DISCORD_WEBHOOK_URL up from
-    # the VSO-synced alerting-discord Secret.
+    # Discord stays "disabled" here on purpose: that block only feeds a
+    # chart-rendered Secret, which would put the webhook URL in git.
     discord:
       enabled: false
     secret:
       create: false
       name: alerting-discord
-    # Keel emits the "preparing to update" event at debug and the
-    # completed rollout at success, so `info` yields exactly one message
-    # per rollout plus failures — no chatter while it polls.
     notificationLevel: info
     debug: false
     resources:

--- a/platform/docs/vault-bootstrap.md
+++ b/platform/docs/vault-bootstrap.md
@@ -270,23 +270,15 @@ vault kv put secret/platform/alerting \
   discord.webhook_url=https://discord.com/api/webhooks/<id>/<token>
 ```
 
-Create the webhook in Discord under *Server Settings → Integrations →
-Webhooks*; the channel it targets is where every alert and rollout
-message lands. Anyone holding the URL can post to that channel, so it
-is a credential and never belongs in git.
+Create the webhook under *Server Settings → Integrations → Webhooks*;
+the channel it targets receives both alerts and rollout messages.
 
-Both consumers tolerate the path being absent: the Gatus Deployment
-marks its `secretKeyRef` optional and logs the discord provider as
-misconfigured while continuing to serve the status page, and the Keel
-HelmRelease patches its chart-rendered `envFrom` to `optional: true` so
-image auto-updates keep running with notifications off. Seeding the
-path and letting VSO sync (≤1 h, or force a reconcile) turns both on;
-the Gatus Deployment is restarted automatically because the
-VaultStaticSecret lists it under `rolloutRestartTargets`.
-
-Rotate by re-running the same `kv put`. Keel reads the env var per
-notification and needs no restart; Gatus reads it once at config load,
-which the rollout-restart target handles.
+The path is optional: both consumers mark their Secret reference
+`optional`, so an unseeded Vault costs notifications but neither the
+status page nor image auto-updates. Seeding it turns both on within one
+refresh cycle (1 h, or force a reconcile). Rotate with the same
+`kv put` — Gatus is restarted by the `rolloutRestartTargets` entry on
+the VaultStaticSecret, Keel needs no restart.
 
 ## 5. Confirm VSO sync
 


### PR DESCRIPTION
## Why

The Discord alerting manifests carried far more comment than the code warranted: a nineteen-line header on the VaultStaticSecret, six lines explaining a single env var, and paragraphs restating what the adjacent field already said. Comment that repeats the code is a maintenance liability — it goes stale silently and buries the few notes that actually matter.

## What this achieves

71 comment lines become 19. What remains is only what a reader cannot infer from the manifest itself:

- why the Secret key is named after Keel's env var rather than the Vault field
- why the transformation excludes every raw field
- why both Secret references are marked optional
- why the chart's own `discord` block stays disabled while Discord notifications are on
- that a Gatus provider default only reaches endpoints which declare the alert

Behaviour is untouched — the diff is comments and one runbook section.

## How

- `alerting-vss.yaml` drops the placement rationale and the restated Vault path; three short notes remain.
- `gatus-config-configmap.yaml`, `gatus/deployment.yaml` and `keel/release.yaml` lose the duplicated explanation of the optional-Secret degradation, which is now stated once where the flag is set.
- `keel.sh/releaseNotes` keeps a single line on the api Deployment; the identical note on frontend is gone.
- `platform/docs/vault-bootstrap.md` keeps the path, the Discord setup step, the optional-path behaviour and the rotation note, in a third of the prose.

Re-rendered `platform/cluster/flux/apps/utility-system` and re-ran `twinproduction/gatus:v5.35.0` against the trimmed ConfigMaps: still `configuredProviders=[discord]` and `Validated 13 endpoints`.

<!-- diff-stats:start -->
---
**Diff breakdown** — `█` added `░` removed, scaled to the largest row.

```text
platform                                           +28    -88    7
  infrastructure     ██████░░░░░░░░░░░░░░░░░░░░    +28    -88    7

──────────────────────────────────────────────────────────────────
total (hand-written)                               +28    -88  7 files
```
<!-- diff-stats:end -->