### PR TITLE
ci: let the registry settle before reading a tag back

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,7 +278,22 @@ jobs:
           fi
 
           docker buildx imagetools create "${tags[@]}" "${sources[@]}"
-          docker buildx imagetools inspect "${IMAGE}:sha-${SHORT}"
+
+          # Same read-after-write as the promote job: the manifest list was
+          # written a moment ago, so let the registry settle rather than failing
+          # the publish over a tag that is about to be there.
+          read_back=false
+          for attempt in 1 2 3 4 5; do
+            if docker buildx imagetools inspect "${IMAGE}:sha-${SHORT}"; then
+              read_back=true
+              break
+            fi
+            sleep "$(( attempt * 2 ))"
+          done
+          if [[ "$read_back" != true ]]; then
+            echo "::error::${IMAGE}:sha-${SHORT} did not read back after 5 attempts"
+            exit 1
+          fi
 
   promote:
     # Moves :latest, the tag Keel polls, for every service in this release —
@@ -331,8 +346,23 @@ jobs:
             exit 0
           fi
 
+          # A tag read back moments after it was written can come back missing
+          # or error outright while the registry settles — ghcr answered a
+          # `:latest` created 1.3s earlier with exit 255, which under
+          # `pipefail` killed the step before the comparison below could say
+          # anything. One read is not an answer, so give the registry a few.
           digest_of() {
-            docker buildx imagetools inspect "$1" | awk '/^Digest:/ { print $2; exit }'
+            local reference="$1" attempt digest
+            for attempt in 1 2 3 4 5; do
+              if digest="$(docker buildx imagetools inspect "$reference" |
+                    awk '/^Digest:/ { print $2; exit }')" && [[ -n "$digest" ]]; then
+                printf '%s\n' "$digest"
+                return 0
+              fi
+              sleep "$(( attempt * 2 ))"
+            done
+            echo "::error::could not read a digest for ${reference} after 5 attempts" >&2
+            return 1
           }
 
           # Re-tagging from the release tag rather than from the digests keeps


### PR DESCRIPTION
## Why

The v1.4.0 release moved every service's `:latest` and then failed verifying it, so the release run is red while production is fine.

The promotion itself worked. For api, frontend and stalwart-tools, `:latest`, `:v1.4.0` and `:sha-a434bfe` all name one manifest — the tags Keel polls are correct and no operator action is needed. What broke is the loop that proves it: it read api's digest, then died on frontend with exit code 255 and no message at all, 1.3 s after writing the tag it was trying to read.

A tag read back that soon can come back missing, or error outright, while the registry settles. `digest_of` piped `docker buildx imagetools inspect` into `awk` under `set -euo pipefail`, so a failing inspect took the whole command substitution down and killed the step before the comparison could name the service — which is why the log ends after one line with nothing to act on.

## What this achieves

A release no longer goes red because the registry answered one read a second too early, and a promotion that genuinely does not land now says which reference it could not read instead of exiting 255 in silence.

## How

- `digest_of` retries the inspect five times with increasing backoff and treats an empty digest as a miss, since either means the registry has not settled. If it never resolves it reports the reference it gave up on.
- A digest that reads back and disagrees with the release tag still fails exactly as before: this widens what counts as a failed *read*, not what counts as a successful promote.
- The merge job's read-after-write on `:sha-<short>` is the same shape — a manifest list inspected immediately after being written — and gets the same treatment.

<!-- diff-stats:start -->
---
**Diff breakdown** — `█` added `░` removed, scaled to the largest row.

```text
ci                                                 +32     -2    1
  build & config     ████████████████████████░░    +32     -2    1

──────────────────────────────────────────────────────────────────
total (hand-written)                               +32     -2  1 file
```
<!-- diff-stats:end -->